### PR TITLE
fix: set default working dataset if none selected

### DIFF
--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -3,6 +3,7 @@ import { ApiAction } from '../store/api'
 import { CSSTransition } from 'react-transition-group'
 import CreateDataset from './modals/CreateDataset'
 import AddDataset from './modals/AddDataset'
+import DatasetContainer from '../containers/DatasetContainer'
 import NoDatasets from './NoDatasets'
 import Onboard from './Onboard'
 import { Modal, ModalType, NoModal } from '../models/modals'
@@ -18,7 +19,6 @@ interface AppProps {
   setPeername: () => Action
   hasDatasets: boolean
   loading: boolean
-  children: any
   sessionID: string
   peername: string
   hasAcceptedTOS: boolean
@@ -96,7 +96,6 @@ export default class App extends React.Component<AppProps, AppState> {
 
   render () {
     const {
-      children,
       hasSetPeername,
       hasAcceptedTOS,
       peername,
@@ -114,7 +113,7 @@ export default class App extends React.Component<AppProps, AppState> {
         acceptTOS={acceptTOS}
       />
       {this.renderNoDatasets()}
-      {children}
+      { this.props.hasDatasets && <DatasetContainer /> }
     </div>)
   }
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import RoutesContainer from './containers/RoutesContainer'
-import { HashRouter as Router } from 'react-router-dom'
+import AppContainer from './containers/AppContainer'
 import { Provider } from 'react-redux'
 import './app.global.scss'
 
@@ -10,9 +9,7 @@ const store = configureStore()
 
 ReactDOM.render(
   <Provider store={store}>
-    <Router>
-      <RoutesContainer/>
-    </Router>
+    <AppContainer />
   </Provider>,
   document.getElementById('root')
 )

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -1,19 +1,22 @@
 import { AnyAction } from 'redux'
 import { Selections } from '../models/store'
 import store from '../utils/localStore'
+import { apiActionTypes } from '../store/api'
 
 export const SELECTIONS_SET_ACTIVE_TAB = 'SELECTIONS_SET_ACTIVE_TAB'
 export const SELECTIONS_SET_SELECTED_LISTITEM = 'SELECTIONS_SET_SELECTED_LISTITEM'
 export const SELECTIONS_SET_WORKING_DATASET = 'SELECTIONS_SET_WORKING_DATASET'
 
 const initialState: Selections = {
-  peername: store().getItem('peername'),
-  name: store().getItem('name'),
+  peername: store().getItem('peername') || '',
+  name: store().getItem('name') || '',
   activeTab: store().getItem('activeTab') || 'status',
   component: store().getItem('component') || '',
   commit: store().getItem('commit') || '',
   commitComponent: store().getItem('commitComponent') || ''
 }
+
+const [, LIST_SUCC] = apiActionTypes('list')
 
 export default (state = initialState, action: AnyAction) => {
   switch (action.type) {
@@ -43,6 +46,17 @@ export default (state = initialState, action: AnyAction) => {
       store().setItem('peername', peername)
       store().setItem('name', name)
       return Object.assign({}, state, { peername, name })
+
+    case LIST_SUCC:
+      // if there is no peername + name in selections, use the first one on the list
+      if (state.peername === '' && state.name === '') {
+        const { peername: firstPeername, name: firstName } = action.payload.data[0]
+        store().setItem('peername', firstPeername)
+        store().setItem('name', firstName)
+        return Object.assign({}, state, { peername: firstPeername, name: firstName })
+      } else {
+        return state
+      }
 
     default:
       return state


### PR DESCRIPTION
- Moves `DatasetContainer` to App, where it is conditionally rendered if `hasDatasets` is true.  This means we aren't rendering it until after the call to `/list` is successful and there are datasets.
- Updates `selections` reducer to set the first dataset returned from `/list` as the selected dataset if there is none already selected.
- Removes `Router` from `index.tsx`, as we are not using routing at all for now (routing was removed in 77782e92f181cc194b5847fbb7cb63fd364fd66b).  `app/routes.tsx` remains in place for whenever we turn routing back on.

Closes #45 