### PR TITLE
Api history and status

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -128,8 +128,9 @@ export function fetchWorkingStatus (): ApiActionThunk {
         map: (data: Array<Record<string, string>>): ComponentStatus[] => {
           return data.map((d) => {
             return {
-              filepath: d.filepath,
-              status: d.status as ComponentState
+              filepath: d.sourceFile,
+              path: d.path,
+              status: d.type as ComponentState
             }
           })
         }

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -142,3 +142,27 @@ export function fetchWorkingStatus (): ApiActionThunk {
     return dispatch(action)
   }
 }
+
+export function fetchWorkingDatasetHistory (): ApiActionThunk {
+  return async (dispatch, getState) => {
+    const { selections } = getState()
+
+    const action: ApiAction = {
+      [CALL_API]: {
+        endpoint: 'history',
+        method: 'GET',
+        params: {
+          // TODO (b5) - these 'default' values are just placeholders for checking
+          // the api call when we have no proper default state. should fix
+          peername: selections.peername || 'me',
+          name: selections.name || 'world_bank_population'
+        },
+        // TODO (b5): confirm this works, if so we may want to remove this
+        // map func entirely
+        map: (data: any[]) => data.map(ref => ref.dataset.commit) // eslint-disable-line
+      }
+    }
+
+    return dispatch(action)
+  }
+}

--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { Commit } from '../models/dataset'
+
+interface CommitDetailsProps {
+  commit: Commit
+}
+
+const CommitDetails: React.FunctionComponent<CommitDetailsProps> = (props: CommitDetailsProps) => {
+  console.log(props)
+  return (
+    <div className='dataset-sidebar'>
+      {props.commit.title}
+      {props.commit.message}
+      {props.commit.path}
+    </div>
+  )
+}
+
+export default CommitDetails

--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -6,7 +6,6 @@ interface CommitDetailsProps {
 }
 
 const CommitDetails: React.FunctionComponent<CommitDetailsProps> = (props: CommitDetailsProps) => {
-  console.log(props)
   return (
     <div className='dataset-sidebar'>
       {props.commit.title}

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -5,6 +5,7 @@ import { Resizable } from '../components/resizable'
 import DatasetSidebar from '../components/DatasetSidebar'
 import DatasetListContainer from '../containers/DatasetListContainer'
 import CommitDetailsContainer from '../containers/CommitDetailsContainer'
+import MetadataContainer from '../containers/MetadataContainer'
 
 import { defaultSidebarWidth } from '../reducers/ui'
 
@@ -97,9 +98,15 @@ export default class Dataset extends React.Component<DatasetProps> {
     let mainContent
 
     if (activeTab === 'status') {
-      mainContent = (
-        <div>Content for the {selectedComponent} component</div>
-      )
+      if (selectedComponent === 'meta') {
+        mainContent = (
+          <MetadataContainer />
+        )
+      } else {
+        mainContent = (
+          <div>Content for the {selectedComponent} component</div>
+        )
+      }
     } else {
       mainContent = (
         <CommitDetailsContainer />
@@ -145,7 +152,7 @@ export default class Dataset extends React.Component<DatasetProps> {
               onListItemClick={setSelectedListItem}
             />
           </Resizable>
-          <div className='content'>
+          <div className='content-wrapper'>
             {showDatasetList && <div className='overlay'></div>}
             {mainContent}
           </div>

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -30,6 +30,7 @@ interface DatasetProps {
   setWorkingDataset: (peername: string, name: string) => Action
   fetchMyDatasetsAndWorkbench: () => Promise<ApiAction>
   fetchWorkingDataset: () => Promise<ApiAction>
+  fetchWorkingStatus: () => Promise<ApiAction>
 }
 
 // using component state + getDerivedStateFromProps to determine when a new
@@ -50,6 +51,7 @@ export default class Dataset extends React.Component<DatasetProps> {
   componentDidMount () {
     // fetch datasets list, working dataset, and working dataset history
     this.props.fetchMyDatasetsAndWorkbench()
+    setInterval(() => { this.props.fetchWorkingStatus() }, 1000)
   }
 
   static getDerivedStateFromProps (nextProps: DatasetProps, prevState: DatasetState) {

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -29,6 +29,7 @@ interface DatasetProps {
   setWorkingDataset: (peername: string, name: string) => Action
   fetchMyDatasets: () => Promise<ApiAction>
   fetchWorkingDataset: () => Promise<ApiAction>
+  fetchWorkingDatasetHistory: () => Promise<ApiAction>
 }
 
 // using component state + getDerivedStateFromProps to determine when a new
@@ -49,6 +50,7 @@ export default class Dataset extends React.Component<DatasetProps> {
   componentDidMount () {
     this.props.fetchMyDatasets()
     this.props.fetchWorkingDataset()
+    this.props.fetchWorkingDatasetHistory()
   }
 
   static getDerivedStateFromProps (nextProps: DatasetProps, prevState: DatasetState) {

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -4,6 +4,7 @@ import { ApiAction } from '../store/api'
 import { Resizable } from '../components/resizable'
 import DatasetSidebar from '../components/DatasetSidebar'
 import DatasetListContainer from '../containers/DatasetListContainer'
+import CommitDetailsContainer from '../containers/CommitDetailsContainer'
 
 import { defaultSidebarWidth } from '../reducers/ui'
 
@@ -27,9 +28,8 @@ interface DatasetProps {
   setFilter: (filter: string) => Action
   setSelectedListItem: (type: string, activeTab: string) => Action
   setWorkingDataset: (peername: string, name: string) => Action
-  fetchMyDatasets: () => Promise<ApiAction>
+  fetchMyDatasetsAndWorkbench: () => Promise<ApiAction>
   fetchWorkingDataset: () => Promise<ApiAction>
-  fetchWorkingDatasetHistory: () => Promise<ApiAction>
 }
 
 // using component state + getDerivedStateFromProps to determine when a new
@@ -48,9 +48,8 @@ export default class Dataset extends React.Component<DatasetProps> {
   };
 
   componentDidMount () {
-    this.props.fetchMyDatasets()
-    this.props.fetchWorkingDataset()
-    this.props.fetchWorkingDatasetHistory()
+    // fetch datasets list, working dataset, and working dataset history
+    this.props.fetchMyDatasetsAndWorkbench()
   }
 
   static getDerivedStateFromProps (nextProps: DatasetProps, prevState: DatasetState) {
@@ -101,7 +100,7 @@ export default class Dataset extends React.Component<DatasetProps> {
       )
     } else {
       mainContent = (
-        <div>Content for commit {selectedCommit}</div>
+        <CommitDetailsContainer />
       )
     }
 

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -18,7 +18,6 @@ export default class DatasetList extends React.Component<DatasetListProps> {
 
   render () {
     const { setWorkingDataset } = this.props
-    console.log(this.props)
     const { filter, value: datasets } = this.props.myDatasets
 
     const filteredDatasets = datasets.filter(({ name, title }) => {

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -41,8 +41,10 @@ export default class DatasetList extends React.Component<DatasetListProps> {
           className='sidebar-list-item sidebar-list-item-text'
           onClick={() => setWorkingDataset(peername, name)}
         >
-          <div className='text'>{title}</div>
-          <div className='subtext'>{name}</div>
+          <div className='text-column'>
+            <div className='text'>{title}</div>
+            <div className='subtext'>{name}</div>
+          </div>
         </div>
       ))
       : <div className='sidebar-list-item-text'>Oops, no matches found for <strong>&apos;{filter}&apos;</strong></div>

--- a/app/components/DatasetSidebar.tsx
+++ b/app/components/DatasetSidebar.tsx
@@ -8,17 +8,34 @@ interface FileRowProps {
   name: string
   filename: string
   selected: boolean
+  status: string
   onClick: (type: string, selectedListItem: string) => Action
 }
 
 const FileRow: React.FunctionComponent<FileRowProps> = (props) => {
+  let statusColor
+  switch (props.status) {
+    case 'modified':
+      statusColor = '#cab081'
+      break
+    case 'unmodified':
+      statusColor = '#9bde9b'
+      break
+    default:
+      statusColor = 'transparent'
+  }
   return (
     <div
       className={`sidebar-list-item sidebar-list-item-text ${props.selected && 'selected'}`}
       onClick={() => { props.onClick('component', props.name) }}
     >
-      <div className='text'>{props.name}</div>
-      <div className='subtext'>{props.filename}</div>
+      <div className='text-column'>
+        <div className='text'>{props.name}</div>
+        <div className='subtext'>{props.filename}</div>
+      </div>
+      <div className='status-column'>
+        <span className='dot' style={{ backgroundColor: statusColor }}></span>
+      </div>
     </div>
   )
 }
@@ -38,11 +55,13 @@ const HistoryListItem: React.FunctionComponent<HistoryListItemProps> = (props) =
       className={`sidebar-list-item sidebar-list-item-text ${props.selected && 'selected'}`}
       onClick={() => { props.onClick('commit', props.path) }}
     >
-      <div className='text'>{props.commitTitle}</div>
-      <div className='subtext'>
-        <img className= 'user-image' src = {props.avatarUrl} />
-        <div className='time-message'>
-          {props.timeMessage}
+      <div className='text-column'>
+        <div className='text'>{props.commitTitle}</div>
+        <div className='subtext'>
+          <img className= 'user-image' src = {props.avatarUrl} />
+          <div className='time-message'>
+            {props.timeMessage}
+          </div>
         </div>
       </div>
     </div>
@@ -88,12 +107,14 @@ const DatasetSidebar: React.FunctionComponent<DatasetSidebarProps> = (props: Dat
           </div>
           {
             Object.keys(status).map((key) => {
-              const { filepath } = status[key]
+              const { filepath, status: fileStatus } = status[key]
+              const filename = filepath.substring((filepath.lastIndexOf('/') + 1))
               return (
                 <FileRow
                   key={key}
                   name={key}
-                  filename={filepath}
+                  filename={filename}
+                  status={fileStatus}
                   selected={selectedComponent === key}
                   onClick={onListItemClick}
                 />

--- a/app/components/Metadata.tsx
+++ b/app/components/Metadata.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import { Meta } from '../models/dataset'
+
+interface MetadataProps {
+  meta: Meta
+}
+
+const Metadata: React.FunctionComponent<MetadataProps> = (props: MetadataProps) => {
+  console.log(props)
+  return (
+    <div className='content'>
+      <pre>{JSON.stringify(props.meta, null, 2)}</pre>
+    </div>
+  )
+}
+
+export default Metadata

--- a/app/containers/CommitDetailsContainer.tsx
+++ b/app/containers/CommitDetailsContainer.tsx
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux'
+import CommitDetails from '../components/CommitDetails'
+import Store from '../models/store'
+
+const mapStateToProps = (state: Store) => {
+  const { workingDataset, selections } = state
+
+  const { commit: selectedCommitPath } = selections
+
+  // find the currently selected commit
+  const selectedCommit = workingDataset.history.value
+    .find(d => d.path === selectedCommitPath)
+
+  return { commit: selectedCommit }
+}
+
+const actions = {}
+
+export default connect(mapStateToProps, actions)(CommitDetails)

--- a/app/containers/DatasetContainer.tsx
+++ b/app/containers/DatasetContainer.tsx
@@ -5,7 +5,8 @@ import Store from '../models/store'
 import { toggleDatasetList, setSidebarWidth } from '../actions/ui'
 import {
   fetchMyDatasetsAndWorkbench,
-  fetchWorkingDataset
+  fetchWorkingDataset,
+  fetchWorkingStatus
 } from '../actions/api'
 import {
   setActiveTab,
@@ -37,7 +38,8 @@ const DatasetContainer = connect(
     setSelectedListItem,
     setWorkingDataset,
     fetchMyDatasetsAndWorkbench,
-    fetchWorkingDataset
+    fetchWorkingDataset,
+    fetchWorkingStatus
   }
 )(Dataset)
 

--- a/app/containers/DatasetContainer.tsx
+++ b/app/containers/DatasetContainer.tsx
@@ -4,9 +4,8 @@ import Store from '../models/store'
 
 import { toggleDatasetList, setSidebarWidth } from '../actions/ui'
 import {
-  fetchMyDatasets,
-  fetchWorkingDataset,
-  fetchWorkingDatasetHistory
+  fetchMyDatasetsAndWorkbench,
+  fetchWorkingDataset
 } from '../actions/api'
 import {
   setActiveTab,
@@ -37,9 +36,8 @@ const DatasetContainer = connect(
     setFilter,
     setSelectedListItem,
     setWorkingDataset,
-    fetchMyDatasets,
-    fetchWorkingDataset,
-    fetchWorkingDatasetHistory
+    fetchMyDatasetsAndWorkbench,
+    fetchWorkingDataset
   }
 )(Dataset)
 

--- a/app/containers/DatasetContainer.tsx
+++ b/app/containers/DatasetContainer.tsx
@@ -3,7 +3,11 @@ import Dataset from '../components/Dataset'
 import Store from '../models/store'
 
 import { toggleDatasetList, setSidebarWidth } from '../actions/ui'
-import { fetchMyDatasets, fetchWorkingDataset } from '../actions/api'
+import {
+  fetchMyDatasets,
+  fetchWorkingDataset,
+  fetchWorkingDatasetHistory
+} from '../actions/api'
 import {
   setActiveTab,
   setSelectedListItem,
@@ -34,7 +38,8 @@ const DatasetContainer = connect(
     setSelectedListItem,
     setWorkingDataset,
     fetchMyDatasets,
-    fetchWorkingDataset
+    fetchWorkingDataset,
+    fetchWorkingDatasetHistory
   }
 )(Dataset)
 

--- a/app/containers/MetadataContainer.tsx
+++ b/app/containers/MetadataContainer.tsx
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux'
+import Metadata from '../components/Metadata'
+import Store from '../models/store'
+
+const mapStateToProps = (state: Store) => {
+  const { workingDataset, selections } = state
+
+  const { component: selectedComponent } = selections
+
+  // get data for the currently selected component
+  const meta = workingDataset.value[selectedComponent]
+  return { meta }
+}
+
+const actions = {}
+
+export default connect(mapStateToProps, actions)(Metadata)

--- a/app/models/dataset.ts
+++ b/app/models/dataset.ts
@@ -49,6 +49,7 @@ export interface Dataset {
   schema?: JSONSchema7
   body?: Object | []
   commit?: Commit
+  [key: string]: any
 }
 
 export default Dataset

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -70,7 +70,7 @@ export interface MyDatasets {
   filter: string // filter string from ui
 }
 
-export type ComponentState = 'changed' | 'unchanged' | 'removed' | 'added'
+export type ComponentState = 'modified' | 'unmodified' | 'removed' | 'added'
 
 // info about a dataset component as compared the same component in previous commit
 export interface ComponentStatus {
@@ -84,6 +84,10 @@ export interface Pages {
   [key: string]: PageInfo
 }
 
+export interface DatasetStatus {
+  [key: string]: ComponentStatus
+}
+
 export interface DatasetComparison {
   path: string
   prevPath: string
@@ -92,9 +96,7 @@ export interface DatasetComparison {
   pages: Pages
   diff: object
   value: Dataset
-  status: {
-    [key: string]: ComponentStatus
-  }
+  status: DatasetStatus
 }
 
 export interface WorkingDataset extends DatasetComparison {
@@ -110,6 +112,6 @@ export default interface Store {
   selections: Selections
   myDatasets: MyDatasets
   workingDataset: WorkingDataset
-  workingHistory: DatasetComparison
+  commitDetail: DatasetComparison
   router: RouterState
 }

--- a/app/reducers/initalState.ts
+++ b/app/reducers/initalState.ts
@@ -135,19 +135,19 @@ export let workingDataset: WorkingDataset = {
   status: {
     meta: {
       filepath: 'meta.json',
-      status: 'unchanged',
+      status: 'unmodified',
       errors: [],
       warnings: []
     },
     schema: {
       filepath: 'schema.json',
-      status: 'unchanged',
+      status: 'unmodified',
       errors: [],
       warnings: []
     },
     body: {
       filepath: 'body.csv',
-      status: 'unchanged',
+      status: 'unmodified',
       errors: [],
       warnings: []
     }

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -42,6 +42,7 @@ const initialState: WorkingDataset = {
 }
 
 const [DATASET_REQ, DATASET_SUCC, DATASET_FAIL] = apiActionTypes('dataset')
+const [DATASET_HISTORY_REQ, DATASET_HISTORY_SUCC, DATASET_HISTORY_FAIL] = apiActionTypes('history')
 
 const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction): WorkingDataset => {
   switch (action.type) {
@@ -51,6 +52,18 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
       return Object.assign({}, state, action.payload.data)
     case DATASET_FAIL:
       return state
+
+    case DATASET_HISTORY_REQ:
+      return state
+    case DATASET_HISTORY_SUCC:
+      return Object.assign({}, state, {
+        history: {
+          value: action.payload.data
+        }
+      })
+    case DATASET_HISTORY_FAIL:
+      return state
+
     default:
       return state
   }

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -13,19 +13,19 @@ const initialState: WorkingDataset = {
   status: {
     meta: {
       filepath: 'meta.json',
-      status: 'unchanged',
+      status: 'unmodified',
       errors: [],
       warnings: []
     },
     schema: {
       filepath: 'schema.json',
-      status: 'unchanged',
+      status: 'unmodified',
       errors: [],
       warnings: []
     },
     body: {
       filepath: 'body.csv',
-      status: 'unchanged',
+      status: 'unmodified',
       errors: [],
       warnings: []
     }
@@ -50,7 +50,8 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
     case DATASET_REQ:
       return state
     case DATASET_SUCC:
-      return Object.assign({}, state, action.payload.data)
+      const { name, path, peername, published, dataset: value } = action.payload.data
+      return Object.assign({}, state, { name, path, peername, published, value })
     case DATASET_FAIL:
       return state
 

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -1,5 +1,5 @@
 import { Reducer, AnyAction } from 'redux'
-import { WorkingDataset } from '../models/store'
+import { WorkingDataset, DatasetStatus, ComponentStatus } from '../models/store'
 import { apiActionTypes } from '../store/api'
 
 const initialState: WorkingDataset = {
@@ -43,6 +43,7 @@ const initialState: WorkingDataset = {
 
 const [DATASET_REQ, DATASET_SUCC, DATASET_FAIL] = apiActionTypes('dataset')
 const [DATASET_HISTORY_REQ, DATASET_HISTORY_SUCC, DATASET_HISTORY_FAIL] = apiActionTypes('history')
+const [DATASET_STATUS_REQ, DATASET_STATUS_SUCC, DATASET_STATUS_FAIL] = apiActionTypes('status')
 
 const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction): WorkingDataset => {
   switch (action.type) {
@@ -62,6 +63,23 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
         }
       })
     case DATASET_HISTORY_FAIL:
+      return state
+
+    case DATASET_STATUS_REQ:
+      return state
+    case DATASET_STATUS_SUCC:
+      const statusObject: DatasetStatus = action.payload.data
+        // sort array, go randomizes order
+        .sort((a: any, b: any) => (a.path > b.path) ? 1 : -1)
+        .reduce((obj: any, item: any): ComponentStatus => {
+          const { path, filepath, status } = item
+          obj[path] = { filepath, status }
+          return obj
+        }, {})
+      return Object.assign({}, state, {
+        status: statusObject
+      })
+    case DATASET_STATUS_FAIL:
       return state
 
     default:

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -179,7 +179,7 @@ $hover-highlight-color: #F6F8FA;
 
   .sidebar-list-item-text {
     padding: $sidebar-item-padding;
-    flex-direction: column;
+    flex-direction: row;
 
     &:hover {
       background-color: $hover-highlight-color;
@@ -189,29 +189,48 @@ $hover-highlight-color: #F6F8FA;
       background-color: #e6e6e6;
     }
 
-    .text {
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      line-height: 1.6rem;
-    }
+    .text-column {
+      flex-direction: column;
+      flex: 1;
 
-    .subtext {
-      display: flex;
-
-      .user-image {
-        height: 16px;
-        width: 16px;
-        margin-right: 4px;
-        border-radius: 2px;
+      .text {
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        line-height: 1.6rem;
       }
 
-      flex: 1;
-      font-size: .65rem;
-      line-height: 1.2rem;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
+      .subtext {
+        display: flex;
+
+        .user-image {
+          height: 16px;
+          width: 16px;
+          margin-right: 4px;
+          border-radius: 2px;
+        }
+
+        flex: 1;
+        font-size: .65rem;
+        line-height: 1.2rem;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
+    }
+
+    .status-column {
+      text-align: center;
+      line-height: 2.9rem;
+      width: 30px;
+
+        .dot {
+          height: 10px;
+          width: 10px;
+          background-color: transparent;
+          border-radius: 50%;
+          display: inline-block;
+        }
     }
   }
 }

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -48,6 +48,7 @@ $hover-highlight-color: #F6F8FA;
 
     #sidebar {
       position: relative;
+      flex: 0 0 auto;
 
       .resize-handle {
         position: absolute;
@@ -59,10 +60,12 @@ $hover-highlight-color: #F6F8FA;
       }
     }
 
-    .content {
+    .content-wrapper {
       background-color: #d8d8d8;
       flex: 1;
       position: relative;
+      flex-basis: auto;
+      overflow: hidden;
 
       .overlay {
         position: absolute;
@@ -70,6 +73,11 @@ $hover-highlight-color: #F6F8FA;
         width: 100%;
         background-color: #000;
         opacity: 0.4;
+      }
+
+      .content {
+        padding: 15px;
+        overflow-x: scroll;
       }
     }
   }


### PR DESCRIPTION
This PR includes more progress on wiring up app state:
- Fetches history after working dataset, populates history pane
- Adds a `CommitDetails` component (placeholder)
- Polls for status, reflects working directory files modified/unmodified status with an orange/green dot
- Adds a `Metadata` component, ready to display metadata in the main content area