### PR TITLE
fix(signin/signup): get session info from response to signin/signup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ app/node_modules
 .DS_Store
 
 # App packaged
+backend/qri
 release
 app/main.js
 app/main.js.map

--- a/app/actions/session.ts
+++ b/app/actions/session.ts
@@ -28,6 +28,9 @@ export function signup (username: string, email: string, password: string): ApiA
           username,
           email,
           password
+        },
+        map: (data: Record<string, any>): Session => {
+          return data as Session
         }
       }
     }
@@ -45,6 +48,9 @@ export function signin (username: string, password: string): ApiActionThunk {
         body: {
           username,
           password
+        },
+        map: (data: Record<string, any>): Session => {
+          return data as Session
         }
       }
     }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -25,6 +25,7 @@ export interface AppProps {
   hasDatasets: boolean
   loading: boolean
   sessionID: string
+  peername: string
   apiConnection?: number
   hasAcceptedTOS: boolean
   qriCloudAuthenticated: boolean
@@ -51,6 +52,7 @@ export interface AppProps {
 interface AppState {
   currentModal: Modal
   sessionID: string
+  peername: string
 }
 
 export default class App extends React.Component<AppProps, AppState> {
@@ -59,7 +61,8 @@ export default class App extends React.Component<AppProps, AppState> {
 
     this.state = {
       currentModal: NoModal,
-      sessionID: this.props.sessionID
+      sessionID: this.props.sessionID,
+      peername: this.props.peername
     }
 
     this.renderModal = this.renderModal.bind(this)
@@ -90,12 +93,18 @@ export default class App extends React.Component<AppProps, AppState> {
       }, 750)
     }
     this.props.fetchSession()
-    this.props.fetchMyDatasets()
+      .then(async () => this.props.fetchMyDatasets())
   }
 
   static getDerivedStateFromProps (NextProps: AppProps, PrevState: AppState) {
-    if (PrevState.sessionID !== NextProps.sessionID) {
-      return { sessionID: NextProps.sessionID }
+    if (PrevState.sessionID !== NextProps.sessionID || PrevState.peername !== NextProps.peername) {
+      // clear selection if the sessionID has changed from one user to another
+      // if it has gone from no user (initial state) to a user, don't re-fetch
+      if (PrevState.sessionID !== '') {
+        NextProps.setWorkingDataset('', '', false)
+          .then(async () => NextProps.fetchMyDatasets(1))
+      }
+      return { sessionID: NextProps.sessionID, peername: NextProps.peername }
     }
     return null
   }

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -20,20 +20,27 @@ const initialSession: Session = {
 }
 
 const [SESSION_REQ, SESSION_SUCC, SESSION_FAIL] = apiActionTypes('session')
-const [SET_PEERNAME_REQ, SET_PEERNAME_SUCC, SET_PEERNAME_FAIL] = apiActionTypes('set_peername')
+const [SIGNUP_REQ, SIGNUP_SUCC, SIGNUP_FAIL] = apiActionTypes('signup')
+const [SIGNIN_REQ, SIGNIN_SUCC, SIGNIN_FAIL] = apiActionTypes('signin')
 
 const sessionReducer: Reducer = (state = initialSession, action: AnyAction) => { // eslint-disable-line
   switch (action.type) {
-    case SESSION_REQ || SET_PEERNAME_REQ:
+    case SESSION_REQ:
+    case SIGNUP_REQ:
+    case SIGNIN_REQ:
       return state
-    case SESSION_SUCC || SET_PEERNAME_SUCC:
+    case SESSION_SUCC:
+    case SIGNUP_SUCC:
+    case SIGNIN_SUCC:
       return {
         ...state,
         ...action.payload.data,
         // hard code this photo until the backend provides user photos
         photo: 'https://avatars0.githubusercontent.com/u/1833820?s=23&v=4'
       }
-    case SESSION_FAIL || SET_PEERNAME_FAIL:
+    case SESSION_FAIL:
+    case SIGNUP_FAIL:
+    case SIGNIN_FAIL:
       return state
     default:
       return state

--- a/app/reducers/myDatasets.ts
+++ b/app/reducers/myDatasets.ts
@@ -27,6 +27,9 @@ const myDatasetsReducer: Reducer = (state = initialState, action: AnyAction): My
       return { ...state, filter }
 
     case LIST_REQ:
+      if (action.pageInfo.page === 1) {
+        return initialState
+      }
       return {
         ...state,
         pageInfo: withPagination(action, state.pageInfo)


### PR DESCRIPTION
Store the session info in Session
If the session is different, reset the selection and pull myDatasets
If we are pulling myDatasets from page 1, added logic that would make sure we are not holding onto the previous list of datasets

closes #152