### PR TITLE
refactor: remove hard-coded avatar image

### DIFF
--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -72,7 +72,7 @@ export default class CommitDetails extends React.Component<CommitDetailsProps> {
           <div className='commit-details-header text-column'>
             <div className='text'>{title}</div>
             <div className='subtext'>
-              <img className= 'user-image' src = {'https://avatars0.githubusercontent.com/u/1154390?s=60&v=4'} />
+              {/* <img className= 'user-image' src = {'https://avatars0.githubusercontent.com/u/1154390?s=60&v=4'} /> */}
               <div className='time-message'>
                 {timeMessage}
               </div>

--- a/app/components/DatasetSidebar.tsx
+++ b/app/components/DatasetSidebar.tsx
@@ -14,7 +14,6 @@ import { WorkingDataset, ComponentType } from '../models/store'
 interface HistoryListItemProps {
   path: string
   commitTitle: string
-  avatarUrl: string
   timeMessage: string
   selected: boolean
   onClick: (type: string, selectedListItem: string) => Action
@@ -29,7 +28,7 @@ const HistoryListItem: React.FunctionComponent<HistoryListItemProps> = (props) =
       <div className='text-column'>
         <div className='text'>{props.commitTitle}</div>
         <div className='subtext'>
-          <img className= 'user-image' src = {props.avatarUrl} />
+          {/* Bring back avatar later <img className= 'user-image' src = {props.avatarUrl} /> */}
           <div className='time-message'>
             {props.timeMessage}
           </div>
@@ -141,7 +140,6 @@ const DatasetSidebar: React.FunctionComponent<DatasetSidebarProps> = ({
                     key={path}
                     path={path}
                     commitTitle={title}
-                    avatarUrl={'https://avatars0.githubusercontent.com/u/1154390?s=60&v=4'}
                     timeMessage={timeMessage}
                     selected={selectedCommit === path}
                     onClick={onListItemClick}


### PR DESCRIPTION
Removes @b5 avatar images.  The containing divs are commented out so we can add them back once we have proper identity management w/ Qri cloud.