### PR TITLE
fix: close the dataset list when a new dataset is loaded

### DIFF
--- a/app/reducers/ui.ts
+++ b/app/reducers/ui.ts
@@ -50,6 +50,8 @@ const initialState = {
 // send an event to electron to block menus on first load
 ipcRenderer.send('block-menus', true)
 
+const [, DATASET_SUCC] = apiActionTypes('dataset')
+
 export default (state = initialState, action: AnyAction) => {
   switch (action.type) {
     case UI_TOGGLE_DATASET_LIST:
@@ -141,6 +143,14 @@ export default (state = initialState, action: AnyAction) => {
         ...state,
         qriCloudAuthenticated: false
       }
+
+    // close the dataset list when the user chooses a new dataset or adds a new dataset
+    case DATASET_SUCC:
+      return {
+        ...state,
+        showDatasetList: false
+      }
+
     default:
       return state
   }


### PR DESCRIPTION
Adds a reducer for the `DATASET_SUCCESS` event that closes the dataset list.  (Dataset list should close automatically if user switches datasets or adds a new dataset.  Closes #135 