### PR TITLE
feat: update components on mtime diff

### DIFF
--- a/app/actions/workingDataset.ts
+++ b/app/actions/workingDataset.ts
@@ -1,0 +1,52 @@
+import { CALL_API, ApiActionThunk } from '../store/api'
+import { Dataset } from '../models/dataset'
+
+import { fetchBody } from './api'
+
+import {
+  RESET_BODY
+} from '../reducers/workingDataset'
+
+// action creators for resetting the body or 'other components' when a
+// difference in mtime is detected in Dataset.tsx
+
+// resetBody() dispatches RESET_BODY which is a normal action that resets
+// workingDataset.components.body to the initial state, then calls fetchBody
+export const resetBody: any = () => {
+  return async (dispatch: any) => {
+    await dispatch({
+      type: RESET_BODY
+    })
+
+    dispatch(fetchBody())
+  }
+}
+
+// resetOtherComponents is the same API call as fetchWorkingDataset
+// but needs to be different so the reducers don't treat it like switching WorkingDataset
+// the reducers for resetOtherComponents only touch workingDataset.meta.value and workingDataset.schema.value
+// this could/should live with the other api actions, but it's here because it's more aligned with resetBody()
+export const resetOtherComponents = (): ApiActionThunk => {
+  return async (dispatch, getState) => {
+    const { selections } = getState()
+    const { peername, name, isLinked } = selections
+
+    const action = {
+      type: 'resetOtherComponents',
+      [CALL_API]: {
+        endpoint: '',
+        method: 'GET',
+        params: { fsi: isLinked },
+        segments: {
+          peername,
+          name
+        },
+        map: (data: Record<string, string>): Dataset => {
+          return data as Dataset
+        }
+      }
+    }
+
+    return dispatch(action)
+  }
+}

--- a/app/containers/DatasetContainer.tsx
+++ b/app/containers/DatasetContainer.tsx
@@ -12,12 +12,19 @@ import {
   publishDataset,
   unpublishDataset
 } from '../actions/api'
+
 import {
   setActiveTab,
   setSelectedListItem,
   setWorkingDataset
 } from '../actions/selections'
+
 import { setFilter } from '../actions/myDatasets'
+
+import {
+  resetBody,
+  resetOtherComponents
+} from '../actions/workingDataset'
 
 const mergeProps = (props: any, actions: any): DatasetProps => {
   return { ...props, ...actions }
@@ -59,6 +66,8 @@ const DatasetContainer = connect(
     fetchWorkingDatasetDetails,
     fetchWorkingStatus,
     fetchWorkingHistory,
+    resetBody,
+    resetOtherComponents,
     publishDataset,
     unpublishDataset,
     signout

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -105,6 +105,7 @@ export type ComponentState = 'modified' | 'unmodified' | 'removed' | 'added'
 export interface ComponentStatus {
   filepath: string
   status: ComponentState
+  mtime?: Date
   errors?: object[]
   warnings?: object[]
   component?: string

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -47,7 +47,10 @@ const [DATASET_REQ, DATASET_SUCC, DATASET_FAIL] = apiActionTypes('dataset')
 const [DATASET_HISTORY_REQ, DATASET_HISTORY_SUCC, DATASET_HISTORY_FAIL] = apiActionTypes('history')
 const [DATASET_STATUS_REQ, DATASET_STATUS_SUCC, DATASET_STATUS_FAIL] = apiActionTypes('status')
 const [DATASET_BODY_REQ, DATASET_BODY_SUCC, DATASET_BODY_FAIL] = apiActionTypes('body')
+const [RESETOTHERCOMPONENTS_REQ, RESETOTHERCOMPONENTS_SUCC, RESETOTHERCOMPONENTS_FAIL] = apiActionTypes('resetOtherComponents')
 const [, ADD_SUCC] = apiActionTypes('add')
+
+export const RESET_BODY = 'RESET_BODY'
 
 const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction): WorkingDataset | null => {
   switch (action.type) {
@@ -130,8 +133,8 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
     case DATASET_STATUS_SUCC:
       const statusObject: DatasetStatus = action.payload.data
         .reduce((obj: any, item: any): ComponentStatus => {
-          const { component, filepath, status } = item
-          obj[component] = { filepath, status }
+          const { component, filepath, status, mtime } = item
+          obj[component] = { filepath, status, mtime }
           return obj
         }, {})
       return {
@@ -189,6 +192,56 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
               ...state.components.body.pageInfo,
               isFetching: false
             }
+          }
+        }
+      }
+
+    case RESET_BODY:
+      return {
+        ...state,
+        components: {
+          ...state.components,
+          body: initialState.components.body
+        }
+      }
+
+    case RESETOTHERCOMPONENTS_REQ:
+      return {
+        ...state,
+        components: {
+          ...state.components,
+          meta: initialState.components.meta,
+          schema: initialState.components.schema
+        }
+      }
+
+    case RESETOTHERCOMPONENTS_SUCC:
+      const { dataset: newDataset } = action.payload.data
+      return {
+        ...state,
+        components: {
+          ...state.components,
+          meta: {
+            value: newDataset.meta || {}
+          },
+          schema: {
+            value: newDataset.structure.schema
+          }
+        }
+      }
+
+    case RESETOTHERCOMPONENTS_FAIL:
+      return {
+        ...state,
+        components: {
+          ...state.components,
+          meta: {
+            ...state.components.meta,
+            error: action.payload.err
+          },
+          schema: {
+            ...state.components.schema,
+            error: action.payload.err
           }
         }
       }


### PR DESCRIPTION
- Updates the store to include `mtime` for each component
- When `Dataset` `didUpdate`, compare previous `mtime` with new `mtime`, determine which components need updating (body or everthing else)
- New actions to `resetBody()` and `resetOtherComponents`

Closes #113