### PR TITLE
feat: Command-R Shortcut

### DIFF
--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -310,7 +310,7 @@ export default class Dataset extends React.Component<DatasetProps> {
           <div className='header-right'>
             <HeaderColumnButton
               icon={faDiscord}
-              tooltip={'Need help? Ask questions in our Discord channel'}
+              tooltip={'Need help? Ask questions<br/> in our Discord channel'}
               onClick={() => { shell.openExternal('https://discordapp.com/invite/thkJHKj') }}
             />
             <HeaderColumnButtonDropdown

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Action } from 'redux'
 import classNames from 'classnames'
 import ReactTooltip from 'react-tooltip'
-import { ipcRenderer, shell } from 'electron'
+import { remote, ipcRenderer, shell } from 'electron'
 import { CSSTransition } from 'react-transition-group'
 import { faDiscord } from '@fortawesome/free-brands-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -109,6 +109,10 @@ export default class Dataset extends React.Component<DatasetProps> {
     ipcRenderer.on('open-working-directory', this.openWorkingDirectory)
 
     ipcRenderer.on('publish-unpublish-dataset', this.publishUnpublishDataset)
+
+    ipcRenderer.on('reload', () => {
+      remote.getCurrentWindow().reload()
+    })
   }
 
   componentDidUpdate (prevProps: DatasetProps) {

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -270,6 +270,13 @@ app.on('ready', () =>
                 type: 'separator'
               },
               {
+                label: 'Reload',
+                accelerator: 'Command+R',
+                click () {
+                  mainWindow.webContents.send('reload')
+                }
+              },
+              {
                 label: 'Toggle Developer Tools',
                 accelerator: 'Option+Command+I',
                 role: 'toggleDevTools'


### PR DESCRIPTION
- Adds 'Reload' to the 'View' menu with shortcut Command-R, reloading the app. (Closes #138)

![Fullscreen_9_4_19__11_39_AM](https://user-images.githubusercontent.com/1833820/64269922-b7b08e00-cf08-11e9-97e1-d00cca2dc676.png)

- Makes the discord tooltip multi-line, so it appears below the icon instead to the left

![Fullscreen_9_4_19__11_40_AM](https://user-images.githubusercontent.com/1833820/64270018-dd3d9780-cf08-11e9-8067-8cf74879c754.png)

