### PR TITLE
fix(*): various bugs from tutorial walkthrough

### DIFF
--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -133,10 +133,8 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
         components.map(({ name, displayName, tooltip, icon }) => {
           if (status[name] && isLinked) {
             const { filepath, status: fileStatus } = status[name]
-            let filename
-            if (filepath === 'repo') {
-              filename = ''
-            } else {
+            let filename = ''
+            if (filepath !== 'repo') {
               filename = filepath.substring((filepath.lastIndexOf('/') + 1))
             }
 
@@ -159,11 +157,11 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
               const menuItems: MenuItemConstructorOptions[] = [
                 {
                   label: 'Open in Finder',
-                  click: () => { shell.showItemInFolder(`${linkpath}/${filepath}`) }
+                  click: () => { shell.showItemInFolder(`${linkpath}/${filename}`) }
                 },
                 {
                   label: 'Copy File Path',
-                  click: () => { clipboard.writeText(`${linkpath}/${filepath}`) }
+                  click: () => { clipboard.writeText(`${linkpath}/${filename}`) }
                 }
               ]
 

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -103,7 +103,7 @@ export default class Dataset extends React.Component<DatasetProps> {
       this.props.setActiveTab('history')
     })
 
-    ipcRenderer.on('show-datasets', () => {
+    ipcRenderer.on('toggle-dataset-list', () => {
       this.props.toggleDatasetList()
     })
 

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -11,6 +11,7 @@ import { Modal, ModalType } from '../models/modals'
 interface DatasetListProps {
   myDatasets: MyDatasets
   workingDataset: WorkingDataset
+  toggleDatasetList: () => Action
   setFilter: (filter: string) => Action
   setWorkingDataset: (peername: string, name: string, isLinked: boolean, published: boolean) => Action
   fetchMyDatasets: (page: number, pageSize: number) => Promise<AnyAction>
@@ -18,6 +19,23 @@ interface DatasetListProps {
 }
 
 export default class DatasetList extends React.Component<DatasetListProps> {
+  constructor (props: DatasetListProps) {
+    super(props)
+    this.handleEsc = this.handleEsc.bind(this)
+  }
+
+  handleEsc (e: KeyboardEvent) {
+    if (e.key === 'Escape') this.props.toggleDatasetList()
+  }
+
+  componentDidMount () {
+    document.addEventListener('keydown', this.handleEsc)
+  }
+
+  componentWillUnmount () {
+    document.removeEventListener('keydown', this.handleEsc)
+  }
+
   handleFilterChange (e: any) {
     const { setFilter } = this.props
     const filter = e.target.value

--- a/app/components/DatasetSidebar.tsx
+++ b/app/components/DatasetSidebar.tsx
@@ -86,13 +86,17 @@ const DatasetSidebar: React.FunctionComponent<DatasetSidebarProps> = ({
         >
           Status
         </div>
-        {!(history.pageInfo.error && history.pageInfo.error.includes('no history')) && <div
-          className={classNames('tab', { 'active': activeTab === 'history' })}
-          onClick={() => { onTabClick('history') }}
+        <div
+          className={classNames('tab', { 'active': activeTab === 'history', 'disabled': history.pageInfo.error && history.pageInfo.error.includes('no history') })}
+          onClick={() => {
+            if (!(history.pageInfo.error && history.pageInfo.error.includes('no history'))) {
+              onTabClick('history')
+            }
+          }}
           data-tip={path ? 'Explore older versions of this dataset' : 'This dataset has no previous versions'}
         >
           History
-        </div>}
+        </div>
       </div>
       <div id='content'>
         <CSSTransition

--- a/app/components/ParseError.tsx
+++ b/app/components/ParseError.tsx
@@ -15,7 +15,7 @@ const ParseError: React.FunctionComponent<ParseErrorProps> = ({ component, filen
     <div className={'message-container'}>
       <div>
         <h4>There are parsing errors in your {component}</h4>
-        <p>Fix the errors in your <strong>{filename}</strong> file to be able to view the file in Qri Desktop or to save a version of your dataset.</p>
+        <p>Fix the errors in your <strong>{filename}</strong> file to be able to view it in Qri Desktop.</p>
         <Button text="Show in Finder" color="primary" onClick={() => { shell.openItem(linkpath) }} />
       </div>
     </div>

--- a/app/containers/DatasetListContainer.tsx
+++ b/app/containers/DatasetListContainer.tsx
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { setFilter } from '../actions/myDatasets'
 import { fetchMyDatasets } from '../actions/api'
+import { toggleDatasetList } from '../actions/ui'
 import { setWorkingDataset } from '../actions/selections'
 import DatasetList from '../components/DatasetList'
 
@@ -21,6 +22,7 @@ const mapStateToProps = (state: any, ownProps: DatasetListContainerProps) => {
 }
 
 const actions = {
+  toggleDatasetList,
   setFilter,
   setWorkingDataset,
   fetchMyDatasets

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -237,11 +237,11 @@ app.on('ready', () =>
                 }
               },
               {
-                id: 'show-dataset-list',
-                label: 'Show Dataset List',
+                id: 'toggle-dataset-list',
+                label: 'Toggle Dataset List',
                 accelerator: 'Command+T',
                 click () {
-                  mainWindow.webContents.send('show-datasets')
+                  mainWindow.webContents.send('toggle-dataset-list')
                 }
               },
               {
@@ -366,6 +366,12 @@ app.on('ready', () =>
                 click: () => {
                   shell.openExternal('https://qri.io/contact/')
                 }
+              },
+              {
+                label: 'Chat with the community...',
+                click: () => {
+                  shell.openExternal('https://discord.gg/etap8Gb')
+                }
               }
             ]
           }
@@ -479,7 +485,7 @@ app.on('ready', () =>
           'add-dataset',
           'show-status',
           'show-history',
-          'show-dataset-list',
+          'toggle-dataset-list',
           'publish-unpublish-dataset',
           'view-on-qri-cloud',
           'open-working-directory'


### PR DESCRIPTION
Added event listener to DatasetList
Refactors app menu to include link to discord & renames "Show Dataset List" to "Toggle Dataset List"
Adds back history tab even if dataset has no history. Tab is disabled and formatted differently.
`Open in finder` bug fixed

closes #173 
closes #176 
closes #170 
closes #171