### PR TITLE
feat: show window on refocusing app

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -62,6 +62,8 @@ const setMenuItemEnabled = (menuItemIds, enabled) => {
   })
 }
 
+let quitting = false
+
 app.on('ready', () =>
   installExtensions()
     .then(() => {
@@ -146,10 +148,10 @@ app.on('ready', () =>
                 type: 'separator'
               },
               {
-                label: 'Quit',
+                label: 'Quit Qri Desktop',
                 accelerator: 'Command+Q',
                 click () {
-                  app.quit()
+                  quitting = true; app.quit()
                 }
               }
             ]
@@ -474,5 +476,16 @@ app.on('ready', () =>
           'open-working-directory'
         ]
         setMenuItemEnabled(blockableMenus, !blockMenus)
+      })
+
+      mainWindow.on('close', (e) => {
+        if (!quitting) {
+          e.preventDefault()
+          Menu.sendActionToFirstResponder('hide:')
+        }
+      })
+
+      app.on('activate', () => {
+        mainWindow.show()
       })
     }))


### PR DESCRIPTION
When a user closes the window, the app is moved to the background.  When they bring the app back to the foreground, the window will be shown again.  (Closes #132)