### PR TITLE
refactor(errors, loading): fix the flow of the app

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -7,6 +7,10 @@ import { setSelectedListItem } from './selections'
 
 const pageSizeDefault = 15
 
+// use NO_ACTION when you need to skip/debounce unneccessary calls to the api
+// it will still register as a success
+export const NO_ACTION: Action = {type: 'NO_ACTION_SUCCESS'}
+
 export function pingApi (): ApiActionThunk {
   return async (dispatch) => {
     const pingAction: ApiAction = {
@@ -45,11 +49,12 @@ export function fetchWorkingDatasetDetails (): ApiActionThunk {
 export function fetchMyDatasets (page: number = 1, pageSize: number = pageSizeDefault): ApiActionThunk {
   return async (dispatch, getState) => {
     const state = getState()
-    if (state &&
+    if (page !== 1 &&
+          state &&
           state.myDatasets &&
           state.myDatasets.pageInfo &&
           state.myDatasets.pageInfo.fetchedAll) {
-      return new Promise(resolve => resolve({ type: 'NO_ACTION_NEEDED' }))
+      return new Promise(resolve => resolve(NO_ACTION))
     }
     const listAction: ApiAction = {
       type: 'list',
@@ -184,7 +189,7 @@ export function fetchWorkingHistory (page: number = 1, pageSize: number = pageSi
         state.workingDataset.history &&
         state.workingDataset.history.pageInfo &&
         state.workingDataset.history.pageInfo.fetchedAll) {
-      return new Promise(resolve => resolve({ type: 'NO_ACTION_NEEDED' }))
+      return new Promise(resolve => resolve(NO_ACTION))
     }
     const { selections } = getState()
     const action = {
@@ -251,7 +256,7 @@ export function fetchBody (page: number, pageSize: number): ApiActionThunk {
     const { peername, name, path } = workingDataset
 
     if (workingDataset.components.body.pageInfo.fetchedAll) {
-      return new Promise(resolve => resolve({ type: 'NO_ACTION_NEEDED' }))
+      return new Promise(resolve => resolve(NO_ACTION))
     }
 
     const action = {
@@ -284,7 +289,7 @@ export function fetchCommitBody (page: number, pageSize: number): ApiActionThunk
     let { peername, name, commit: path } = selections
 
     if (commitDetails.components.body.pageInfo.fetchedAll) {
-      return new Promise(resolve => resolve({ type: 'NO_ACTION_NEEDED' }))
+      return new Promise(resolve => resolve(NO_ACTION))
     }
 
     const action = {

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -9,7 +9,7 @@ const pageSizeDefault = 15
 
 // use NO_ACTION when you need to skip/debounce unneccessary calls to the api
 // it will still register as a success
-export const NO_ACTION: Action = {type: 'NO_ACTION_SUCCESS'}
+export const NO_ACTION: Action = { type: 'NO_ACTION_SUCCESS' }
 
 export function pingApi (): ApiActionThunk {
   return async (dispatch) => {

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -35,9 +35,9 @@ export function fetchWorkingDatasetDetails (): ApiActionThunk {
     let response: Action
 
     response = await fetchWorkingDataset()(dispatch, getState)
-    response = await whenOk(fetchWorkingHistory())(response)
     response = await whenOk(fetchWorkingStatus())(response)
     response = await whenOk(fetchBody())(response)
+    response = await whenOk(fetchWorkingHistory())(response)
 
     // set selected commit to be the first on the list
     const { workingDataset, selections } = getState()

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -6,6 +6,7 @@ import { Action } from 'redux'
 import { setSelectedListItem } from './selections'
 
 const pageSizeDefault = 15
+const bodyPageSizeDefault = 100
 
 // use NO_ACTION when you need to skip/debounce unneccessary calls to the api
 // it will still register as a success
@@ -253,7 +254,7 @@ export function fetchWorkingStatus (): ApiActionThunk {
   }
 }
 
-export function fetchBody (page: number, pageSize: number): ApiActionThunk {
+export function fetchBody (page: number = 1, pageSize: number = bodyPageSizeDefault): ApiActionThunk {
   return async (dispatch, getState) => {
     const { workingDataset, selections } = getState()
     const { peername, name } = selections
@@ -287,7 +288,7 @@ export function fetchBody (page: number, pageSize: number): ApiActionThunk {
   }
 }
 
-export function fetchCommitBody (page: number, pageSize: number): ApiActionThunk {
+export function fetchCommitBody (page: number= 1, pageSize: number = bodyPageSizeDefault): ApiActionThunk {
   return async (dispatch, getState) => {
     const { selections, commitDetails } = getState()
     let { peername, name, commit: path } = selections

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -38,10 +38,13 @@ export function fetchWorkingDatasetDetails (): ApiActionThunk {
     response = await whenOk(fetchWorkingStatus())(response)
 
     // set selected commit to be the first on the list
-    const { workingDataset } = getState()
+    const { workingDataset, selections } = getState()
     const { history } = workingDataset
-    await dispatch(setSelectedListItem('commit', history.value[0].path))
+    const { commit } = selections
 
+    if (commit === '' || !history.value.some(c => c.path === commit)) {
+      await dispatch(setSelectedListItem('commit', history.value[0].path))
+    }
     return response
   }
 }
@@ -252,8 +255,9 @@ export function fetchWorkingStatus (): ApiActionThunk {
 
 export function fetchBody (page: number, pageSize: number): ApiActionThunk {
   return async (dispatch, getState) => {
-    const { workingDataset } = getState()
-    const { peername, name, path } = workingDataset
+    const { workingDataset, selections } = getState()
+    const { peername, name } = selections
+    const { path } = workingDataset
 
     if (workingDataset.components.body.pageInfo.fetchedAll) {
       return new Promise(resolve => resolve(NO_ACTION))

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -37,6 +37,7 @@ export function fetchWorkingDatasetDetails (): ApiActionThunk {
     response = await fetchWorkingDataset()(dispatch, getState)
     response = await whenOk(fetchWorkingHistory())(response)
     response = await whenOk(fetchWorkingStatus())(response)
+    response = await whenOk(fetchBody())(response)
 
     // set selected commit to be the first on the list
     const { workingDataset, selections } = getState()
@@ -122,6 +123,7 @@ export function fetchCommitDetail (): ApiActionThunk {
 
     response = await fetchCommitDataset()(dispatch, getState)
     response = await whenOk(fetchCommitStatus())(response)
+    response = await whenOk(fetchCommitBody())(response)
 
     return response
   }
@@ -288,7 +290,7 @@ export function fetchBody (page: number = 1, pageSize: number = bodyPageSizeDefa
   }
 }
 
-export function fetchCommitBody (page: number= 1, pageSize: number = bodyPageSizeDefault): ApiActionThunk {
+export function fetchCommitBody (page: number = 1, pageSize: number = bodyPageSizeDefault): ApiActionThunk {
   return async (dispatch, getState) => {
     const { selections, commitDetails } = getState()
     let { peername, name, commit: path } = selections

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -8,10 +8,6 @@ import { setSelectedListItem } from './selections'
 const pageSizeDefault = 15
 const bodyPageSizeDefault = 100
 
-// use NO_ACTION when you need to skip/debounce unneccessary calls to the api
-// it will still register as a success
-export const NO_ACTION: Action = { type: 'NO_ACTION_SUCCESS' }
-
 export function pingApi (): ApiActionThunk {
   return async (dispatch) => {
     const pingAction: ApiAction = {
@@ -59,7 +55,7 @@ export function fetchMyDatasets (page: number = 1, pageSize: number = pageSizeDe
           state.myDatasets &&
           state.myDatasets.pageInfo &&
           state.myDatasets.pageInfo.fetchedAll) {
-      return new Promise(resolve => resolve(NO_ACTION))
+      return new Promise(resolve => resolve())
     }
     const listAction: ApiAction = {
       type: 'list',
@@ -190,7 +186,7 @@ export function fetchWorkingHistory (page: number = 1, pageSize: number = pageSi
         state.workingDataset.history &&
         state.workingDataset.history.pageInfo &&
         state.workingDataset.history.pageInfo.fetchedAll) {
-      return new Promise(resolve => resolve(NO_ACTION))
+      return new Promise(resolve => resolve())
     }
     const { selections } = getState()
     const { peername, name, isLinked } = selections
@@ -262,7 +258,7 @@ export function fetchBody (page: number = 1, pageSize: number = bodyPageSizeDefa
     const { path } = workingDataset
 
     if (workingDataset.components.body.pageInfo.fetchedAll) {
-      return new Promise(resolve => resolve(NO_ACTION))
+      return new Promise(resolve => resolve())
     }
 
     const action = {
@@ -296,7 +292,7 @@ export function fetchCommitBody (page: number = 1, pageSize: number = bodyPageSi
     let { peername, name, commit: path } = selections
 
     if (commitDetails.components.body.pageInfo.fetchedAll) {
-      return new Promise(resolve => resolve(NO_ACTION))
+      return new Promise(resolve => resolve())
     }
 
     const action = {

--- a/app/actions/selections.ts
+++ b/app/actions/selections.ts
@@ -21,12 +21,13 @@ export const setSelectedListItem = (type: string, selectedListItem: string) => {
   }
 }
 
-export const setWorkingDataset = (peername: string, name: string) => {
+export const setWorkingDataset = (peername: string, name: string, isLinked: boolean) => {
   return {
     type: SELECTIONS_SET_WORKING_DATASET,
     payload: {
       peername,
-      name
+      name,
+      isLinked
     }
   }
 }

--- a/app/actions/session.ts
+++ b/app/actions/session.ts
@@ -1,6 +1,5 @@
 import { CALL_API, ApiActionThunk } from '../store/api'
 import { Session } from '../models/session'
-import { NO_ACTION } from './api'
 
 export function fetchSession (): ApiActionThunk {
   return async (dispatch) => {
@@ -22,7 +21,7 @@ export function setPeername (newPeername: string): ApiActionThunk {
   return async (dispatch, getStore) => {
     const { session } = getStore()
     if (newPeername === session.peername) {
-      return new Promise(resolve => resolve(NO_ACTION))
+      return new Promise(resolve => resolve())
     }
     const newSession = Object.assign({}, session, { peername: newPeername })
     const action = {

--- a/app/actions/session.ts
+++ b/app/actions/session.ts
@@ -1,5 +1,6 @@
 import { CALL_API, ApiActionThunk } from '../store/api'
 import { Session } from '../models/session'
+import { NO_ACTION } from './api'
 
 export function fetchSession (): ApiActionThunk {
   return async (dispatch) => {
@@ -21,7 +22,7 @@ export function setPeername (newPeername: string): ApiActionThunk {
   return async (dispatch, getStore) => {
     const { session } = getStore()
     if (newPeername === session.peername) {
-      return new Promise(resolve => resolve({ type: 'NO_ACTION_NEEDED' }))
+      return new Promise(resolve => resolve(NO_ACTION))
     }
     const newSession = Object.assign({}, session, { peername: newPeername })
     const action = {

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -61,16 +61,16 @@ export default class App extends React.Component<AppProps, AppState> {
   componentDidMount () {
     if (this.props.apiConnection === 0) {
       var iter = 0
-      const pingTimer = setInterval(() => {
-        if (iter > 15) {
-          this.props.setApiConnection(-1)
-          clearInterval(pingTimer)
-        }
+      const backendLoadedCheck = setInterval(() => {
         this.props.pingApi()
         iter++
-      }, 10000)
+        if (this.props.apiConnection === 1) clearInterval(backendLoadedCheck)
+        if (iter > 20) {
+          this.props.setApiConnection(-1)
+          clearInterval(backendLoadedCheck)
+        }
+      }, 750)
     }
-    this.props.pingApi()
     this.props.fetchSession()
     this.props.fetchMyDatasets()
   }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -17,7 +17,7 @@ import { ApiAction } from '../store/api'
 import { Modal, ModalType, NoModal } from '../models/modals'
 import { Toast as IToast } from '../models/store'
 
-interface AppProps {
+export interface AppProps {
   hasDatasets: boolean
   loading: boolean
   sessionID: string
@@ -29,6 +29,7 @@ interface AppProps {
   fetchSession: () => Promise<ApiAction>
   fetchMyDatasets: (page?: number, pageSize?: number) => Promise<ApiAction>
   addDataset: (peername: string, name: string) => Promise<ApiAction>
+  setWorkingDataset: (peername: string, name: string) => Promise<ApiAction>
   initDataset: (path: string, name: string, format: string) => Promise<ApiAction>
   acceptTOS: () => Action
   setHasSetPeername: () => Action
@@ -98,7 +99,12 @@ export default class App extends React.Component<AppProps, AppState> {
           timeout={300}
           unmountOnExit
         >
-          <CreateDataset onSubmit={this.props.initDataset} onDismissed={() => this.setState({ currentModal: NoModal })}/>
+          <CreateDataset
+            onSubmit={this.props.initDataset}
+            onDismissed={() => this.setState({ currentModal: NoModal })}
+            setWorkingDataset={this.props.setWorkingDataset}
+            fetchMyDatasets={this.props.fetchMyDatasets}
+          />
         </CSSTransition>
         <CSSTransition
           in={ModalType.AddDataset === Modal.type}
@@ -107,7 +113,12 @@ export default class App extends React.Component<AppProps, AppState> {
           timeout={300}
           unmountOnExit
         >
-          <AddDataset onSubmit={this.props.addDataset} onDismissed={() => this.setState({ currentModal: NoModal })}/>
+          <AddDataset
+            onSubmit={this.props.addDataset}
+            onDismissed={() => this.setState({ currentModal: NoModal })}
+            setWorkingDataset={this.props.setWorkingDataset}
+            fetchMyDatasets={this.props.fetchMyDatasets}
+          />
         </CSSTransition>
       </div>
     )

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -29,7 +29,7 @@ export interface AppProps {
   fetchSession: () => Promise<ApiAction>
   fetchMyDatasets: (page?: number, pageSize?: number) => Promise<ApiAction>
   addDataset: (peername: string, name: string) => Promise<ApiAction>
-  setWorkingDataset: (peername: string, name: string) => Promise<ApiAction>
+  setWorkingDataset: (peername: string, name: string, isLinked: boolean) => Promise<ApiAction>
   initDataset: (path: string, name: string, format: string) => Promise<ApiAction>
   acceptTOS: () => Action
   setHasSetPeername: () => Action

--- a/app/components/Body.tsx
+++ b/app/components/Body.tsx
@@ -18,6 +18,10 @@ export interface BodyProps {
 }
 
 const Body: React.FunctionComponent<BodyProps> = ({ value, pageInfo, headers, onFetch }) => {
+  if (!value || value.length === 0) {
+    return <SpinnerWithIcon loading={true} />
+  }
+
   const [isLoadingFirstPage, setIsLoadingFirstPage] = React.useState(false)
   const isLoadingFirstPageRef = React.useRef(pageInfo.page === 1 && pageInfo.isFetching)
 

--- a/app/components/Body.tsx
+++ b/app/components/Body.tsx
@@ -17,7 +17,7 @@ export interface BodyProps {
   onFetch: (page?: number, pageSize?: number) => Promise<ApiAction>
 }
 
-const Body: React.FunctionComponent<BodyProps> = ({ peername, name, path, value, pageInfo, headers, onFetch }) => {
+const Body: React.FunctionComponent<BodyProps> = ({ value, pageInfo, headers, onFetch }) => {
   const [isLoadingFirstPage, setIsLoadingFirstPage] = React.useState(false)
   const isLoadingFirstPageRef = React.useRef(pageInfo.page === 1 && pageInfo.isFetching)
 
@@ -33,10 +33,6 @@ const Body: React.FunctionComponent<BodyProps> = ({ peername, name, path, value,
       isLoadingFirstPageRef.current = true
     }
   }, [pageInfo.page, pageInfo.isFetching])
-
-  React.useEffect(() => {
-    onFetch()
-  }, [peername, name, path])
 
   const handleScrollToBottom = () => {
     onFetch(pageInfo.page + 1, pageInfo.pageSize)

--- a/app/components/Body.tsx
+++ b/app/components/Body.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { ApiAction } from '../store/api'
-import { CSSTransition } from 'react-transition-group'
+import Toast, { ToastTypes } from './chrome/Toast'
 import HandsonTable from './HandsonTable'
 
 import { PageInfo } from '../models/store'
@@ -53,13 +53,11 @@ export default class Body extends React.Component<BodyProps> {
             />
           )
         }
-        <CSSTransition
-          in={this.props.pageInfo.isFetching && this.props.pageInfo.page > 0}
-          classNames="body-toast"
-          timeout={300}
-        >
-          <div className='body-toast'>Loading more rows...</div>
-        </CSSTransition>
+        <Toast
+          show={this.props.pageInfo.isFetching && this.props.pageInfo.page > 0}
+          type={ToastTypes.message}
+          text='Loading more rows...'
+        />
       </div>
     )
   }

--- a/app/components/ChoosePeername.tsx
+++ b/app/components/ChoosePeername.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react'
 import WelcomeTemplate from './WelcomeTemplate'
 import TextInput from './form/TextInput'
+import getActionType from '../utils/actionType'
+import { ApiAction } from '../store/api'
+import { Action } from 'redux'
 
 export interface ChoosePeernameProps {
-  onSave: (newPeername: string) => Promise<any>
+  setPeername: (newPeername: string) => Promise<ApiAction>
+  setHasSetPeername: () => Action
   peername: string
 }
 
 const ChoosePeername: React.FunctionComponent<ChoosePeernameProps> = (props: ChoosePeernameProps) => {
-  const { peername, onSave } = props
+  const { peername, setPeername, setHasSetPeername } = props
   const [newPeername, setNewPeername] = React.useState(peername)
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState('')
@@ -32,13 +36,22 @@ const ChoosePeername: React.FunctionComponent<ChoosePeernameProps> = (props: Cho
 
   async function handleSave () {
     new Promise(resolve => {
+      error && setError('')
       setLoading(true)
       resolve()
     })
-      .then(async () => onSave(newPeername))
-      .catch(() => {
-        setLoading(false)
-        setError('some error occured')
+      .then(async () => {
+        setPeername(newPeername)
+          .then((action) => {
+            setLoading(false)
+            // TODO (ramfox): possibly these should move to the reducer
+            if (getActionType(action.type) === 'failure') {
+              setError(action.payload.err.message)
+            }
+            if (getActionType(action.type) === 'success') {
+              setHasSetPeername()
+            }
+          })
       })
   }
 

--- a/app/components/ChoosePeername.tsx
+++ b/app/components/ChoosePeername.tsx
@@ -45,10 +45,9 @@ const ChoosePeername: React.FunctionComponent<ChoosePeernameProps> = (props: Cho
           .then((action) => {
             setLoading(false)
             // TODO (ramfox): possibly these should move to the reducer
-            if (getActionType(action.type) === 'failure') {
+            if (getActionType(action) === 'failure') {
               setError(action.payload.err.message)
-            }
-            if (getActionType(action.type) === 'success') {
+            } else {
               setHasSetPeername()
             }
           })

--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -81,6 +81,8 @@ const CommitDetails: React.FunctionComponent<CommitDetailsProps> = ({
       isLoadingRef.current = commitDetails.isLoading
     }
     // make sure that the component we are trying to show actually exists in this version of the dataset
+    // TODO (ramfox): there is a bug here when we try to switch to body, but body hasn't finished fetching yet
+    // this will prematurely decide to switch away from body.
     if (!commitDetails.isLoading) {
       const { components } = commitDetails
       if (selectedComponent === '' || (!components[selectedComponent].value || components[selectedComponent].value.length === 0)) {

--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import moment from 'moment'
-import { Resizable } from '../components/resizable'
+import { Resizable } from '../components/Resizable'
 import { Action } from 'redux'
 import ComponentList from '../components/ComponentList'
 import DatasetComponent from './DatasetComponent'
@@ -17,7 +17,7 @@ export interface CommitDetailsProps {
   name: string
   selectedCommitPath: string
   commit: Commit
-  selectedComponent: string
+  selectedComponent: 'meta' | 'body' | 'schema' | ''
   sidebarWidth: number
   setSelectedListItem: (type: string, activeTab: string) => Action
   setSidebarWidth: (type: string, sidebarWidth: number) => Action
@@ -79,6 +79,21 @@ const CommitDetails: React.FunctionComponent<CommitDetailsProps> = ({
   React.useEffect(() => {
     if (isLoadingRef.current !== commitDetails.isLoading) {
       isLoadingRef.current = commitDetails.isLoading
+    }
+    // make sure that the component we are trying to show actually exists in this version of the dataset
+    if (!commitDetails.isLoading) {
+      const { components } = commitDetails
+      if (selectedComponent === '' || (!components[selectedComponent].value || components[selectedComponent].value.length === 0)) {
+        if (status['meta']) {
+          setSelectedListItem('commitComponent', 'meta')
+          return
+        }
+        if (status['body']) {
+          setSelectedListItem('commitComponent', 'body')
+          return
+        }
+        setSelectedListItem('commitComponent', 'schema')
+      }
     }
   }, [commitDetails.isLoading])
 

--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -53,11 +53,20 @@ const CommitDetails: React.FunctionComponent<CommitDetailsProps> = ({
   // version of the dataset.
   // for now, we will tell the user to run a command on the command line
   const [isLogError, setLogError] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
+  const isLoadingRef = React.useRef(commitDetails.isLoading)
+
+  const isLoadingTimeout = setTimeout(() => {
+    if (isLoadingRef.current) {
+      setLoading(true)
+    }
+    clearTimeout(isLoadingTimeout)
+  }, 250)
+
   React.useEffect(() => {
     if (selectedCommitPath !== '') {
       fetchCommitDetail()
         .then(() => {
-          console.log('here')
           if (isLogError) setLogError(false)
         })
         .catch(action => {
@@ -67,12 +76,17 @@ const CommitDetails: React.FunctionComponent<CommitDetailsProps> = ({
     }
   }, [selectedCommitPath])
 
+  React.useEffect(() => {
+    if (isLoadingRef.current !== commitDetails.isLoading) {
+      isLoadingRef.current = commitDetails.isLoading
+    }
+  }, [commitDetails.isLoading])
 
-  const { status, isLoading } = commitDetails
+  const { status } = commitDetails
   return (
     <div id='commit-details' className='dataset-content transition-group'>
       <CSSTransition
-        in={!isLogError}
+        in={!isLogError && !loading}
         classNames='fade'
         timeout={300}
         unmountOnExit
@@ -103,12 +117,13 @@ const CommitDetails: React.FunctionComponent<CommitDetailsProps> = ({
               />
             </Resizable>
             <div className='content-wrapper'>
-              <DatasetComponent isLoading={isLoading} component={selectedComponent} componentStatus={status[selectedComponent]} history />
+              <DatasetComponent isLoading={loading} component={selectedComponent} componentStatus={status[selectedComponent]} history />
             </div>
           </div>
         </div>
       </CSSTransition>
-      <SpinnerWithIcon loading={isLogError} title='Oh no!' spinner={false}>
+      <SpinnerWithIcon loading={loading} />
+      <SpinnerWithIcon loading={isLogError && !loading} title='Oh no!' spinner={false}>
         <p>Oops, you don&apos;t have this version of the dataset.</p>
         <p>Try adding it by using the terminal and the Qri command line tool that can be used when this desktop app is running!</p>
         <p>Open up the terminal and paste this command:</p>

--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -60,12 +60,11 @@ export default class CommitDetails extends React.Component<CommitDetailsProps> {
 
     if (this.props.commit && !isEmpty(this.props.commitDetails.status)) {
       const { commit, sidebarWidth, setSidebarWidth, setSelectedListItem, commitDetails } = this.props
-      const { status } = commitDetails
+      const { status, isLoading } = commitDetails
       const { title, timestamp } = commit
       const timeMessage = moment(timestamp).fromNow()
 
       const componentStatus = status[selectedComponent]
-      let mainContent = <DatasetComponent component={selectedComponent} componentStatus={componentStatus} history />
 
       return (
         <div id='commit-details' className='dataset-content'>
@@ -94,7 +93,7 @@ export default class CommitDetails extends React.Component<CommitDetailsProps> {
               />
             </Resizable>
             <div className='content-wrapper'>
-              {mainContent}
+              <DatasetComponent isLoading={isLoading} component={selectedComponent} componentStatus={componentStatus} history />
             </div>
           </div>
         </div>

--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -39,32 +39,50 @@ interface FileRowProps {
   status?: string
   selectionType?: ComponentType
   disabled?: boolean
-  tooltip?: string
   onClick?: (type: ComponentType, activeTab: string) => Action
 }
 
-export const FileRow: React.FunctionComponent<FileRowProps> = (props) => (
-  <div
-    className={classNames('sidebar-list-item', 'sidebar-list-item-text', {
-      'selected': props.selected,
-      'disabled': props.disabled
-    })}
-    onClick={() => {
-      if (props.onClick && props.selectionType && props.name) {
-        props.onClick(props.selectionType, props.name)
-      }
-    }}
-    data-tip={props.tooltip}
-  >
-    <div className='text-column'>
-      <div className='text'>{props.displayName}</div>
-      <div className='subtext'>{props.filename}</div>
+export const FileRow: React.FunctionComponent<FileRowProps> = (props) => {
+  let statusColor
+  switch (props.status) {
+    case 'modified':
+      statusColor = '#cab081'
+      break
+    case 'add':
+      statusColor = '#83d683'
+      break
+    case 'removed':
+      statusColor = '#e04f4f'
+      break
+    default:
+      statusColor = 'transparent'
+  }
+
+  // if previously not disabled, and turned to disabled
+  // set timeout to see if it is going to stay disabled before changing it
+
+  return (
+    <div
+      className={classNames('sidebar-list-item', 'sidebar-list-item-text', {
+        'selected': props.selected,
+        'disabled': props.disabled
+      })}
+      onClick={() => {
+        if (props.onClick && props.selectionType && props.name) {
+          props.onClick(props.selectionType, props.name)
+        }
+      }}
+    >
+      <div className='text-column'>
+        <div className='text'>{props.displayName}</div>
+        <div className='subtext'>{props.filename}</div>
+      </div>
+      <div className='status-column'>
+        <span className='dot' style={{ backgroundColor: statusColor }}></span>
+      </div>
     </div>
-    <div className='status-column'>
-      <StatusDot status={props.status} />
-    </div>
-  </div>
-)
+  )
+}
 
 FileRow.displayName = 'FileRow'
 
@@ -114,7 +132,7 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
         Dataset Components
       </div>
       {
-        components.map(({ name, displayName, tooltip }) => {
+        components.map(({ name, displayName }) => {
           if (status[name]) {
             const { filepath, status: fileStatus } = status[name]
             let filename
@@ -133,7 +151,6 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
                 status={fileStatus}
                 selected={selectedComponent === name}
                 selectionType={selectionType}
-                tooltip={tooltip}
                 onClick={onComponentClick}
               />
             )
@@ -144,7 +161,6 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
                 displayName={displayName}
                 name={displayName}
                 disabled={true}
-                tooltip={tooltip}
               />
             )
           }

--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -39,50 +39,32 @@ interface FileRowProps {
   status?: string
   selectionType?: ComponentType
   disabled?: boolean
+  tooltip?: string
   onClick?: (type: ComponentType, activeTab: string) => Action
 }
 
-export const FileRow: React.FunctionComponent<FileRowProps> = (props) => {
-  let statusColor
-  switch (props.status) {
-    case 'modified':
-      statusColor = '#cab081'
-      break
-    case 'add':
-      statusColor = '#83d683'
-      break
-    case 'removed':
-      statusColor = '#e04f4f'
-      break
-    default:
-      statusColor = 'transparent'
-  }
-
-  // if previously not disabled, and turned to disabled
-  // set timeout to see if it is going to stay disabled before changing it
-
-  return (
-    <div
-      className={classNames('sidebar-list-item', 'sidebar-list-item-text', {
-        'selected': props.selected,
-        'disabled': props.disabled
-      })}
-      onClick={() => {
-        if (props.onClick && props.selectionType && props.name) {
-          props.onClick(props.selectionType, props.name)
-        }
-      }}
-    >
-      <div className='text-column'>
-        <div className='text'>{props.displayName}</div>
-        <div className='subtext'>{props.filename}</div>
-      </div>
-      <div className='status-column'>
-        <span className='dot' style={{ backgroundColor: statusColor }}></span>
-      </div>
+export const FileRow: React.FunctionComponent<FileRowProps> = (props) => (
+  <div
+    className={classNames('sidebar-list-item', 'sidebar-list-item-text', {
+      'selected': props.selected,
+      'disabled': props.disabled
+    })}
+    onClick={() => {
+      if (props.onClick && props.selectionType && props.name) {
+        props.onClick(props.selectionType, props.name)
+      }
+    }}
+    data-tip={props.tooltip}
+  >
+    <div className='text-column'>
+      <div className='text'>{props.displayName}</div>
+      <div className='subtext'>{props.filename}</div>
     </div>
-  )
-}
+    <div className='status-column'>
+      <StatusDot status={props.status} />
+    </div>
+  </div>
+)
 
 FileRow.displayName = 'FileRow'
 
@@ -132,7 +114,7 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
         Dataset Components
       </div>
       {
-        components.map(({ name, displayName }) => {
+        components.map(({ name, displayName, tooltip }) => {
           if (status[name]) {
             const { filepath, status: fileStatus } = status[name]
             let filename
@@ -151,6 +133,7 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
                 status={fileStatus}
                 selected={selectedComponent === name}
                 selectionType={selectionType}
+                tooltip={tooltip}
                 onClick={onComponentClick}
               />
             )
@@ -161,6 +144,7 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
                 displayName={displayName}
                 name={displayName}
                 disabled={true}
+                tooltip={tooltip}
               />
             )
           }

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -66,12 +66,26 @@ export default class Dataset extends React.Component<DatasetProps> {
   componentDidMount () {
     // poll for status
     setInterval(() => { this.props.fetchWorkingStatus() }, 5000)
+    const { selections, workingDataset } = this.props
+    const { activeTab, isLinked } = selections
+    if (activeTab === 'status' && !isLinked) {
+      this.props.setActiveTab('history')
+    } else if (activeTab === 'history' && workingDataset.history.pageInfo.error && workingDataset.history.pageInfo.error.includes('no history')) {
+      this.props.setActiveTab('status')
+    }
   }
 
   componentDidUpdate () {
     // this "wires up" all of the tooltips, must be called on update, as tooltips
     // in descendents can come and go
     ReactTooltip.rebuild()
+    const { selections, workingDataset } = this.props
+    const { activeTab, isLinked } = selections
+    if (activeTab === 'status' && !isLinked) {
+      this.props.setActiveTab('history')
+    } else if (activeTab === 'history' && workingDataset.history.pageInfo.error && workingDataset.history.pageInfo.error.includes('no history')) {
+      this.props.setActiveTab('status')
+    }
   }
 
   // using component state + getDerivedStateFromProps to determine when a new
@@ -138,7 +152,8 @@ export default class Dataset extends React.Component<DatasetProps> {
       name,
       activeTab,
       component: selectedComponent,
-      commit: selectedCommit
+      commit: selectedCommit,
+      isLinked
     } = selections
 
     const { history, status, path } = workingDataset
@@ -152,7 +167,6 @@ export default class Dataset extends React.Component<DatasetProps> {
       fetchWorkingHistory
     } = this.props
 
-    const isLinked = !!workingDataset.linkpath
     const linkButton = isLinked ? (
       <div
         className='header-column'

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -20,6 +20,8 @@ import {
   WorkingDataset,
   Mutations
 } from '../models/store'
+import { CSSTransition } from 'react-transition-group'
+import SpinnerWithIcon from './chrome/SpinnerWithIcon'
 
 export interface DatasetProps {
   // redux state
@@ -126,9 +128,8 @@ export default class Dataset extends React.Component<DatasetProps> {
     // mainContent will either be a loading spinner, or content based on the selected
     // sidebar list items
     let mainContent
-    if (workingDataset.isLoading || workingDataset.peername === '') {
-      // TODO (chriswhong) add a proper loading spinner
-      mainContent = <div>Loading</div>
+    if ((activeTab === 'status' && workingDataset.isLoading) || workingDataset.peername === '' || (activeTab === 'history' && workingDataset.history.pageInfo.isFetching)) {
+      mainContent = <SpinnerWithIcon loading={true}/>
     } else {
       if (activeTab === 'status') {
         const componentStatus = status[selectedComponent]
@@ -136,11 +137,15 @@ export default class Dataset extends React.Component<DatasetProps> {
       } else {
         if (workingDataset.history) {
           mainContent = <CommitDetailsContainer />
-        } else {
-          mainContent = <div>Loading History</div>
         }
       }
     }
+
+    // TODO (ramfox): since this loading boolean is controlling the entire
+    // main-content section, it might make more sense for each container
+    // (eg metadata container, commit details container) to control its own
+    // loading
+    const loading = workingDataset.isLoading || workingDataset.peername === ''
 
     const isLinked = !!workingDataset.linkpath
     const linkButton = isLinked ? (
@@ -213,7 +218,18 @@ export default class Dataset extends React.Component<DatasetProps> {
           </Resizable>
           <div className='content-wrapper'>
             {showDatasetList && <div className='overlay'></div>}
-            {mainContent}
+            <div className='main-content'>
+              <div><SpinnerWithIcon loading={loading}/></div>
+              <div><CSSTransition
+                in={!loading}
+                classNames='fade'
+                component='div'
+                timeout={300}
+                unmountOnExit
+              >
+                {mainContent}
+              </CSSTransition></div>
+            </div>
           </div>
 
         </div>

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -114,7 +114,7 @@ export default class Dataset extends React.Component<DatasetProps> {
       component: selectedComponent,
       commit: selectedCommit
     } = selections
-    const { name, history, status } = workingDataset
+    const { name, history, status, path } = workingDataset
 
     // actions
     const {
@@ -205,6 +205,7 @@ export default class Dataset extends React.Component<DatasetProps> {
             maximumWidth={495}
           >
             <DatasetSidebar
+              path={path}
               isLinked={isLinked}
               activeTab={activeTab}
               selectedComponent={selectedComponent}

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -36,7 +36,7 @@ export interface DatasetProps {
   setSidebarWidth: (type: string, sidebarWidth: number) => Action
   setFilter: (filter: string) => Action
   setSelectedListItem: (type: string, activeTab: string) => Action
-  setWorkingDataset: (peername: string, name: string) => Action
+  setWorkingDataset: (peername: string, name: string, isLinked: boolean) => Action
   fetchWorkingDatasetDetails: () => Promise<ApiAction>
   fetchWorkingHistory: (page?: number, pageSize?: number) => ApiActionThunk
   fetchWorkingStatus: () => Promise<ApiAction>
@@ -92,6 +92,8 @@ export default class Dataset extends React.Component<DatasetProps> {
     }
 
     // make sure that the component we are trying to show actually exists in this version of the dataset
+    // TODO (ramfox): there is a bug here when we try to switch to body, but body hasn't finished fetching yet
+    // this will prematurely decide to switch away from body.
     if ((workingDatasetIsLoading && !nextProps.workingDataset.isLoading && nextProps.selections.activeTab === 'status') ||
         (activeTab === 'history' && nextProps.selections.activeTab === 'status')) {
       const { workingDataset, selections, setSelectedListItem } = nextProps
@@ -155,7 +157,7 @@ export default class Dataset extends React.Component<DatasetProps> {
       <div
         className='header-column'
         data-tip={workingDataset.linkpath}
-        onClick={() => { shell.openItem(String(workingDataset.linkpath)) }}
+        onClick={() => { shell.openItem(workingDataset.linkpath) }}
       >
         <div className='header-column-icon'>
           <span className='icon-inline'>openfolder</span>

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -20,8 +20,8 @@ import {
   WorkingDataset,
   Mutations
 } from '../models/store'
+
 import { CSSTransition } from 'react-transition-group'
-import SpinnerWithIcon from './chrome/SpinnerWithIcon'
 
 export interface DatasetProps {
   // redux state
@@ -61,7 +61,7 @@ export default class Dataset extends React.Component<DatasetProps> {
 
   componentDidMount () {
     // poll for status
-    setInterval(() => { this.props.fetchWorkingStatus() }, 1000)
+    setInterval(() => { this.props.fetchWorkingStatus() }, 5000)
   }
 
   componentDidUpdate () {
@@ -114,7 +114,8 @@ export default class Dataset extends React.Component<DatasetProps> {
       component: selectedComponent,
       commit: selectedCommit
     } = selections
-    const { name, history, status, path } = workingDataset
+
+    const { history, status, path } = workingDataset
 
     // actions
     const {
@@ -124,28 +125,6 @@ export default class Dataset extends React.Component<DatasetProps> {
       setSelectedListItem,
       fetchWorkingHistory
     } = this.props
-
-    // mainContent will either be a loading spinner, or content based on the selected
-    // sidebar list items
-    let mainContent
-    if ((activeTab === 'status' && workingDataset.isLoading) || workingDataset.peername === '' || (activeTab === 'history' && workingDataset.history.pageInfo.isFetching)) {
-      mainContent = <SpinnerWithIcon loading={true}/>
-    } else {
-      if (activeTab === 'status') {
-        const componentStatus = status[selectedComponent]
-        mainContent = <DatasetComponent component={selectedComponent} componentStatus={componentStatus}/>
-      } else {
-        if (workingDataset.history) {
-          mainContent = <CommitDetailsContainer />
-        }
-      }
-    }
-
-    // TODO (ramfox): since this loading boolean is controlling the entire
-    // main-content section, it might make more sense for each container
-    // (eg metadata container, commit details container) to control its own
-    // loading
-    const loading = workingDataset.isLoading || workingDataset.peername === ''
 
     const isLinked = !!workingDataset.linkpath
     const linkButton = isLinked ? (
@@ -184,7 +163,7 @@ export default class Dataset extends React.Component<DatasetProps> {
               <img className='app-loading-blob' src={logo} />
             </div>
             <div className='header-column-text'>
-              <div className="label">Current Dataset</div>
+              <div className="label">{name ? 'Current Dataset' : 'Choose a Dataset'}</div>
               <div className="name">{name}</div>
             </div>
             {
@@ -219,17 +198,25 @@ export default class Dataset extends React.Component<DatasetProps> {
           </Resizable>
           <div className='content-wrapper'>
             {showDatasetList && <div className='overlay'></div>}
-            <div className='main-content'>
-              <div><SpinnerWithIcon loading={loading}/></div>
-              <div><CSSTransition
-                in={!loading}
+            <div className='transition-group' >
+              <CSSTransition
+                in={activeTab === 'status'}
                 classNames='fade'
-                component='div'
                 timeout={300}
+                mountOnEnter
                 unmountOnExit
               >
-                {mainContent}
-              </CSSTransition></div>
+                <DatasetComponent component={selectedComponent} componentStatus={status[selectedComponent]} isLoading={workingDataset.isLoading}/>
+              </CSSTransition>
+              <CSSTransition
+                in={activeTab === 'history'}
+                classNames='fade'
+                timeout={300}
+                mountOnEnter
+                unmountOnExit
+              >
+                <CommitDetailsContainer />
+              </CSSTransition>
             </div>
           </div>
 

--- a/app/components/DatasetComponent.tsx
+++ b/app/components/DatasetComponent.tsx
@@ -2,33 +2,22 @@ import * as React from 'react'
 import MetadataContainer from '../containers/MetadataContainer'
 import BodyContainer from '../containers/BodyContainer'
 import SchemaContainer from '../containers/SchemaContainer'
+import { CSSTransition } from 'react-transition-group'
+import SpinnerWithIcon from './chrome/SpinnerWithIcon'
 
 import { getComponentDisplayName, StatusDot } from './ComponentList'
 
 import { ComponentStatus } from '../models/store'
 
 interface DatasetComponentProps {
+  isLoading: boolean
   component: string
   componentStatus: ComponentStatus
   history?: boolean
 }
 
 const DatasetComponent: React.FunctionComponent<DatasetComponentProps> = (props: DatasetComponentProps) => {
-  const { component, componentStatus, history } = props
-  let mainContent
-  switch (component) {
-    case 'meta':
-      mainContent = <MetadataContainer history={history} />
-      break
-    case 'body':
-      mainContent = <BodyContainer history={history} />
-      break
-    case 'schema':
-      mainContent = <SchemaContainer history={history} />
-      break
-    default:
-      mainContent = <MetadataContainer history={history} />
-  }
+  const { component, componentStatus, isLoading, history = false } = props
 
   return (
     <div className='component-container'>
@@ -40,8 +29,47 @@ const DatasetComponent: React.FunctionComponent<DatasetComponentProps> = (props:
           {componentStatus && <StatusDot status={componentStatus.status} />}
         </div>
       </div>
-      <div className='component-content'>
-        {mainContent}
+      <div className='component-content transition-group'>
+        <CSSTransition
+          in={component === 'meta' && !isLoading}
+          classNames='fade'
+          component='div'
+          timeout={300}
+          mountOnEnter
+          unmountOnExit
+          appear={true}
+        >
+          <div id='transition-wrap'>
+            <MetadataContainer history={history}/>
+          </div>
+        </CSSTransition>
+        <CSSTransition
+          in={component === 'body'}
+          classNames='fade'
+          component='div'
+          timeout={300}
+          mountOnEnter
+          unmountOnExit
+          appear={true}
+        >
+          <div id='transition-wrap'>
+            <BodyContainer history={history}/>
+          </div>
+        </CSSTransition>
+        <CSSTransition
+          in={component === 'schema' && !isLoading}
+          classNames='fade'
+          component='div'
+          timeout={300}
+          mountOnEnter
+          unmountOnExit
+          appear={true}
+        >
+          <div id='transition-wrap'>
+            <SchemaContainer history={history}/>
+          </div>
+        </CSSTransition>
+        <SpinnerWithIcon loading={isLoading}/>
       </div>
     </div>
   )

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -7,7 +7,7 @@ interface DatasetListProps {
   myDatasets: MyDatasets
   workingDataset: WorkingDataset
   setFilter: (filter: string) => Action
-  setWorkingDataset: (peername: string, name: string) => Action
+  setWorkingDataset: (peername: string, name: string, isLinked: boolean) => Action
   fetchMyDatasets: (page: number, pageSize: number) => Promise<AnyAction>
 }
 
@@ -52,7 +52,7 @@ export default class DatasetList extends React.Component<DatasetListProps> {
           className={classNames('sidebar-list-item', 'sidebar-list-item-text', {
             'selected': (peername === workingDataset.peername) && (name === workingDataset.name)
           })}
-          onClick={() => setWorkingDataset(peername, name)}
+          onClick={() => setWorkingDataset(peername, name, isLinked)}
         >
           <div className='text-column'>
             <div className='text'>{title}</div>

--- a/app/components/DatasetSidebar.tsx
+++ b/app/components/DatasetSidebar.tsx
@@ -79,20 +79,20 @@ const DatasetSidebar: React.FunctionComponent<DatasetSidebarProps> = ({
   return (
     <div className='dataset-sidebar'>
       <div id='tabs' className='sidebar-list-item'>
-        <div
+        {isLinked && <div
           className={classNames('tab', { 'active': activeTab === 'status' })}
           onClick={() => { onTabClick('status') }}
           data-tip='View the latest version or working changes<br/> to this dataset&apos;s components'
         >
             Status
-        </div>
-        <div
-          className={classNames('tab', { 'active': activeTab === 'history', 'disabled': !path })}
-          onClick={() => { !!path && onTabClick('history') }}
+        </div>}
+        {!(history.pageInfo.error && history.pageInfo.error.includes('no history')) && <div
+          className={classNames('tab', { 'active': activeTab === 'history' })}
+          onClick={() => { onTabClick('history') }}
           data-tip={path ? 'Explore older versions of this dataset' : 'This dataset has no previous versions'}
         >
             History
-        </div>
+        </div>}
       </div>
       <div id='content'>
         <CSSTransition

--- a/app/components/DatasetSidebar.tsx
+++ b/app/components/DatasetSidebar.tsx
@@ -7,7 +7,7 @@ import { ApiActionThunk } from '../store/api'
 import SaveFormContainer from '../containers/SaveFormContainer'
 import ComponentList from './ComponentList'
 
-import { Spinner } from './chrome/Spinner'
+import Spinner from './chrome/Spinner'
 
 import { WorkingDataset, ComponentType } from '../models/store'
 

--- a/app/components/DatasetSidebar.tsx
+++ b/app/components/DatasetSidebar.tsx
@@ -7,6 +7,7 @@ import { ApiActionThunk } from '../store/api'
 import SaveFormContainer from '../containers/SaveFormContainer'
 import ComponentList from './ComponentList'
 
+import classNames from 'classnames'
 import Spinner from './chrome/Spinner'
 
 import { WorkingDataset, ComponentType } from '../models/store'
@@ -40,6 +41,7 @@ const HistoryListItem: React.FunctionComponent<HistoryListItemProps> = (props) =
 
 interface DatasetSidebarProps {
   activeTab: string
+  path: string
   selectedComponent: string
   selectedCommit: string
   history: WorkingDataset['history']
@@ -52,6 +54,7 @@ interface DatasetSidebarProps {
 
 const DatasetSidebar: React.FunctionComponent<DatasetSidebarProps> = ({
   activeTab,
+  path,
   selectedComponent,
   selectedCommit,
   history,
@@ -73,23 +76,22 @@ const DatasetSidebar: React.FunctionComponent<DatasetSidebarProps> = ({
       fetchWorkingHistory(history.pageInfo.page + 1, history.pageInfo.pageSize)
     }
   }
-
   return (
     <div className='dataset-sidebar'>
       <div id='tabs' className='sidebar-list-item'>
         <div
-          className={`tab ${activeTab === 'status' && 'active'}`}
+          className={classNames('tab', { 'active': activeTab === 'status' })}
           onClick={() => { onTabClick('status') }}
           data-tip='View the latest version or working changes<br/> to this dataset&apos;s components'
         >
-          Status
+            Status
         </div>
         <div
-          className={`tab ${activeTab !== 'status' && 'active'}`}
-          onClick={() => { onTabClick('history') }}
-          data-tip='Explore older versions of this dataset'
+          className={classNames('tab', { 'active': activeTab === 'history', 'disabled': !path })}
+          onClick={() => { !!path && onTabClick('history') }}
+          data-tip={path ? 'Explore older versions of this dataset' : 'This dataset has no previous versions'}
         >
-          History
+            History
         </div>
       </div>
       <div id='content'>

--- a/app/components/Metadata.tsx
+++ b/app/components/Metadata.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import ExternalLink from './ExternalLink'
 import { Meta, Citation, License } from '../models/dataset'
 
+import SpinnerWithIcon from './chrome/SpinnerWithIcon'
+
 interface MetadataProps {
   meta: Meta
 }
@@ -74,6 +76,11 @@ const renderTable = (keys: string[], data: Meta) => {
 
 const Metadata: React.FunctionComponent<MetadataProps> = (props: MetadataProps) => {
   const { meta } = props
+
+  if (!meta) {
+    return <SpinnerWithIcon loading={true} />
+  }
+
   const standardFields = [
     'title',
     'theme',

--- a/app/components/Onboard.tsx
+++ b/app/components/Onboard.tsx
@@ -26,11 +26,6 @@ const Onboard: React.FunctionComponent<OnboardProps> = (
     setPeername,
     setHasSetPeername
   }) => {
-  async function onSave (peername: string): Promise<any> {
-    return setPeername(peername)
-      .then(() => setHasSetPeername())
-  }
-
   const renderWelcome = () => {
     return (
       <CSSTransition
@@ -54,7 +49,11 @@ const Onboard: React.FunctionComponent<OnboardProps> = (
         timeout={1000}
         unmountOnExit
       >
-        < ChoosePeername onSave={onSave} peername={peername}/>
+        < ChoosePeername
+          peername={peername}
+          setPeername={setPeername}
+          setHasSetPeername={setHasSetPeername}
+        />
       </CSSTransition>
     )
   }

--- a/app/components/Schema.tsx
+++ b/app/components/Schema.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react'
 import { Dataset } from '../models/dataset'
+import SpinnerWithIcon from './chrome/SpinnerWithIcon'
 
 interface SchemaProps {
   schema: Dataset['schema']
 }
 
 const Schema: React.FunctionComponent<SchemaProps> = (props: SchemaProps) => {
+  if (!props.schema) {
+    return <SpinnerWithIcon loading={true} />
+  }
+
   return (
     <div className='content'>
       <pre>{JSON.stringify(props.schema, null, 2)}</pre>

--- a/app/components/WelcomeTemplate.tsx
+++ b/app/components/WelcomeTemplate.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react' // eslint-disable-line
 import { remote } from 'electron'
-import { Spinner } from './chrome/Spinner'
+import Spinner from './chrome/Spinner'
 import classNames from 'classnames'
 export const logo = require('../assets/qri-blob-logo-large.png') // eslint-disable-line
 

--- a/app/components/chrome/Spinner.tsx
+++ b/app/components/chrome/Spinner.tsx
@@ -7,7 +7,7 @@ export interface SpinnerProps {
   large?: boolean
 }
 
-export const Spinner: React.FunctionComponent<SpinnerProps> = ({ center, button, white, large }) =>
+const Spinner: React.FunctionComponent<SpinnerProps> = ({ center, button, white, large }) =>
   <div className={`${button ? 'spinner-button' : 'spinner-spinner'} ${center && 'spinner-center'} ${!large && 'spinner-small'}`}>
     <div className={`spinner-block spinner-rect1 ${white ? 'spinner-white' : 'spinner-dark'}`} />
     <div className={`spinner-block spinner-rect2 ${white ? 'spinner-white' : 'spinner-dark'}`} />

--- a/app/components/chrome/SpinnerWithIcon.tsx
+++ b/app/components/chrome/SpinnerWithIcon.tsx
@@ -7,15 +7,18 @@ interface SpinnerWithIconProps {
   title?: string
   subtitle?: string
   loading: boolean
+  spinner?: boolean
 }
 
-const SpinnerWithIcon: React.FunctionComponent<SpinnerWithIconProps> = ({ loading, title, subtitle, children }) => {
+const SpinnerWithIcon: React.FunctionComponent<SpinnerWithIconProps> = ({ loading, title, subtitle, spinner = true, children }) => {
   return (
     <CSSTransition
       in={loading}
       classNames='fade'
       component='div'
       timeout={300}
+      appear={true}
+      mountOnEnter
       unmountOnExit
     >
       <div className='welcome-center' id='spinner-with-icon-wrap'>
@@ -27,7 +30,7 @@ const SpinnerWithIcon: React.FunctionComponent<SpinnerWithIconProps> = ({ loadin
         <div className='welcome-content'>
           {children}
           <div className='welcome-spinner'>
-            <Spinner/>
+            {spinner && <Spinner/>}
           </div>
         </div>
       </div>

--- a/app/components/chrome/SpinnerWithIcon.tsx
+++ b/app/components/chrome/SpinnerWithIcon.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import Spinner from './Spinner'
+import { logo } from '../WelcomeTemplate'
+import { CSSTransition } from 'react-transition-group'
+
+interface SpinnerWithIconProps {
+  title?: string
+  subtitle?: string
+  loading: boolean
+}
+
+const SpinnerWithIcon: React.FunctionComponent<SpinnerWithIconProps> = ({ loading, title, subtitle, children }) => {
+  return (
+    <CSSTransition
+      in={loading}
+      classNames='fade'
+      component='div'
+      timeout={300}
+      unmountOnExit
+    >
+      <div className='welcome-center' id='spinner-with-icon-wrap'>
+        <img className='welcome-graphic' id='spinner-with-icon-graphic' src={logo} />
+        <div className='welcome-title'>
+          <h2>{title}</h2>
+          <h6>{subtitle}</h6>
+        </div>
+        <div className='welcome-content'>
+          {children}
+          <div className='welcome-spinner'>
+            <Spinner/>
+          </div>
+        </div>
+      </div>
+    </CSSTransition>
+  )
+}
+
+export default SpinnerWithIcon

--- a/app/components/chrome/Toast.tsx
+++ b/app/components/chrome/Toast.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import { CSSTransition } from 'react-transition-group'
+import classNames from 'classnames'
+
+interface ToastProps {
+  show: boolean
+  type: ToastTypes
+  text: string
+}
+
+export enum ToastTypes {
+  message = 'message',
+  error = 'error',
+  success = 'success'
+}
+
+const Toast: React.FunctionComponent<ToastProps> = (props: ToastProps) => {
+  const { show, type, text } = props
+  return (
+    <CSSTransition
+      in={show}
+      classNames="body-toast"
+      timeout={300}
+    >
+      <div className={classNames('body-toast', type)}>{text}</div>
+    </CSSTransition>
+  )
+}
+
+export default Toast

--- a/app/components/modals/AddDataset.tsx
+++ b/app/components/modals/AddDataset.tsx
@@ -111,6 +111,7 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
   const handleSubmit = () => {
     setDismissable(false)
     setLoading(true)
+    error && setError('')
     // should fire off action and catch error response
     // if success, fetchDatatsets
     if (!onSubmit) return
@@ -125,6 +126,7 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
     onSubmit(names[0], names[1])
       .then(() => onDismissed())
       .catch((action) => {
+        setDismissable(true)
         setLoading(false)
         setError(action.payload.err.message)
       })
@@ -180,7 +182,14 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
           {/* restore when you can add by URL */}
           {/* {renderAddByUrl()} */}
         </div>
-        <div id='error'><Error text={error} /></div>
+        <CSSTransition
+          in={!!error}
+          timeout={300}
+          classNames='slide'
+          component='div'
+        >
+          <div id='error'><Error text={error} /></div>
+        </CSSTransition>
       </div>
       <Buttons
         cancelText='cancel'

--- a/app/components/modals/AddDataset.tsx
+++ b/app/components/modals/AddDataset.tsx
@@ -5,6 +5,7 @@ import Modal from './Modal'
 import TextInput from '../form/TextInput'
 import Error from './Error'
 import Buttons from './Buttons'
+import { fetchMyDatasets } from '../../actions/api'
 // import Tabs from './Tabs'
 
 interface AddByNameProps {
@@ -17,7 +18,7 @@ const AddByName: React.FunctionComponent<AddByNameProps> = ({ datasetName, onCha
     <div className='content'>
       <p>Add a dataset that already exists on Qri</p>
       <p>Qri dataset names have the following structure: <strong>peername/dataset name</strong>.</p>
-      <p>For example: <strong>chriswhong/usgs_earthquakes</strong>.</p>
+      <p>For example: <strong>chriswhong/usgs_earthquakes</strong></p>
       <TextInput
         name='datasetName'
         label='Peername/Dataset_Name:'
@@ -38,7 +39,7 @@ interface AddByUrl {
 const AddByUrl: React.FunctionComponent<AddByUrl> = ({ url, onChange }) => {
   return (
     <div className='content'>
-      <p>Add a dataset that already exists on Qri using a <strong>url</strong>.</p>
+      <p>Add a dataset that already exists on Qri using a <strong>url</strong></p>
       <TextInput
         name='url'
         label='Url'
@@ -59,9 +60,11 @@ enum TabTypes {
 interface AddDatasetProps {
   onDismissed: () => void
   onSubmit: (peername: string, name: string) => Promise<ApiAction>
+  setWorkingDataset: (peername: string, name: string) => Promise<ApiAction>
+  fetchMyDatasets: () => Promise<ApiAction>
 }
 
-const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onSubmit }) => {
+const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onSubmit, setWorkingDataset }) => {
   const [datasetName, setDatasetName] = React.useState('')
 
   // restore when you can add by URL
@@ -124,7 +127,11 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
     }
 
     onSubmit(names[0], names[1])
-      .then(() => onDismissed())
+      .then(() => {
+        fetchMyDatasets()
+        setWorkingDataset(names[0], names[1])
+          .then(() => onDismissed())
+      })
       .catch((action) => {
         setDismissable(true)
         setLoading(false)

--- a/app/components/modals/AddDataset.tsx
+++ b/app/components/modals/AddDataset.tsx
@@ -60,7 +60,7 @@ enum TabTypes {
 interface AddDatasetProps {
   onDismissed: () => void
   onSubmit: (peername: string, name: string) => Promise<ApiAction>
-  setWorkingDataset: (peername: string, name: string) => Promise<ApiAction>
+  setWorkingDataset: (peername: string, name: string, isLinked: boolean) => Promise<ApiAction>
   fetchMyDatasets: () => Promise<ApiAction>
 }
 
@@ -129,7 +129,7 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
     onSubmit(names[0], names[1])
       .then(() => {
         fetchMyDatasets()
-        setWorkingDataset(names[0], names[1])
+        setWorkingDataset(names[0], names[1], false)
           .then(() => onDismissed())
       })
       .catch((action) => {

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -28,7 +28,7 @@ enum TabTypes {
 interface CreateDatasetProps {
   onDismissed: () => void
   onSubmit: (path: string, name: string, format: string) => Promise<ApiAction>
-  setWorkingDataset: (peername: string, name: string) => Promise<ApiAction>
+  setWorkingDataset: (peername: string, name: string, isLinked: boolean) => Promise<ApiAction>
   fetchMyDatasets: () => Promise<ApiAction>
 }
 
@@ -222,7 +222,7 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
       .then(() => {
         console.log('AFTER SUBMIT')
         fetchMyDatasets()
-        setWorkingDataset('me', datasetName)
+        setWorkingDataset('me', datasetName, true)
           .then(() => {
             console.log('DISMISSING')
             onDismissed()

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -212,13 +212,13 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
   const handleSubmit = () => {
     setDismissable(false)
     setLoading(true)
-    // should fire off action and catch error response
-    // if success, fetchDatatsets
+    error && setError('')
     if (!onSubmit) return
     onSubmit(path, datasetName, bodyFormat)
       .then(() => onDismissed())
       .catch((action) => {
         setLoading(false)
+        setDismissable(true)
         setError(action.payload.err.message)
       })
   }

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -11,6 +11,7 @@ import Buttons from './Buttons'
 import ButtonInput from '../form/ButtonInput'
 
 import { ISelectOption } from '../../models/forms'
+import { fetchMyDatasets } from '../../actions/api'
 
 const formatOptions: ISelectOption[] = [
   { name: 'csv', value: 'csv' },
@@ -27,9 +28,11 @@ enum TabTypes {
 interface CreateDatasetProps {
   onDismissed: () => void
   onSubmit: (path: string, name: string, format: string) => Promise<ApiAction>
+  setWorkingDataset: (peername: string, name: string) => Promise<ApiAction>
+  fetchMyDatasets: () => Promise<ApiAction>
 }
 
-const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismissed, onSubmit }) => {
+const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismissed, onSubmit, setWorkingDataset }) => {
   const [datasetName, setDatasetName] = React.useState('')
   const [path, setPath] = React.useState('')
   const [bodyFormat, setBodyFormat] = React.useState(formatOptions[0].value)
@@ -214,8 +217,17 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
     setLoading(true)
     error && setError('')
     if (!onSubmit) return
+    console.log('submitting!')
     onSubmit(path, datasetName, bodyFormat)
-      .then(() => onDismissed())
+      .then(() => {
+        console.log('AFTER SUBMIT')
+        fetchMyDatasets()
+        setWorkingDataset('me', datasetName)
+          .then(() => {
+            console.log('DISMISSING')
+            onDismissed()
+          })
+      })
       .catch((action) => {
         setLoading(false)
         setDismissable(true)

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -217,14 +217,11 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
     setLoading(true)
     error && setError('')
     if (!onSubmit) return
-    console.log('submitting!')
     onSubmit(path, datasetName, bodyFormat)
       .then(() => {
-        console.log('AFTER SUBMIT')
         fetchMyDatasets()
         setWorkingDataset('me', datasetName, true)
           .then(() => {
-            console.log('DISMISSING')
             onDismissed()
           })
       })

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -221,9 +221,7 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
       .then(() => {
         fetchMyDatasets()
         setWorkingDataset('me', datasetName, true)
-          .then(() => {
-            onDismissed()
-          })
+          .then(onDismissed)
       })
       .catch((action) => {
         setLoading(false)

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import App from '../components/App'
+import App, { AppProps } from '../components/App'
 import Store from '../models/store'
 
 import {
@@ -20,6 +20,14 @@ import {
   fetchSession,
   setPeername
 } from '../actions/session'
+
+import {
+  setWorkingDataset
+} from '../actions/selections'
+
+const mergeProps = (props: any, actions: any): AppProps => {
+  return { ...props, ...actions }
+}
 
 const AppContainer = connect(
   (state: Store) => {
@@ -49,8 +57,10 @@ const AppContainer = connect(
     initDataset: initDatasetAndFetch,
     closeToast,
     pingApi,
-    setApiConnection
-  }
+    setApiConnection,
+    setWorkingDataset
+  },
+  mergeProps
 )(App)
 
 export default AppContainer

--- a/app/containers/BodyContainer.tsx
+++ b/app/containers/BodyContainer.tsx
@@ -34,7 +34,8 @@ const mapStateToProps = (state: Store, ownProps: BodyContainerProps) => {
   return {
     pageInfo,
     headers,
-    value
+    value,
+    datasetLoading: workingDataset.isLoading
   }
 }
 

--- a/app/containers/BodyContainer.tsx
+++ b/app/containers/BodyContainer.tsx
@@ -24,14 +24,18 @@ interface BodyContainerProps {
 
 const mapStateToProps = (state: Store, ownProps: BodyContainerProps) => {
   const { history } = ownProps
-  const { workingDataset, commitDetails } = state
+  const { workingDataset, commitDetails, selections } = state
   const dataset = history ? commitDetails : workingDataset
   const { pageInfo, value } = dataset.components.body
+  const { peername, name, commit: path } = selections
 
   const headers = extractColumnHeaders(workingDataset)
 
   // get data for the currently selected component
   return {
+    peername,
+    path,
+    name,
     pageInfo,
     headers,
     value,

--- a/app/containers/CommitDetailsContainer.tsx
+++ b/app/containers/CommitDetailsContainer.tsx
@@ -9,6 +9,8 @@ const mapStateToProps = (state: Store) => {
   const { workingDataset, selections, ui, commitDetails } = state
 
   const {
+    peername,
+    name,
     commit: selectedCommitPath,
     commitComponent: selectedComponent
   } = selections
@@ -18,6 +20,8 @@ const mapStateToProps = (state: Store) => {
     .find(d => d.path === selectedCommitPath)
 
   return {
+    peername,
+    name,
     selectedCommitPath: selectedCommitPath,
     commit: selectedCommit,
     selectedComponent,

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -118,7 +118,7 @@ export interface CommitDetails {
   peername: string
   name: string
   status: DatasetStatus
-  isLoading: false
+  isLoading: boolean
   components: {
     body: {
       value: any[] | undefined

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -62,6 +62,7 @@ export interface UI {
 export interface Selections {
   peername: string | null
   name: string | null
+  isLinked: boolean
   activeTab: string
   component: string
   commit: string
@@ -134,7 +135,8 @@ export interface CommitDetails {
 }
 
 export interface WorkingDataset extends CommitDetails {
-  linkpath: string | null
+  linkpath: string
+  hasHistory: boolean
   history: {
     pageInfo: PageInfo
     value: Commit[]

--- a/app/reducers/commitDetail.ts
+++ b/app/reducers/commitDetail.ts
@@ -8,12 +8,12 @@ const initialState: CommitDetails = {
   peername: '',
   name: '',
   status: {},
-  isLoading: false,
+  isLoading: true,
   components: {
     body: {
       value: [],
       pageInfo: {
-        isFetching: false,
+        isFetching: true,
         page: 0,
         pageSize: 100,
         fetchedAll: false
@@ -35,10 +35,7 @@ const [COMMITBODY_REQ, COMMITBODY_SUCC, COMMITBODY_FAIL] = apiActionTypes('commi
 const commitDetailsReducer: Reducer = (state = initialState, action: AnyAction): CommitDetails => {
   switch (action.type) {
     case COMMITDATASET_REQ:
-      return {
-        ...state,
-        isLoading: true
-      }
+      return initialState
     case COMMITDATASET_SUCC:
       const { name, path, peername, published, dataset } = action.payload.data
       return {
@@ -50,13 +47,7 @@ const commitDetailsReducer: Reducer = (state = initialState, action: AnyAction):
         isLoading: false,
         components: {
           body: {
-            value: [],
-            pageInfo: {
-              ...state.components.body.pageInfo,
-              isFetching: false,
-              page: 0,
-              fetchedAll: false
-            }
+            ...state.components.body
           },
           meta: {
             value: dataset.meta
@@ -68,7 +59,7 @@ const commitDetailsReducer: Reducer = (state = initialState, action: AnyAction):
       }
     case COMMITDATASET_FAIL:
       return {
-        ...state,
+        ...initialState,
         isLoading: false
       }
 

--- a/app/reducers/page.ts
+++ b/app/reducers/page.ts
@@ -1,5 +1,6 @@
 import { AnyAction } from 'redux'
 import { PageInfo } from '../models/store'
+import getActionType from '../utils/actionType'
 
 const initialPageInfo = {
   isFetching: true,
@@ -10,13 +11,6 @@ const initialPageInfo = {
 }
 
 export function withPagination (action: AnyAction, pageInfo: PageInfo = initialPageInfo): PageInfo {
-  // TODO (ramfox): export this and move to /store/api ?
-  const getActionType = (type: string): string => {
-    if (type.includes('REQUEST')) return 'request'
-    if (type.includes('SUCCESS')) return 'success'
-    if (type.includes('FAILURE')) return 'failure'
-    return 'default'
-  }
   switch (getActionType(action.type)) {
     case 'request':
       return Object.assign({},

--- a/app/reducers/page.ts
+++ b/app/reducers/page.ts
@@ -33,7 +33,7 @@ export function withPagination (action: AnyAction, pageInfo: PageInfo = initialP
         pageInfo,
         {
           isFetching: false,
-          error: action.payload.message
+          error: action.payload.err.message
         })
     default:
       return pageInfo

--- a/app/reducers/page.ts
+++ b/app/reducers/page.ts
@@ -11,7 +11,7 @@ const initialPageInfo = {
 }
 
 export function withPagination (action: AnyAction, pageInfo: PageInfo = initialPageInfo): PageInfo {
-  switch (getActionType(action.type)) {
+  switch (getActionType(action)) {
     case 'request':
       return Object.assign({},
         pageInfo,

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -10,6 +10,7 @@ export const SELECTIONS_SET_WORKING_DATASET = 'SELECTIONS_SET_WORKING_DATASET'
 const initialState: Selections = {
   peername: store().getItem('peername') || '',
   name: store().getItem('name') || '',
+  isLinked: store().getItem('isLinked') === 'true',
   activeTab: store().getItem('activeTab') || 'status',
   component: store().getItem('component') || '',
   commit: store().getItem('commit') || '',
@@ -42,19 +43,21 @@ export default (state = initialState, action: AnyAction) => {
       return state
 
     case SELECTIONS_SET_WORKING_DATASET:
-      const { peername, name } = action.payload
+      const { peername, name, isLinked } = action.payload
       store().setItem('peername', peername)
       store().setItem('name', name)
-      return Object.assign({}, state, { peername, name })
+      store().setItem('isLinked', isLinked)
+      return Object.assign({}, state, { peername, name, isLinked })
 
     case LIST_SUCC:
       // if there is no peername + name in selections, use the first one on the list
       if (state.peername === '' && state.name === '') {
         if (action.payload.data.length === 0) return state
-        const { peername: firstPeername, name: firstName } = action.payload.data[0]
+        const { peername: firstPeername, name: firstName, isLinked: firstIsLinked } = action.payload.data[0]
         store().setItem('peername', firstPeername)
         store().setItem('name', firstName)
-        return Object.assign({}, state, { peername: firstPeername, name: firstName })
+        store().setItem('isLinked', firstIsLinked)
+        return Object.assign({}, state, { peername: firstPeername, name: firstName, isLinked: firstIsLinked })
       } else {
         return state
       }

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -50,6 +50,7 @@ export default (state = initialState, action: AnyAction) => {
     case LIST_SUCC:
       // if there is no peername + name in selections, use the first one on the list
       if (state.peername === '' && state.name === '') {
+        if (action.payload.data.length === 0) return state
         const { peername: firstPeername, name: firstName } = action.payload.data[0]
         store().setItem('peername', firstPeername)
         store().setItem('name', firstName)

--- a/app/reducers/ui.ts
+++ b/app/reducers/ui.ts
@@ -15,7 +15,7 @@ export const defaultSidebarWidth = 250
 export const hasAcceptedTOSKey = 'acceptedTOS'
 export const hasSetPeernameKey = 'setPeername'
 
-const [, HEALTH_SUCCESS, HEALTH_FAILURE] = apiActionTypes('health')
+const [, HEALTH_SUCCESS] = apiActionTypes('health')
 
 const getSidebarWidth = (key: string): number => {
   const width = store().getItem(key)
@@ -112,8 +112,6 @@ export default (state = initialState, action: AnyAction) => {
     case HEALTH_SUCCESS:
       if (state.apiConnection === 1) return state
       return Object.assign({}, state, { apiConnection: 1 })
-    case HEALTH_FAILURE:
-      return Object.assign({}, state, { apiConnection: -1 })
     case UI_SET_API_CONNECTION:
       return Object.assign({}, state, { apiConnection: action.status })
     default:

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -92,7 +92,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
       return {
         ...state,
         history: {
-          ...history,
+          ...state.history,
           value: state.history.value
             ? state.history.value.concat(action.payload.data)
             : action.payload.data,
@@ -100,7 +100,14 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
         }
       }
     case DATASET_HISTORY_FAIL:
-      return state
+      return {
+        ...state,
+        hasHistory: !action.payload.err.message.includes('no history'),
+        history: {
+          ...state.history,
+          pageInfo: withPagination(action, state.history.pageInfo)
+        }
+      }
 
     case DATASET_STATUS_REQ:
       return state

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -15,7 +15,7 @@ const initialState: WorkingDataset = {
     body: {
       value: [],
       pageInfo: {
-        isFetching: false,
+        isFetching: true,
         page: 0,
         pageSize: 100,
         fetchedAll: false
@@ -30,7 +30,7 @@ const initialState: WorkingDataset = {
   },
   history: {
     pageInfo: {
-      isFetching: false,
+      isFetching: true,
       page: 0,
       fetchedAll: false,
       pageSize: 0
@@ -60,12 +60,9 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
         components: {
           body: {
             pageInfo: {
-              ...state.components.body.pageInfo,
-              isFetching: false,
-              page: 0,
-              fetchedAll: false
+              ...state.components.body.pageInfo
             },
-            value: []
+            value: state.components.body.value
           },
           meta: {
             value: dataset.meta
@@ -174,7 +171,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
             ...state.body,
             error: action.payload.err,
             pageInfo: {
-              ...state.body.pageInfo,
+              ...state.components.body.pageInfo,
               isFetching: false
             }
           }

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -10,7 +10,8 @@ const initialState: WorkingDataset = {
   name: '',
   status: {},
   isLoading: true,
-  linkpath: null,
+  linkpath: '',
+  hasHistory: true,
   components: {
     body: {
       value: [],
@@ -112,7 +113,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
         }, {})
       // check filepath in the first element in the payload to determine whether the
       // dataset is linked
-      let linkpath = null
+      let linkpath = ''
       const { filepath } = action.payload.data[0]
       if (filepath !== 'repo') {
         linkpath = filepath.substring(0, (filepath.lastIndexOf('/')))

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -91,6 +91,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
     case DATASET_HISTORY_SUCC:
       return {
         ...state,
+        hasHistory: true,
         history: {
           ...state.history,
           value: state.history.value

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -9,7 +9,7 @@ const initialState: WorkingDataset = {
   peername: '',
   name: '',
   status: {},
-  isLoading: false,
+  isLoading: true,
   linkpath: null,
   components: {
     body: {
@@ -47,10 +47,7 @@ const [DATASET_BODY_REQ, DATASET_BODY_SUCC, DATASET_BODY_FAIL] = apiActionTypes(
 const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction): WorkingDataset | null => {
   switch (action.type) {
     case DATASET_REQ:
-      return {
-        ...state,
-        isLoading: true
-      }
+      return initialState
     case DATASET_SUCC:
       const { name, path, peername, published, dataset } = action.payload.data
       return {

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -116,6 +116,18 @@ $header-font-size: .9rem;
         z-index: 110;
       }
 
+      .main-content {
+        position: relative;
+        width: 100%;
+        height: 100%;
+
+        > div {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+        }
+      }
+
       .component-container {
         display: flex;
         flex-direction: column;
@@ -283,7 +295,6 @@ $header-font-size: .9rem;
       background:$appBackground;
     }
   }
-
 }
 
 ////////////////////////////

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -25,7 +25,11 @@ $header-font-size: .9rem;
 
   .header-column {
     height: 100%;
+<<<<<<< HEAD
     border-right: 1px solid #66737b;
+=======
+    border-right: 1px solid $border-color;
+>>>>>>> refactor(api): fix some api bugs & some style
     padding: 0 9px;
     display: inline-flex;
     flex-direction: row;
@@ -80,11 +84,23 @@ $header-font-size: .9rem;
     }
   }
 
+  .terminal {
+    background: $black;
+    border: solid 1px $border-color;
+    font-family: $font-family-monospace;
+    overflow: scroll;
+    font-size: $small-font-size;
+    padding: $spacer;
+    color: $white;
+    text-overflow: unset;
+  }
+
   .columns {
     display: flex;
     flex-direction: row;
     flex-grow: 1;
     overflow-y: auto;
+    height: 100%;
 
     #sidebar {
       position: relative;
@@ -116,6 +132,7 @@ $header-font-size: .9rem;
         z-index: 110;
       }
 
+<<<<<<< HEAD
       .main-content {
         position: relative;
         width: 100%;
@@ -160,6 +177,8 @@ $header-font-size: .9rem;
         }
       }
 
+=======
+>>>>>>> refactor(api): fix some api bugs & some style
       .content {
         padding: 15px;
         overflow-x: scroll;
@@ -276,6 +295,11 @@ $header-font-size: .9rem;
         border-bottom: 3px solid #315379;
       }
 
+      &.disabled {
+        background-color: #efefef;
+        color: $text-muted;
+      }
+
       &:hover {
         background-color: #efefef;
       }
@@ -353,6 +377,8 @@ $header-font-size: .9rem;
   flex-direction: column;
   flex-grow: 1;
   height: 100%;
+  width: 100%;
+  position:relative;
 
   .commit-details-header {
     height: 60px;

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -25,11 +25,7 @@ $header-font-size: .9rem;
 
   .header-column {
     height: 100%;
-<<<<<<< HEAD
     border-right: 1px solid #66737b;
-=======
-    border-right: 1px solid $border-color;
->>>>>>> refactor(api): fix some api bugs & some style
     padding: 0 9px;
     display: inline-flex;
     flex-direction: row;
@@ -132,7 +128,6 @@ $header-font-size: .9rem;
         z-index: 110;
       }
 
-<<<<<<< HEAD
       .main-content {
         position: relative;
         width: 100%;
@@ -177,8 +172,6 @@ $header-font-size: .9rem;
         }
       }
 
-=======
->>>>>>> refactor(api): fix some api bugs & some style
       .content {
         padding: 15px;
         overflow-x: scroll;

--- a/app/scss/_dialog.scss
+++ b/app/scss/_dialog.scss
@@ -14,8 +14,7 @@ dialog {
 
   z-index: $zindex-modal;
 
-  min-width: 500px;
-  max-width: 600px;
+  width: 500px;
 
   &::backdrop {
     background-color: rgba(0, 0, 0, 0.1);
@@ -86,18 +85,18 @@ dialog {
   .content-wrap {
     min-height: 300px; 
     position: relative;
+    display: flex;
+    flex-direction: column;
     
     .content {
-      position: absolute;
       width: 100%;
       height: 100%;
       background: $appBackground;
     }
 
-    #error {
-      bottom: 1rem;
-      position: absolute;
-    }
+    // #error {
+    //   bottom: 1rem;
+    // }
   }
 
   #create-dataset-content-wrap {
@@ -146,7 +145,10 @@ dialog {
 
   .error {
     color: $error;
-    height: $spacer * 2;
+    height: 100%;
+    overflow-wrap: normal;
+    width: 90%;
+    margin-bottom: $spacer;
   }
   
   .buttons {

--- a/app/scss/_transitions.scss
+++ b/app/scss/_transitions.scss
@@ -44,3 +44,21 @@
     transition: opacity 300ms, transform 300ms;
   }
 }
+
+.slide-enter {
+  max-height: 0px;
+}
+
+.slide-enter-active {
+  max-height: 500px;
+  transition: max-height 300ms, transform 300ms;
+}
+
+.slide-exit {
+  max-height: 500px;
+}
+
+.slide-exit-active {
+  max-height: 0px;
+  transition: max-height 300ms, transform 300ms;
+}

--- a/app/scss/_transitions.scss
+++ b/app/scss/_transitions.scss
@@ -30,6 +30,22 @@
     transition: opacity 300ms, transform 300ms;
   }
 }
+
+.fade-appear {
+  opacity: 0;
+  &::backdrop {
+    opacity: 0;
+  }
+}
+.fade-appear-active {
+  opacity: 1;
+  transition: opacity 300ms, transform 300ms;
+  &::backdrop {
+    opacity: 1;
+    transition: opacity 300ms, transform 300ms;
+  }
+}
+
 .fade-exit {
   opacity: 1;
   &::backdrop {
@@ -61,4 +77,18 @@
 .slide-exit-active {
   max-height: 0px;
   transition: max-height 300ms, transform 300ms;
+}
+
+// outer div
+.transition-group {
+  position:relative;
+  height:100%;
+  width:100%;
+}
+
+// inner divs
+#transition-wrap {
+  position: absolute;
+  width: 100%;
+  height: 100%;
 }

--- a/app/scss/_welcome.scss
+++ b/app/scss/_welcome.scss
@@ -21,7 +21,7 @@
 #choose-peername-page { z-index: 198 }
 #no-datasets-page { z-index: 197 }
 
-#spinner-with-icon-wrap { width: 100% }
+#spinner-with-icon-wrap { width: 100%; height: 100%; position: absolute; }
   
 .welcome-center {
   width: 600px;

--- a/app/scss/_welcome.scss
+++ b/app/scss/_welcome.scss
@@ -20,6 +20,8 @@
 #welcome-page { z-index: 199 }
 #choose-peername-page { z-index: 198 }
 #no-datasets-page { z-index: 197 }
+
+#spinner-with-icon-wrap { width: 100% }
   
 .welcome-center {
   width: 600px;

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -126,7 +126,7 @@ function apiUrl (endpoint: string, segments?: ApiSegments, query?: ApiQuery, pag
   }
 
   const addToUrl = (url: string, seg: string): string => {
-    if (url[-1] !== '/') url += '/'
+    if (url[-1] !== '/' || seg[0] !== '/') url += '/'
     return url + seg
   }
 

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -125,22 +125,27 @@ function apiUrl (endpoint: string, segments?: ApiSegments, query?: ApiQuery, pag
     return ['', `${endpoint} is not a valid api endpoint`]
   }
 
+  const addToUrl = (url: string, seg: string): string => {
+    if (url[-1] !== '/') url += '/'
+    return url + seg
+  }
+
   let url = `http://localhost:2503/${path}`
   if (segments) {
     if (segments.peername) {
-      url += `/${segments.peername}`
+      url = addToUrl(url, segments.peername)
     }
     if (segments.name) {
-      url += `/${segments.name}`
+      url = addToUrl(url, segments.name)
     }
     if (segments.peerID || segments.path) {
-      url += '/at'
+      url = addToUrl(url, 'at')
     }
     if (segments.peerID) {
-      url += `/${segments.peerID}`
+      url = addToUrl(url, segments.peerID)
     }
     if (segments.path) {
-      url += segments.path
+      url = addToUrl(url, segments.path)
     }
   }
 

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -126,7 +126,7 @@ function apiUrl (endpoint: string, segments?: ApiSegments, query?: ApiQuery, pag
   }
 
   const addToUrl = (url: string, seg: string): string => {
-    if (url[-1] !== '/' || seg[0] !== '/') url += '/'
+    if (url[-1] !== '/' && seg[0] !== '/') url += '/'
     return url + seg
   }
 

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -5,6 +5,7 @@ import {
 } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
 import Store from '../models/store'
+import mapError from './mapError'
 
 // CALL_API is a global, unique constant for passing actions to API middleware
 export const CALL_API = Symbol('CALL_API')
@@ -94,13 +95,12 @@ export function apiActionTypes (endpoint: string): [string, string, string] {
 
 // getJSON fetches json data from a url
 async function getJSON<T> (url: string, options: FetchOptions): Promise<T> {
-  const res = await fetch(url, options)
-  if (res.status !== 200) {
-    throw new Error(`Received non-200 status code: ${res.status}`)
+  const r = await fetch(url, options)
+  const res = await r.json()
+  if (res.meta.code !== 200) {
+    throw new Error(mapError(res.meta.error))
   }
-
-  const json = await res.json()
-  return json as T
+  return res as T
 }
 
 // endpointMap is an object that maps frontend endpoint names to their

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -126,7 +126,7 @@ function apiUrl (endpoint: string, segments?: ApiSegments, query?: ApiQuery, pag
   }
 
   const addToUrl = (url: string, seg: string): string => {
-    if (url[-1] !== '/' && seg[0] !== '/') url += '/'
+    if (!(url[url.length - 1] === '/' || seg[0] === '/')) url += '/'
     return url + seg
   }
 

--- a/app/store/mapError.ts
+++ b/app/store/mapError.ts
@@ -1,0 +1,9 @@
+// place to map backend errors to human readable errors
+// this is basically a wishlist for what we would prefer the backend to say
+const errors: {[key: string]: string} = {
+  'error saving profile: handle is taken': 'This peername is already in use.'
+}
+
+export default function mapError (err: string): string {
+  return errors[err] || err
+}

--- a/app/store/mapError.ts
+++ b/app/store/mapError.ts
@@ -1,9 +1,20 @@
 // place to map backend errors to human readable errors
 // this is basically a wishlist for what we would prefer the backend to say
 const errors: {[key: string]: string} = {
-  'error saving profile: handle is taken': 'This peername is already in use.'
+  'error saving profile: handle is taken': 'This peername is already in use.',
+  'working directory is already linked, .qri-ref exists': 'This directory already contains a linked dataset.',
+  // this backend error seems like a mistake
+  'error resolving ref: error 404: ': 'Dataset not found.',
+  'error resolving ref: p2p network responded with incomplete reference': 'Dataset not found.'
 }
 
 export default function mapError (err: string): string {
-  return errors[err] || err
+  var errMessage = err
+  if (err.includes('@')) {
+    const start = err.indexOf('@')
+    const errSlice = err.slice(start)
+    const end = errSlice.indexOf(' ') + start
+    errMessage = err.slice(0, start) + err.slice(end)
+  }
+  return errors[errMessage] || errMessage
 }

--- a/app/utils/actionType.ts
+++ b/app/utils/actionType.ts
@@ -1,0 +1,8 @@
+const getActionType = (type: string): string => {
+  if (type.includes('REQUEST')) return 'request'
+  if (type.includes('SUCCESS')) return 'success'
+  if (type.includes('FAILURE')) return 'failure'
+  return 'default'
+}
+
+export default getActionType

--- a/app/utils/actionType.ts
+++ b/app/utils/actionType.ts
@@ -1,8 +1,8 @@
-const getActionType = (type: string): string => {
-  if (type.includes('REQUEST')) return 'request'
-  if (type.includes('SUCCESS')) return 'success'
-  if (type.includes('FAILURE')) return 'failure'
-  return 'default'
+const getActionType = (action = { type: '' }): string => {
+  if (action.type.includes('REQUEST')) return 'request'
+  if (action.type.includes('SUCCESS')) return 'success'
+  if (action.type.includes('FAILURE')) return 'failure'
+  return ''
 }
 
 export default getActionType

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,7 +472,7 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-tooltip@^3.9.3":
+"@types/react-tooltip@3.9.3":
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/@types/react-tooltip/-/react-tooltip-3.9.3.tgz#2eb1e08e128bb691197c5c7f9063fda9ffd5ea42"
   integrity sha512-X9xuVWlZTLUQadIIrf5MnMPo/FE8izJPRo6c6f+XUs8eIaQ2vj+5Qw4Ttw9bMUPrqImmsJp7o7FY4t1qHLFf4g==
@@ -506,7 +506,7 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
 
-"@types/underscore@^1.9.2":
+"@types/underscore@1.9.2":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.9.2.tgz#2c4f7743287218f5c2d9a83db3806672aa48530d"
   integrity sha512-KgOKTAD+9X+qvZnB5S1+onqKc4E+PZ+T6CM/NA5ohRPLHJXb+yCJMVf8pWOnvuBuKFNUAJW8N97IA6lba6mZGg==
@@ -6242,7 +6242,7 @@ react-test-renderer@16.8.6, react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.13.6"
 
-react-tooltip@^3.10.0:
+react-tooltip@3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.10.0.tgz#268b5ef519fd8a1369288d1f086f42c90d5da7ef"
   integrity sha512-GGdxJvM1zSFztkTP7gCQbLTstWr1OOoMpJ5WZUGhimj0nhRY+MPz+92MpEnKmj0cftJ9Pd/M6FfSl0sfzmZWkg==
@@ -7629,7 +7629,7 @@ uglify-js@^3.1.4:
     commander "~2.20.0"
     source-map "~0.6.1"
 
-underscore@^1.9.1:
+underscore@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
   integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==


### PR DESCRIPTION
closes #85 
closes #91 


closes #46 create dataset and add dataset should send you to that dataset
closes #27 handling errors and loading status
closes #101 handle when dataset has no history or dataset is not linked 
closes #102 store isLinked in selections & localStorage 

This pr generally fixes issues flipping between commits and datasets! Makes sure a dataset has certain parts before allowing the app to display those parts. Adds sensible alternatives for default components to show.

Best way to play with this is to have some datasets that aren't linked, a dataset that is linked and has history, and a dataset that is linked but has no history, some datasets that have all the components, others that don't. We shouldn't be erroring when something is missing anymore.

This pr depends on a specific branch: [no-history](https://github.com/qri-io/qri/tree/no-history)
More specifically, it relies on [no-history-kasey](https://github.com/qri-io/qri/tree/no-history-kasey), which adds two commits to dustin's branch to smooth out some errors.