### PR TITLE
88 fsi working dataset

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -65,12 +65,20 @@ export function fetchMyDatasets (): ApiActionThunk {
 
 export function fetchWorkingDataset (): ApiActionThunk {
   return async (dispatch, getState) => {
-    const { selections } = getState()
+    const { selections, myDatasets } = getState()
+    const { peername, name } = selections
+
+    // find the selected dataset in myDatasets to determine isLinked
+    const match = myDatasets.value.find((d) => d.name === name && d.peername === peername)
+
+    const params = (match && match.isLinked) ? { fsi: true } : {}
+
     const action = {
       type: 'dataset',
       [CALL_API]: {
         endpoint: 'dataset',
         method: 'GET',
+        params,
         segments: {
           peername: selections.peername,
           name: selections.name

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -70,6 +70,7 @@ export default class App extends React.Component<AppProps, AppState> {
         iter++
       }, 850)
     }
+    this.props.pingApi()
     this.props.fetchSession()
     this.props.fetchMyDatasets()
   }


### PR DESCRIPTION
- Before firing `fetchWorkingDataset`, check whether the selected dataset `isLinked`.  If it is, add `fsi=true` to the query so it will return the correct data for `meta` and `schema`

Unrelated, this PR also includes a change to call ping the API immediately, then call it again many times with setInterval.  It was waiting to make the first call, which shows the user a loading screen unnecessarily.