### PR TITLE
fix(*): Welcome, ChoosePeername, AddDataset, CreateDataset

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -1,7 +1,6 @@
 import { CALL_API, ApiAction, ApiActionThunk, chainSuccess } from '../store/api'
 import { DatasetSummary, ComponentStatus, ComponentState } from '../models/store'
 import { Dataset, Commit } from '../models/dataset'
-import { Session } from '../models/session'
 import { Action } from 'redux'
 
 import { setSelectedListItem } from './selections'
@@ -271,27 +270,6 @@ export function saveWorkingDataset (title: string, message: string): ApiActionTh
       }
     }
 
-    return dispatch(action)
-  }
-}
-
-export function fetchSession (): ApiActionThunk {
-  return async (dispatch) => {
-    const action = {
-      type: 'session',
-      [CALL_API]: {
-        endpoint: 'session',
-        method: 'GET',
-        map: (data: Record<string, string>): Session => {
-          return {
-            peername: data.peername,
-            id: data.id,
-            created: data.created,
-            updated: data.updated
-          }
-        }
-      }
-    }
     return dispatch(action)
   }
 }

--- a/app/actions/session.ts
+++ b/app/actions/session.ts
@@ -1,0 +1,40 @@
+import { CALL_API, ApiActionThunk } from '../store/api'
+import { Session } from '../models/session'
+
+export function fetchSession (): ApiActionThunk {
+  return async (dispatch) => {
+    const action = {
+      type: 'session',
+      [CALL_API]: {
+        endpoint: 'session',
+        method: 'GET',
+        map: (data: Record<string, any>): Session => {
+          return data as Session
+        }
+      }
+    }
+    return dispatch(action)
+  }
+}
+
+export function setPeername (newPeername: string): ApiActionThunk {
+  return async (dispatch, getStore) => {
+    const { session } = getStore()
+    if (newPeername === session.peername) {
+      return new Promise(resolve => resolve({ type: 'NO_ACTION_NEEDED' }))
+    }
+    const newSession = Object.assign({}, session, { peername: newPeername })
+    const action = {
+      type: 'new_peername',
+      [CALL_API]: {
+        endpoint: 'session',
+        method: 'POST',
+        body: newSession,
+        map: (data: Record<string, any>): Session => {
+          return data as Session
+        }
+      }
+    }
+    return dispatch(action)
+  }
+}

--- a/app/actions/ui.ts
+++ b/app/actions/ui.ts
@@ -26,7 +26,7 @@ export const acceptTOS = () => {
   }
 }
 
-export const setPeername = () => {
+export const setHasSetPeername = () => {
   return {
     type: UI_SET_PEERNAME
   }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -53,18 +53,28 @@ export default class App extends React.Component<AppProps, AppState> {
     // }
     const Modal = this.state.currentModal
 
-    switch (Modal.type) {
-      case ModalType.CreateDataset:
-        return (
+    return (
+      <div >
+        <CSSTransition
+          in={ModalType.CreateDataset === Modal.type}
+          classNames='fade'
+          component='div'
+          timeout={300}
+          unmountOnExit
+        >
           <CreateDataset onSubmit={this.props.initDataset} onDismissed={() => this.setState({ currentModal: NoModal })}/>
-        )
-      case ModalType.AddDataset:
-        return (
+        </CSSTransition>
+        <CSSTransition
+          in={ModalType.AddDataset === Modal.type}
+          classNames='fade'
+          component='div'
+          timeout={300}
+          unmountOnExit
+        >
           <AddDataset onSubmit={this.props.addDataset} onDismissed={() => this.setState({ currentModal: NoModal })}/>
-        )
-      default:
-        return null
-    }
+        </CSSTransition>
+      </div>
+    )
   }
 
   private renderNoDatasets () {

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -12,10 +12,11 @@ import { Action } from 'redux'
 interface AppProps {
   fetchSession: () => Promise<ApiAction>
   fetchMyDatasetsAndLinks: () => Promise<ApiAction>
+  setPeername: (newPeername: string) => Promise<ApiAction>
   addDataset: (peername: string, name: string) => Promise<ApiAction>
   initDataset: (path: string, name: string, format: string) => Promise<ApiAction>
   acceptTOS: () => Action
-  setPeername: () => Action
+  setHasSetPeername: () => Action
   hasDatasets: boolean
   loading: boolean
   children: any
@@ -101,7 +102,8 @@ export default class App extends React.Component<AppProps, AppState> {
       hasAcceptedTOS,
       peername,
       acceptTOS,
-      setPeername
+      setPeername,
+      setHasSetPeername
     } = this.props
     return (<div style={{ height: '100%' }}>
       {this.renderAppLoading()}
@@ -110,6 +112,7 @@ export default class App extends React.Component<AppProps, AppState> {
         peername={peername}
         hasAcceptedTOS={hasAcceptedTOS}
         hasSetPeername={hasSetPeername}
+        setHasSetPeername={setHasSetPeername}
         setPeername={setPeername}
         acceptTOS={acceptTOS}
       />

--- a/app/components/ChoosePeername.tsx
+++ b/app/components/ChoosePeername.tsx
@@ -7,13 +7,17 @@ export interface ChoosePeernameProps {
   peername: string
 }
 
-const SET_PEERNAME_FAILURE = 'SET_PEERNAME_FAILURE'
-
 const ChoosePeername: React.FunctionComponent<ChoosePeernameProps> = (props: ChoosePeernameProps) => {
   const { peername, onSave } = props
   const [newPeername, setNewPeername] = React.useState(peername)
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState('')
+  const [acceptEnabled, setAcceptEnabled] = React.useState(true)
+
+  React.useEffect(() => {
+    if (newPeername === '' && acceptEnabled) setAcceptEnabled(false)
+    else if (!acceptEnabled) setAcceptEnabled(true)
+  }, [newPeername])
 
   React.useEffect(() => {
     setNewPeername(peername)
@@ -26,22 +30,23 @@ const ChoosePeername: React.FunctionComponent<ChoosePeernameProps> = (props: Cho
     setNewPeername(value)
   }
 
-  const handleSave = () => {
-    setLoading(true)
-    setError('')
-    setTimeout(async () =>
-      onSave(newPeername)
-        .then((action: any) => {
-          if (action.type === SET_PEERNAME_FAILURE) {
-            setLoading(false)
-            setError(action.error)
-          }
-        }), 2000)
+  async function handleSave () {
+    new Promise(resolve => {
+      setLoading(true)
+      resolve()
+    })
+      .then(async () => onSave(newPeername))
+      .catch((action) => {
+        console.log(action)
+        setLoading(false)
+        setError('some error occured')
+      })
   }
 
   return (
     <WelcomeTemplate
       onAccept={handleSave}
+      acceptEnabled={acceptEnabled}
       acceptText='Take me to Qri '
       title='Choose Your Peername'
       subtitle='We&apos;ve generated a peername for you'

--- a/app/components/Onboard.tsx
+++ b/app/components/Onboard.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react'
 import { Action } from 'redux'
+import { ApiAction } from '../store/api'
 import { CSSTransition } from 'react-transition-group'
 
 import Welcome from './Welcome'
 import ChoosePeername from './ChoosePeername'
-
-const peernameError: string = 'peername_error'
-const SET_PEERNAME_FAILURE = 'SET_PEERNAME_FAILURE'
-const SET_PEERNAME_SUCCESS = 'SET_PEERNAME_SUCCESS'
 
 export interface OnboardProps {
   peername: string
@@ -15,7 +12,8 @@ export interface OnboardProps {
   hasSetPeername: boolean
 
   acceptTOS: () => Action
-  setPeername: () => Action
+  setHasSetPeername: () => Action
+  setPeername: (newPeername: string) => Promise<ApiAction>
 }
 
 // Onboard is a series of flows for onboarding a new user
@@ -25,20 +23,12 @@ const Onboard: React.FunctionComponent<OnboardProps> = (
     hasAcceptedTOS,
     hasSetPeername,
     acceptTOS,
-    setPeername
+    setPeername,
+    setHasSetPeername
   }) => {
   async function onSave (peername: string): Promise<any> {
-    return new Promise((resolve) => {
-      let error: string = ''
-      let type: string = SET_PEERNAME_SUCCESS
-      if (peername === peernameError) {
-        error = 'this peername is already taken'
-        type = SET_PEERNAME_FAILURE
-      } else {
-        setPeername()
-      }
-      resolve({ type, error })
-    })
+    return setPeername(peername)
+      .then(() => setHasSetPeername())
   }
 
   const renderWelcome = () => {

--- a/app/components/Welcome.tsx
+++ b/app/components/Welcome.tsx
@@ -16,7 +16,7 @@ const Welcome: React.FunctionComponent<WelcomeProps> = ({ onAccept }) =>
     exit
   >
     <span>
-      <p>We’re currently in Beta. There will be bugs. Features will change quickly &amp; often. We hope you’ll come on this adventure with us! Our <ExternalLink href='https://github.com/qri-io/frontend'>github org</ExternalLink> and our <ExternalLink href='https://discord.gg/etap8Gb' >discord</ExternalLink> are the best places to stay informed.</p>
+      <p>We’re currently in Beta. There will be bugs. Features will change quickly &amp; often. We hope you’ll come on this adventure with us! Our <ExternalLink href='https://github.com/qri-io/desktop'>github org</ExternalLink> and our <ExternalLink href='https://discord.gg/etap8Gb' >discord</ExternalLink> are the best places to stay informed.</p>
       <div>
           A few notes before we get started:<br />
         <ul>

--- a/app/components/WelcomeTemplate.tsx
+++ b/app/components/WelcomeTemplate.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react' // eslint-disable-line
 import { remote } from 'electron'
 import { Spinner } from './chrome/Spinner'
+import classNames from 'classnames'
 export const logo = require('../assets/qri-blob-logo-large.png') // eslint-disable-line
 
 interface WelcomeTemplateProps {
@@ -11,9 +12,16 @@ interface WelcomeTemplateProps {
   subtitle: string
   loading?: boolean
   id?: string
+  acceptEnabled?: boolean
 }
 
-const WelcomeTemplate: React.FunctionComponent<WelcomeTemplateProps> = ({ onAccept, acceptText, exit, title, subtitle, loading, id, children }) => {
+const WelcomeTemplate: React.FunctionComponent<WelcomeTemplateProps> = ({ onAccept, acceptText, exit, title, subtitle, loading, id, acceptEnabled = true, children }) => {
+  const handleOnClick = () => {
+    if (acceptEnabled && onAccept) {
+      onAccept()
+    }
+  }
+
   return (
     <div className='welcome-page' id={id}>
       <div className='welcome-center'>
@@ -30,7 +38,7 @@ const WelcomeTemplate: React.FunctionComponent<WelcomeTemplateProps> = ({ onAcce
                 <Spinner/>
               </div>
               : !!onAccept && <div className='welcome-accept'>
-                <a className='linkLarge' onClick={onAccept}>{acceptText}<span className='icon-inline'>right</span></a><br />
+                <a className={classNames('linkLarge', { 'linkDisabled': !acceptEnabled })} onClick={handleOnClick}><span>{acceptText}</span><span className={classNames('icon-inline', { 'linkDisabled': !acceptEnabled })}>right</span></a><br />
                 {exit && <a className='linkSmallMuted' onClick={() => { remote.app.quit() }}>exit</a>}
               </div>
           }

--- a/app/components/modals/AddDataset.tsx
+++ b/app/components/modals/AddDataset.tsx
@@ -162,7 +162,7 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
       id="addDataset"
       title={'Add Dataset'}
       onDismissed={onDismissed}
-      onSubmit={handleSubmit}
+      onSubmit={() => {}}
       dismissable={dismissable}
       setDismissable={setDismissable}
     >

--- a/app/components/modals/AddDataset.tsx
+++ b/app/components/modals/AddDataset.tsx
@@ -5,29 +5,22 @@ import Modal from './Modal'
 import TextInput from '../form/TextInput'
 import Error from './Error'
 import Buttons from './Buttons'
-import Tabs from './Tabs'
+// import Tabs from './Tabs'
 
 interface AddByNameProps {
-  peername: string
   datasetName: string
   onChange: (name: string, value: any, e: any) => void
 }
 
-const AddByName: React.FunctionComponent<AddByNameProps> = ({ peername, datasetName, onChange }) => {
+const AddByName: React.FunctionComponent<AddByNameProps> = ({ datasetName, onChange }) => {
   return (
     <div className='content'>
-      <p>Add a dataset that already exists on Qri using the <strong>peername</strong> and <strong>dataset name</strong>.</p>
-      <TextInput
-        name='peername'
-        label='Peername:'
-        type=''
-        value={peername}
-        onChange={onChange}
-        maxLength={300}
-      />
+      <p>Add a dataset that already exists on Qri</p>
+      <p>Qri dataset names have the following structure: <strong>peername/dataset name</strong>.</p>
+      <p>For example: <strong>chriswhong/usgs_earthquakes</strong>.</p>
       <TextInput
         name='datasetName'
-        label='Dataset Name:'
+        label='Peername/Dataset_Name:'
         type=''
         value={datasetName}
         onChange={onChange}
@@ -69,17 +62,20 @@ interface AddDatasetProps {
 }
 
 const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onSubmit }) => {
-  const [peername, setPeername] = React.useState('')
   const [datasetName, setDatasetName] = React.useState('')
-  const [url, setUrl] = React.useState('')
-  const [activeTab, setActiveTab] = React.useState(TabTypes.ByName)
+
+  // restore when you can add by URL
+  // const [url, setUrl] = React.useState('')
+  // const [activeTab, setActiveTab] = React.useState(TabTypes.ByName)
+  const activeTab = TabTypes.ByName
+
   const [dismissable, setDismissable] = React.useState(true)
   const [buttonDisabled, setButtonDisabled] = React.useState(true)
 
   React.useEffect(() => {
     toggleButton(activeTab)
     if (error !== '') setError('')
-  }, [url, peername, datasetName, activeTab])
+  }, [datasetName, activeTab])
 
   // should come from props
   const [error, setError] = React.useState('')
@@ -89,26 +85,27 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
     if (value[value.length - 1] === ' ') {
       return
     }
-    if (name === 'peername') setPeername(value)
     if (name === 'datasetName') setDatasetName(value)
-    if (name === 'url') setUrl(value)
+    // restore when you can add by URL
+    // if (name === 'url') setUrl(value)
   }
 
   const toggleButton = (activeTab: TabTypes) => {
     if (activeTab === TabTypes.ByName) {
-      if (peername && datasetName) {
+      if (datasetName) {
         setButtonDisabled(false)
       } else {
         setButtonDisabled(true)
       }
     }
-    if (activeTab === TabTypes.ByUrl) {
-      if (url) {
-        setButtonDisabled(false)
-      } else {
-        setButtonDisabled(true)
-      }
-    }
+    // restore when you can add by URL
+    // if (activeTab === TabTypes.ByUrl) {
+    //   if (url) {
+    //     setButtonDisabled(false)
+    //   } else {
+    //     setButtonDisabled(true)
+    //   }
+    // }
   }
 
   const handleSubmit = () => {
@@ -117,7 +114,15 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
     // should fire off action and catch error response
     // if success, fetchDatatsets
     if (!onSubmit) return
-    onSubmit(peername, datasetName)
+    const names = datasetName.split('/')
+    if (names.length !== 2) {
+      setError('dataset reference should be in the format [peername]/[dataset_name]')
+      setLoading(false)
+      setDismissable(true)
+      return
+    }
+
+    onSubmit(names[0], names[1])
       .then(() => onDismissed())
       .catch((action) => {
         setLoading(false)
@@ -134,28 +139,29 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
         timeout={300}
         unmountOnExit
       >
-        <AddByName peername={peername} datasetName={datasetName} onChange={handleChanges}/>
+        <AddByName datasetName={datasetName} onChange={handleChanges}/>
       </CSSTransition>
     )
   }
 
-  const renderAddByUrl = () => {
-    return (
-      <CSSTransition
-        in={ activeTab === TabTypes.ByUrl }
-        classNames="fade"
-        component="div"
-        timeout={300}
-        unmountOnExit
-      >
-        <AddByUrl url={url} onChange={handleChanges}/>
-      </CSSTransition>
-    )
-  }
-
-  const handleSetActiveTab = (activeTab: TabTypes) => {
-    setActiveTab(activeTab)
-  }
+  // restore when you can add by URL
+  // const renderAddByUrl = () => {
+  //   return (
+  //     <CSSTransition
+  //       in={ activeTab === TabTypes.ByUrl }
+  //       classNames="fade"
+  //       component="div"
+  //       timeout={300}
+  //       unmountOnExit
+  //     >
+  //       <AddByUrl url={url} onChange={handleChanges}/>
+  //     </CSSTransition>
+  //   )
+  // }
+  //
+  // const handleSetActiveTab = (activeTab: TabTypes) => {
+  //   setActiveTab(activeTab)
+  // }
 
   return (
     <Modal
@@ -166,11 +172,13 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
       dismissable={dismissable}
       setDismissable={setDismissable}
     >
-      <Tabs tabs={[TabTypes.ByName, TabTypes.ByUrl]} active={activeTab} onClick={handleSetActiveTab} id='add-dataset-tab'/>
+      {/* restore when you can add by URL */}
+      {/* <Tabs tabs={[TabTypes.ByName, TabTypes.ByUrl]} active={activeTab} onClick={handleSetActiveTab} id='add-dataset-tab'/> */}
       <div className='content-wrap'>
         <div>
           {renderAddByName()}
-          {renderAddByUrl()}
+          {/* restore when you can add by URL */}
+          {/* {renderAddByUrl()} */}
         </div>
         <div id='error'><Error text={error} /></div>
       </div>

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -7,7 +7,7 @@ import TextInput from '../form/TextInput'
 import SelectInput from '../form/SelectInput'
 import Error from './Error'
 import Buttons from './Buttons'
-import Tabs from './Tabs'
+// import Tabs from './Tabs'
 import ButtonInput from '../form/ButtonInput'
 
 import { ISelectOption } from '../../models/forms'
@@ -34,7 +34,11 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
   const [path, setPath] = React.useState('')
   const [bodyFormat, setBodyFormat] = React.useState(formatOptions[0].value)
   const [bodyPath, setBodyPath] = React.useState('')
-  const [activeTab, setActiveTab] = React.useState(TabTypes.NewBody)
+
+  // remove until we can init from an existing bodyfile
+  // const [activeTab, setActiveTab] = React.useState(TabTypes.NewBody)
+  const activeTab = TabTypes.NewBody
+
   const [dismissable, setDismissable] = React.useState(true)
   const [buttonDisabled, setButtonDisabled] = React.useState(true)
   const [alreadyDatasetError, setAlreadyDatasetError] = React.useState('')
@@ -85,21 +89,24 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
     }
   }
 
-  const showFilePicker = () => {
-    const window = remote.getCurrentWindow()
-    const directory: string[] | undefined = remote.dialog.showOpenDialog(window, {
-      properties: ['createDirectory', 'openFile'],
-      filters: [{ name: 'Data', extensions: ['csv', 'json', 'xlsx', 'cbor'] }]
-    })
+  //
+  // remove until we can init from an existing bodyfile
+  //
+  // const showFilePicker = () => {
+  //   const window = remote.getCurrentWindow()
+  //   const directory: string[] | undefined = remote.dialog.showOpenDialog(window, {
+  //     properties: ['createDirectory', 'openFile'],
+  //     filters: [{ name: 'Data', extensions: ['csv', 'json', 'xlsx', 'cbor'] }]
+  //   })
 
-    if (!directory) {
-      return
-    }
+  //   if (!directory) {
+  //     return
+  //   }
 
-    const path = directory[0]
+  //   const path = directory[0]
 
-    setBodyPath(path)
-  }
+  //   setBodyPath(path)
+  // }
 
   const handlePickerDialog = (showFunc: () => void) => {
     new Promise(resolve => {
@@ -150,10 +157,12 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
     if (name === 'bodyPath') setBodyPath(value)
   }
 
-  const renderTabs = () => {
-    // return <Tabs tabs={[TabTypes.NewBody, TabTypes.ExistingBody]} active={activeTab} onClick={(activeTab: TabTypes) => setActiveTab(activeTab)}/>
-    return <Tabs tabs={[TabTypes.NewBody]} active={activeTab} onClick={(activeTab: TabTypes) => setActiveTab(activeTab)}/>
-  }
+  //
+  // remove until we can init on an existing bodyfile
+  //
+  // const renderTabs = () => {
+  //   return <Tabs tabs={[TabTypes.NewBody]} active={activeTab} onClick={(activeTab: TabTypes) => setActiveTab(activeTab)}/>
+  // }
 
   const renderCreateNewBody = () =>
     <CSSTransition
@@ -174,28 +183,31 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
       </div>
     </CSSTransition>
 
-  const renderUseExistingBody = () =>
-    <CSSTransition
-      in={ activeTab === TabTypes.ExistingBody }
-      classNames="fade"
-      component="div"
-      timeout={300}
-      unmountOnExit
-    >
-      <div className='content flex-space-between'>
-        <TextInput
-          name='bodyPath'
-          label='Path to datafile:'
-          type=''
-          helpText='data file can be csv, json, xlsx, or cbor'
-          showHelpText
-          value={bodyPath}
-          onChange={handleChanges}
-          maxLength={600}
-        />
-        <div className='margin-left'><ButtonInput onClick={() => handlePickerDialog(showFilePicker)} >Choose...</ButtonInput></div>
-      </div>
-    </CSSTransition>
+  //
+  // remove until we can also init on an existing bodyfile
+  //
+  // const renderUseExistingBody = () =>
+  //   <CSSTransition
+  //     in={ activeTab === TabTypes.ExistingBody }
+  //     classNames="fade"
+  //     component="div"
+  //     timeout={300}
+  //     unmountOnExit
+  //   >
+  //     <div className='content flex-space-between'>
+  //       <TextInput
+  //         name='bodyPath'
+  //         label='Path to datafile:'
+  //         type=''
+  //         helpText='data file can be csv, json, xlsx, or cbor'
+  //         showHelpText
+  //         value={bodyPath}
+  //         onChange={handleChanges}
+  //         maxLength={600}
+  //       />
+  //       <div className='margin-left'><ButtonInput onClick={() => handlePickerDialog(showFilePicker)} >Choose...</ButtonInput></div>
+  //     </div>
+  //   </CSSTransition>
 
   const handleSubmit = () => {
     setDismissable(false)
@@ -222,11 +234,13 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
     >
       <div>
         {renderCreateDataset()}
-        <hr />
-        {renderTabs()}
+        {/* remove tabs until we can also init on an existing body file */}
+        {/* <hr /> */}
+        {/* {renderTabs()} */}
         <div id='create-dataset-content-wrap' className='content-wrap'>
           {renderCreateNewBody()}
-          {renderUseExistingBody()}
+          {/* remove until we can also init on an existing body file */}
+          {/* {renderUseExistingBody()} */}
         </div>
         <Error text={error} />
       </div>

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -2,8 +2,9 @@ import { connect } from 'react-redux'
 import App from '../components/App'
 import Store from '../models/store'
 
-import { fetchSession, fetchMyDatasetsAndLinks, addDatasetAndFetch, initDatasetAndFetch } from '../actions/api'
-import { acceptTOS, setPeername } from '../actions/ui'
+import { fetchMyDatasetsAndLinks, addDatasetAndFetch, initDatasetAndFetch } from '../actions/api'
+import { acceptTOS, setHasSetPeername } from '../actions/ui'
+import { fetchSession, setPeername } from '../actions/session'
 
 const AppContainer = connect(
   (state: Store) => {
@@ -26,6 +27,7 @@ const AppContainer = connect(
     fetchMyDatasetsAndLinks,
     acceptTOS,
     setPeername,
+    setHasSetPeername,
     addDataset: addDatasetAndFetch,
     initDataset: initDatasetAndFetch
   }

--- a/app/models/session.ts
+++ b/app/models/session.ts
@@ -3,4 +3,15 @@ export interface Session {
   peername: string
   created: string
   updated: string
+  type?: string
+  email?: string
+  name?: string
+  description?: string
+  homeurl?: string
+  color?: string
+  thumb?: string
+  photo?: string
+  poster?: string
+  twitter?: string
+  peerIDs?: string[]
 }

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -18,14 +18,15 @@ const initialSession: Session = {
 }
 
 const [SESSION_REQ, SESSION_SUCC, SESSION_FAIL] = apiActionTypes('session')
+const [SET_PEERNAME_REQ, SET_PEERNAME_SUCC, SET_PEERNAME_FAIL] = apiActionTypes('set_peername')
 
 const sessionReducer: Reducer = (state = initialSession, action: AnyAction) => { // eslint-disable-line
   switch (action.type) {
-    case SESSION_REQ:
+    case SESSION_REQ || SET_PEERNAME_REQ:
       return state
-    case SESSION_SUCC:
+    case SESSION_SUCC || SET_PEERNAME_SUCC:
       return Object.assign({}, state, action.payload.data)
-    case SESSION_FAIL:
+    case SESSION_FAIL || SET_PEERNAME_FAIL:
       return state
     default:
       return state

--- a/app/scss/_dialog.scss
+++ b/app/scss/_dialog.scss
@@ -146,7 +146,7 @@ dialog {
 
   .error {
     color: $error;
-    height: $spacer;
+    height: $spacer * 2;
   }
   
   .buttons {

--- a/app/scss/_transitions.scss
+++ b/app/scss/_transitions.scss
@@ -18,34 +18,29 @@
 
 .fade-enter {
   opacity: 0;
+  &::backdrop {
+    opacity: 0;
+  }
 }
 .fade-enter-active {
   opacity: 1;
   transition: opacity 300ms, transform 300ms;
+  &::backdrop {
+    opacity: 1;
+    transition: opacity 300ms, transform 300ms;
+  }
 }
 .fade-exit {
   opacity: 1;
+  &::backdrop {
+    opacity: 1;
+  }
 }
 .fade-exit-active {
   opacity: 0;
   transition: opacity 300ms, transform 300ms;
-}
-
-.modal-enter {
-  opacity: 0;
-  background: black;
-}
-.modal-enter-active {
-  opacity: 1;
-  transition: opacity 300ms, transform 300ms;
-  background: red;
-}
-.modal-exit {
-  opacity: 1;
-  background: green;
-}
-.modal-exit-active {
-  opacity: 0;
-  transition: opacity 300ms, transform 300ms;
-  background: blue;
+  &::backdrop {
+    opacity: 0;
+    transition: opacity 300ms, transform 300ms;
+  }
 }

--- a/app/scss/_type.scss
+++ b/app/scss/_type.scss
@@ -254,6 +254,20 @@ label {
   color: $primary;
 }
 
+.linkDisabled {
+  color: $primary-muted;
+  &:hover {
+    cursor: default;
+  }
+  &:focus {
+    color: $primary-muted;
+  }
+  &:hover, &:focus {
+    color: $primary-muted;   
+    cursor: default;
+  }
+}
+
 .linkMedium {
   font-weight: $font-weight-medium;
   font-size: 15px;

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -111,7 +111,7 @@ const endpointMap: Record<string, string> = {
   'session': 'me',
   'fsilinks': 'fsilinks',
   'add': 'add',
-  'init': 'fsi/init'
+  'init': 'fsi/init/'
 }
 
 function apiUrl (endpoint: string, segments?: ApiSegments, params?: ApiParams): [string, string] {
@@ -121,29 +121,27 @@ function apiUrl (endpoint: string, segments?: ApiSegments, params?: ApiParams): 
   }
 
   let url = `http://localhost:2503/${path}`
-  if (!segments) {
-    return [url, '']
-  }
-
-  if (segments.peername) {
-    url += `/${segments.peername}`
-  }
-  if (segments.name) {
-    url += `/${segments.name}`
-  }
-  if (segments.peerID || segments.path) {
-    url += '/at'
-  }
-  if (segments.peerID) {
-    url += `/${segments.peerID}`
-  }
-  if (segments.path) {
-    url += segments.path
+  if (segments) {
+    if (segments.peername) {
+      url += `/${segments.peername}`
+    }
+    if (segments.name) {
+      url += `/${segments.name}`
+    }
+    if (segments.peerID || segments.path) {
+      url += '/at'
+    }
+    if (segments.peerID) {
+      url += `/${segments.peerID}`
+    }
+    if (segments.path) {
+      url += segments.path
+    }
   }
 
   if (params) {
-    url += '?'
-    Object.keys(params).forEach((key) => {
+    Object.keys(params).forEach((key, index) => {
+      url += index === 0 ? '?' : '&'
       url += `${key}=${params[key]}`
     })
   }


### PR DESCRIPTION
closes #41 - bug in TOS page, (change link from `frontend` to `desktop`)  
closes #42 - wire up ChoosePeername page
This is closed, however this won't be functioning until qri-io/qri#849 
closes #48 - removed 'By Url' tab in AddDataset and add more info and error handling describing what a good dataset reference is
closes #50 - fix CreateDataset submit bug & commented out 'Use existing datafile' tab
This ended up being an error in how we were setting `params` in the api. Fixed now.