### PR TITLE
fix(cloud link): show in cloud should use QRI_CLOUD_URL

### DIFF
--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -257,11 +257,11 @@ export default class Dataset extends React.Component<DatasetProps> {
     if (username === workingDataset.peername) {
       publishButton = published ? (
         <HeaderColumnButtonDropdown
-          onClick={() => { shell.openExternal(`http://localhost:3000/${workingDataset.peername}/${workingDataset.name}`) }}
+          onClick={() => { shell.openExternal(`${QRI_CLOUD_URL}/${workingDataset.peername}/${workingDataset.name}`) }}
           icon='faCloud'
           label='View in Cloud'
           items={[
-            <a key={0} onClick={(e) => { shell.openExternal(`http://localhost:3000/${workingDataset.peername}/${workingDataset.name}`); e.stopPropagation() }}>Copy Link</a>,
+            <a key={0} onClick={(e) => { shell.openExternal(`${QRI_CLOUD_URL}/${workingDataset.peername}/${workingDataset.name}`); e.stopPropagation() }}>Copy Link</a>,
             <a key={1} onClick={this.publishUnpublishDataset}>Unpublish</a>
           ]}
         />

--- a/app/utils/registry.ts
+++ b/app/utils/registry.ts
@@ -1,2 +1,2 @@
 
-export const QRI_CLOUD_URL = 'http://localhost:3000'
+export const QRI_CLOUD_URL = 'https://qri.cloud'


### PR DESCRIPTION
closes #145

also change QRI_CLOUD_URL to `https://qri.cloud`.