### PR TITLE
New dataset modal

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -448,7 +448,7 @@ export function addDatasetAndFetch (peername: string, name: string): ApiActionTh
   }
 }
 
-export function initDataset (filepath: string, name: string, format: string): ApiActionThunk {
+export function initDataset (filepath: string, name: string, dir: string): ApiActionThunk {
   return async (dispatch) => {
     const action = {
       type: 'init',
@@ -458,7 +458,7 @@ export function initDataset (filepath: string, name: string, format: string): Ap
         params: {
           filepath,
           name,
-          format
+          dir
         }
       }
     }

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -289,7 +289,7 @@ export default class Dataset extends React.Component<DatasetProps> {
         <div className='header'>
           <div className='header-left'>
             <div
-              className={classNames('current-dataset', 'header-column', { 'expanded': showDatasetList })}
+              className={classNames('current-dataset', 'header-column', 'sidebar-list-item', { 'expanded': showDatasetList })}
               data-tip={`${workingDataset.peername}/${workingDataset.name}`}
               onClick={toggleDatasetList}
               style={{ width: datasetSidebarWidth }}

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Action, AnyAction } from 'redux'
 import classNames from 'classnames'
+
 import { MyDatasets, WorkingDataset } from '../models/store'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFolderOpen } from '@fortawesome/free-regular-svg-icons'
@@ -73,6 +74,23 @@ export default class DatasetList extends React.Component<DatasetListProps> {
 
     return (
       <div className='dataset-sidebar' >
+        <div>
+          <div id='buttons'>
+            <div
+              className='dataset-list-button'
+              onClick={() => { setModal({ type: ModalType.AddDataset }) }}
+              data-tip='Add an existing<br/>Qri dataset'
+            >
+              <a href='#'>Add a Dataset</a>
+            </div>
+            <div
+              className='dataset-list-button'
+              onClick={() => { setModal({ type: ModalType.CreateDataset }) }}
+              data-tip='Create a new Qri <br/>dataset from a data file'
+            >
+              <a href='#'>New Dataset</a></div>
+          </div>
+        </div>
         <div id='dataset-list-header' className='sidebar-list-item'>
           <div id='controls'>
             <input
@@ -81,7 +99,6 @@ export default class DatasetList extends React.Component<DatasetListProps> {
               placeholder='Filter'
               onKeyUp={(e) => this.handleFilterKeyUp(e)}
             />
-            <div id='add-button' onClick={() => { setModal({ type: ModalType.AddDataset }) }}>Add</div>
           </div>
           <div className='strong-message'>You have {filteredDatasets.length} local datasets</div>
         </div>

--- a/app/components/form/TextInput.tsx
+++ b/app/components/form/TextInput.tsx
@@ -34,9 +34,9 @@ const TextInput: React.FunctionComponent<TextInputProps> = ({ label, name, type,
           placeholder={placeHolder}
           onChange={(e) => { onChange(name, e.target.value) }}
         />
-      </div>
-      <div style={{ height: 20 }}>
-        <h6 style={{ textAlign: 'left', margin: 3 }} className={feedbackColor} >{feedback || ''}</h6>
+        <div style={{ height: 20 }}>
+          <h6 style={{ textAlign: 'left', margin: 3 }} className={feedbackColor} >{feedback || ''}</h6>
+        </div>
       </div>
     </>
   )

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -69,6 +69,11 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
     }
 
     const path = filePath[0]
+    const splitOnSlash = path.split('/')
+    const file = splitOnSlash && splitOnSlash.pop()
+    const name = file && file.split('.')[0]
+
+    name && datasetName === '' && setDatasetName(name)
 
     setFilePath(path)
     const isDataset = isQriDataset(path)
@@ -136,15 +141,6 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
     >
       <div className='content-wrap'>
         <div className='content'>
-          <TextInput
-            name='datasetName'
-            label='Dataset Name'
-            type=''
-            value={datasetName}
-            onChange={handleChanges}
-            maxLength={600}
-            errorText={alreadyDatasetError}
-          />
           <div className='flex-space-between'>
             <TextInput
               name='path'
@@ -157,6 +153,15 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
             />
             <div className='margin-left'><ButtonInput onClick={() => handleFilePickerDialog(showFilePicker)} >Choose...</ButtonInput></div>
           </div>
+          <TextInput
+            name='datasetName'
+            label='Dataset Name'
+            type=''
+            value={datasetName}
+            onChange={handleChanges}
+            maxLength={600}
+            errorText={alreadyDatasetError}
+          />
           <div className='flex-space-between'>
             <TextInput
               name='path'

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -1,76 +1,42 @@
 import * as React from 'react'
 import { remote } from 'electron'
-import { CSSTransition } from 'react-transition-group'
 import Modal from './Modal'
 import { ApiAction } from '../../store/api'
 import TextInput from '../form/TextInput'
-import SelectInput from '../form/SelectInput'
 import Error from './Error'
 import Buttons from './Buttons'
 // import Tabs from './Tabs'
 import ButtonInput from '../form/ButtonInput'
 
-import { ISelectOption } from '../../models/forms'
-import { fetchMyDatasets } from '../../actions/api'
-
-const formatOptions: ISelectOption[] = [
-  { name: 'csv', value: 'csv' },
-  { name: 'json', value: 'json' },
-  { name: 'xlsx', value: 'xlsx' },
-  { name: 'cbor', value: 'cbor' }
-]
-
-enum TabTypes {
-  NewBody = 'Create new datafile',
-  ExistingBody = 'Use existing file',
-}
-
 interface CreateDatasetProps {
   onDismissed: () => void
   onSubmit: (path: string, name: string, format: string) => Promise<ApiAction>
-  setWorkingDataset: (peername: string, name: string, isLinked: boolean) => Promise<ApiAction>
+  setWorkingDataset: (peername: string, name: string, isLinked: boolean, published: boolean) => Promise<ApiAction>
   fetchMyDatasets: () => Promise<ApiAction>
 }
 
-const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismissed, onSubmit, setWorkingDataset }) => {
+// setWorkingDataset
+const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismissed, onSubmit, setWorkingDataset, fetchMyDatasets }) => {
   const [datasetName, setDatasetName] = React.useState('')
   const [path, setPath] = React.useState('')
-  const [bodyFormat, setBodyFormat] = React.useState(formatOptions[0].value)
-  const [bodyPath, setBodyPath] = React.useState('')
-
-  // remove until we can init from an existing bodyfile
-  // const [activeTab, setActiveTab] = React.useState(TabTypes.NewBody)
-  const activeTab = TabTypes.NewBody
+  const [filePath, setFilePath] = React.useState('')
 
   const [dismissable, setDismissable] = React.useState(true)
   const [buttonDisabled, setButtonDisabled] = React.useState(true)
   const [alreadyDatasetError, setAlreadyDatasetError] = React.useState('')
 
+  React.useEffect(() => {
+    // disable unless all fields have valid
+    const ready = path !== '' && filePath !== '' && datasetName !== ''
+    setButtonDisabled(!ready)
+  }, [datasetName, path, filePath])
+
   // should come from props
   const [error, setError] = React.useState('')
   const [loading, setLoading] = React.useState(false)
 
-  React.useEffect(() => {
-    toggleButton(activeTab)
-    if (error !== '') setError('')
-  }, [path, bodyFormat, bodyPath, datasetName, activeTab])
-
   // should come from props/actions that has us check if the directory already contains a qri dataset
   const isQriDataset = (path: string) => !path
-
-  // call this whenever we need to check if the button should be disabled
-  const toggleButton = (activeTab: TabTypes) => {
-    if (!(datasetName && path)) {
-      setButtonDisabled(true)
-      return
-    }
-    if ((activeTab === TabTypes.ExistingBody && bodyPath === '') ||
-        (activeTab === TabTypes.NewBody && bodyFormat === '')) {
-      setButtonDisabled(true)
-      return
-    }
-    setButtonDisabled(false)
-  }
 
   const showDirectoryPicker = () => {
     const window = remote.getCurrentWindow()
@@ -92,26 +58,27 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
     }
   }
 
-  //
-  // remove until we can init from an existing bodyfile
-  //
-  // const showFilePicker = () => {
-  //   const window = remote.getCurrentWindow()
-  //   const directory: string[] | undefined = remote.dialog.showOpenDialog(window, {
-  //     properties: ['createDirectory', 'openFile'],
-  //     filters: [{ name: 'Data', extensions: ['csv', 'json', 'xlsx', 'cbor'] }]
-  //   })
+  const showFilePicker = () => {
+    const window = remote.getCurrentWindow()
+    const filePath: string[] | undefined = remote.dialog.showOpenDialog(window, {
+      properties: ['openFile']
+    })
 
-  //   if (!directory) {
-  //     return
-  //   }
+    if (!filePath) {
+      return
+    }
 
-  //   const path = directory[0]
+    const path = filePath[0]
 
-  //   setBodyPath(path)
-  // }
+    setFilePath(path)
+    const isDataset = isQriDataset(path)
+    if (isDataset) {
+      setAlreadyDatasetError('A dataset already exists in this directory.')
+      setButtonDisabled(true)
+    }
+  }
 
-  const handlePickerDialog = (showFunc: () => void) => {
+  const handleFilePickerDialog = (showFunc: () => void) => {
     new Promise(resolve => {
       setDismissable(false)
       resolve()
@@ -120,110 +87,38 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
       .then(() => setDismissable(true))
   }
 
-  const renderCreateDataset = () => {
-    return (
-      <div className='margin-bottom'>
-        <TextInput
-          name='datasetName'
-          label='Dataset Name:'
-          type=''
-          value={datasetName}
-          onChange={handleChanges}
-          maxLength={300}
-        />
-        <div className='flex-space-between'>
-          <TextInput
-            name='path'
-            label='Local Path:'
-            type=''
-            value={path}
-            onChange={handleChanges}
-            maxLength={600}
-            errorText={alreadyDatasetError}
-          />
-          <div className='margin-left'><ButtonInput onClick={() => handlePickerDialog(showDirectoryPicker)} >Choose...</ButtonInput></div>
-        </div>
-      </div>
-    )
+  const handlePathPickerDialog = (showFunc: () => void) => {
+    new Promise(resolve => {
+      setDismissable(false)
+      resolve()
+    })
+      .then(() => showFunc())
+      .then(() => setDismissable(true))
   }
 
   const handleChanges = (name: string, value: any) => {
     if (value[value.length - 1] === ' ') {
       return
     }
-    if (name === 'datasetName') setDatasetName(value)
-    if (name === 'path') {
-      setPath(value)
+
+    if (name === 'datasetName') {
+      setDatasetName(value)
       setAlreadyDatasetError('')
     }
-    if (name === 'format') setBodyFormat(value)
-    if (name === 'bodyPath') setBodyPath(value)
   }
-
-  //
-  // remove until we can init on an existing bodyfile
-  //
-  // const renderTabs = () => {
-  //   return <Tabs tabs={[TabTypes.NewBody]} active={activeTab} onClick={(activeTab: TabTypes) => setActiveTab(activeTab)}/>
-  // }
-
-  const renderCreateNewBody = () =>
-    <CSSTransition
-      in={ activeTab === TabTypes.NewBody }
-      classNames="fade"
-      component="div"
-      timeout={300}
-      unmountOnExit
-    >
-      <div className='content'>
-        <SelectInput
-          name='format'
-          label='Choose format:'
-          options={formatOptions}
-          value={bodyFormat}
-          onChange={handleChanges}
-        />
-      </div>
-    </CSSTransition>
-
-  //
-  // remove until we can also init on an existing bodyfile
-  //
-  // const renderUseExistingBody = () =>
-  //   <CSSTransition
-  //     in={ activeTab === TabTypes.ExistingBody }
-  //     classNames="fade"
-  //     component="div"
-  //     timeout={300}
-  //     unmountOnExit
-  //   >
-  //     <div className='content flex-space-between'>
-  //       <TextInput
-  //         name='bodyPath'
-  //         label='Path to datafile:'
-  //         type=''
-  //         helpText='data file can be csv, json, xlsx, or cbor'
-  //         showHelpText
-  //         value={bodyPath}
-  //         onChange={handleChanges}
-  //         maxLength={600}
-  //       />
-  //       <div className='margin-left'><ButtonInput onClick={() => handlePickerDialog(showFilePicker)} >Choose...</ButtonInput></div>
-  //     </div>
-  //   </CSSTransition>
 
   const handleSubmit = () => {
     setDismissable(false)
     setLoading(true)
     error && setError('')
     if (!onSubmit) return
-    onSubmit(path, datasetName, bodyFormat)
-      .then(() => {
+    onSubmit(filePath, datasetName, `${path}/${datasetName}`)
+      .then(({ peername, name, isLinked, published }) => {
+        onDismissed()
+        setWorkingDataset(peername, name, isLinked, published)
         fetchMyDatasets()
-        setWorkingDataset('me', datasetName, true)
-          .then(onDismissed)
       })
-      .catch((action) => {
+      .catch((action: any) => {
         setLoading(false)
         setDismissable(true)
         setError(action.payload.err.message)
@@ -239,18 +134,50 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
       dismissable={dismissable}
       setDismissable={setDismissable}
     >
-      <div>
-        {renderCreateDataset()}
-        {/* remove tabs until we can also init on an existing body file */}
-        {/* <hr /> */}
-        {/* {renderTabs()} */}
-        <div id='create-dataset-content-wrap' className='content-wrap'>
-          {renderCreateNewBody()}
-          {/* remove until we can also init on an existing body file */}
-          {/* {renderUseExistingBody()} */}
+      <div className='content-wrap'>
+        <div className='content'>
+          <TextInput
+            name='datasetName'
+            label='Dataset Name'
+            type=''
+            value={datasetName}
+            onChange={handleChanges}
+            maxLength={600}
+            errorText={alreadyDatasetError}
+          />
+          <div className='flex-space-between'>
+            <TextInput
+              name='path'
+              label='Data file'
+              type=''
+              value={filePath}
+              onChange={handleChanges}
+              maxLength={600}
+              errorText={alreadyDatasetError}
+            />
+            <div className='margin-left'><ButtonInput onClick={() => handleFilePickerDialog(showFilePicker)} >Choose...</ButtonInput></div>
+          </div>
+          <div className='flex-space-between'>
+            <TextInput
+              name='path'
+              label='Save Path'
+              type=''
+              value={path}
+              onChange={handleChanges}
+              maxLength={600}
+              errorText={alreadyDatasetError}
+            />
+            <div className='margin-left'><ButtonInput onClick={() => handlePathPickerDialog(showDirectoryPicker)} >Choose...</ButtonInput></div>
+          </div>
         </div>
-        <Error text={error} />
       </div>
+
+      <p className='submit-message'>
+        {!buttonDisabled && (
+          <span>Qri will create the directory {path}/{datasetName} and import your data file</span>
+        )}
+      </p>
+      <Error text={error} />
       <Buttons
         cancelText='cancel'
         onCancel={onDismissed}

--- a/app/components/modals/Header.tsx
+++ b/app/components/modals/Header.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTimes } from '@fortawesome/free-solid-svg-icons'
+
 import Spinner from '../chrome/Spinner'
 
 // Mimicing React's DialogHeader
@@ -68,7 +71,7 @@ const DialogHeader: React.FunctionComponent<IDialogHeaderProps> = ({ onDismissed
         className="close"
         onClick={onCloseButtonClick}
         aria-label="close"
-        role="button" ><span className='icon'>close</span></a>
+        role="button" ><FontAwesomeIcon icon={faTimes} size='lg'/></a>
     )
   }
 

--- a/app/scss/_dataset-list.scss
+++ b/app/scss/_dataset-list.scss
@@ -6,28 +6,35 @@
 
     #controls {
       display: flex;
-      flex-direction: row;
+      flex-direction: column;
       padding-bottom: 6px;
 
       input {
         margin-right: 10px;
         flex: 1;
       }
-
-      #add-button {
-        align-self: flex-end;
-        cursor: pointer;
-        color: $primary;
-
-        &:hover {
-          color: $primary-dark;
-        }
-      }
     }
 
     .strong-message {
       font-weight: 500;
       font-size: 0.8rem;
+    }
+  }
+
+  #buttons {
+    display: flex;
+    justify-content: space-between;
+    border-bottom: $list-item-bottom-border;
+
+    .dataset-list-button {
+      flex: 1;
+      text-align: center;
+      border-right: $list-item-bottom-border;
+      padding: 4px;
+
+      &:last-child {
+        border-right: none;
+      }
     }
   }
 }

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -143,6 +143,7 @@ $header-font-size: .9rem;
       display: flex;
       justify-content: center;
       background-color: rgba(0,0,0,0.1);
+      user-select: none; 
     }
 
     &:hover {

--- a/app/scss/_dialog.scss
+++ b/app/scss/_dialog.scss
@@ -30,7 +30,6 @@ dialog {
     justify-content: space-between;
     align-items: center;
     padding: $spacer $spacer $spacer $spacer;
-    margin: 0 $spacer 0 $spacer * .5;
 
     h1 {
       font-weight: $font-weight-bold;
@@ -47,7 +46,7 @@ dialog {
       height: 18px;
       width: 18px;
 
-      margin: $spacer * -3 $spacer * -2 0 auto;
+      margin: $spacer * -1.5 $spacer * -1 0 auto;
       padding: 0;
       background: transparent;
 
@@ -79,15 +78,15 @@ dialog {
   // wrap all the views of content in a `.content-wrap` class
   // (if you want a different min-height, use an id)
   // then wrap each different view with the .content class
-  // set the CSSTransition `in` param to be true when 
+  // set the CSSTransition `in` param to be true when
   // the correct tab is active
   // as you click through the tabs, they will transition
   .content-wrap {
-    min-height: 300px; 
+    min-height: 300px;
     position: relative;
     display: flex;
     flex-direction: column;
-    
+
     .content {
       width: 100%;
       height: 100%;
@@ -150,7 +149,7 @@ dialog {
     width: 90%;
     margin-bottom: $spacer;
   }
-  
+
   .buttons {
     display: flex;
     justify-content: space-between;

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -24,10 +24,9 @@
 @import "compare";
 @import "stylesheet";
 
-@import "dataset-list";
-@import "saveform";
-
 @import "dataset";
+@import "saveform";
+@import "dataset-list";
 @import "welcome";
 @import "flex";
 @import "toast";


### PR DESCRIPTION
Refactors the Create Dataset Modal, prompts the user for an input file, dataset name, and path to create a linked directory.

Gives user feedback about what will happen when they click 'Create Dataset'

Pre-populates the dataset name with the filename minus its extension

![Qri_Desktop](https://user-images.githubusercontent.com/1833820/64287048-ada08680-cf2c-11e9-8f3f-e61355682db5.png)

Styles the add dataset button in the dataset list, adds a create dataset button.  Each fires its respective Modal.

![Fullscreen_9_4_19__3_53_PM](https://user-images.githubusercontent.com/1833820/64286966-7cc05180-cf2c-11e9-80b6-fb89e6920fa1.png)