### PR TITLE
fix(selection): when we signin/signup, clear the selection

### DIFF
--- a/app/actions/selections.ts
+++ b/app/actions/selections.ts
@@ -1,7 +1,8 @@
 import {
   SELECTIONS_SET_ACTIVE_TAB,
   SELECTIONS_SET_SELECTED_LISTITEM,
-  SELECTIONS_SET_WORKING_DATASET
+  SELECTIONS_SET_WORKING_DATASET,
+  SELECTIONS_CLEAR
 } from '../reducers/selections'
 
 export const setActiveTab = (activeTab: string) => {
@@ -30,5 +31,11 @@ export const setWorkingDataset = (peername: string, name: string, isLinked: bool
       isLinked,
       published
     }
+  }
+}
+
+export const clearSelection = () => {
+  return {
+    type: SELECTIONS_CLEAR
   }
 }

--- a/app/components/Signin.tsx
+++ b/app/components/Signin.tsx
@@ -11,7 +11,7 @@ import { validateUsername, validatePassword } from '../utils/formValidation'
 
 export interface SigninProps {
   signin: (username: string, password: string) => Promise<ApiAction>
-  onSuccess: () => Action
+  onSuccess: () => Action | void
 }
 
 const Signin: React.FunctionComponent<SigninProps> = (props: SigninProps) => {
@@ -47,6 +47,10 @@ const Signin: React.FunctionComponent<SigninProps> = (props: SigninProps) => {
   const handleChange = (name: string, value: any) => {
     if (name === 'username') setUsername(value)
     if (name === 'password') setPassword(value)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && acceptEnabled) handleSave()
   }
 
   const handleSave = async () => {
@@ -95,7 +99,8 @@ const Signin: React.FunctionComponent<SigninProps> = (props: SigninProps) => {
           maxLength={100}
           value={password}
           errorText={passwordError}
-          onChange={handleChange} />
+          onChange={handleChange}
+          onKeyDown={handleKeyDown} />
         <div className = 'error'> { serverError } </div>
       </div>
     </WelcomeTemplate>

--- a/app/components/Signup.tsx
+++ b/app/components/Signup.tsx
@@ -11,7 +11,7 @@ import { validateUsername, validateEmail, validatePassword } from '../utils/form
 
 export interface SignupProps {
   signup: (username: string, email: string, password: string) => Promise<ApiAction>
-  onSuccess: () => Action
+  onSuccess: () => Action | void
 }
 
 const Signup: React.FunctionComponent<SignupProps> = (props: SignupProps) => {

--- a/app/components/form/DebouncedTextInput.tsx
+++ b/app/components/form/DebouncedTextInput.tsx
@@ -7,7 +7,7 @@ interface DebouncedTextInputProps extends TextInputProps {
 }
 
 const DebouncedTextInput: React.FunctionComponent<DebouncedTextInputProps> = ({ debounceTimer = 500, ...props }) => {
-  const { value, name, onChange } = props
+  const { value, name, onChange, onKeyDown } = props
 
   const [internalValue, setInternalValue] = React.useState(value)
   const [debouncedValue] = useDebounce(internalValue, debounceTimer)
@@ -23,6 +23,7 @@ const DebouncedTextInput: React.FunctionComponent<DebouncedTextInputProps> = ({ 
       {...props}
       value={internalValue}
       onChange={handleChange}
+      onKeyDown={onKeyDown}
     />
   )
 }

--- a/app/components/form/TextInput.tsx
+++ b/app/components/form/TextInput.tsx
@@ -9,12 +9,13 @@ export interface TextInputProps {
   errorText?: string
   helpText?: string
   showHelpText?: boolean
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void | undefined
   onChange: (name: string, value: any) => void
   placeHolder?: string
   white?: boolean
 }
 
-const TextInput: React.FunctionComponent<TextInputProps> = ({ label, name, type, value, maxLength, errorText, helpText, showHelpText, onChange, placeHolder
+const TextInput: React.FunctionComponent<TextInputProps> = ({ label, name, type, value, maxLength, errorText, helpText, showHelpText, onChange, onKeyDown, placeHolder
 }) => {
   const feedbackColor = errorText ? 'error' : showHelpText && helpText ? 'textMuted' : ''
   const feedback = errorText || (showHelpText &&
@@ -33,6 +34,7 @@ const TextInput: React.FunctionComponent<TextInputProps> = ({ label, name, type,
           value={value || ''}
           placeholder={placeHolder}
           onChange={(e) => { onChange(name, e.target.value) }}
+          onKeyDown={onKeyDown}
         />
         <div style={{ height: 20 }}>
           <h6 style={{ textAlign: 'left', margin: 3 }} className={feedbackColor} >{feedback || ''}</h6>

--- a/app/containers/RoutesContainer.tsx
+++ b/app/containers/RoutesContainer.tsx
@@ -8,13 +8,22 @@ import {
   setModal
 } from '../actions/ui'
 
+import {
+  clearSelection,
+  setWorkingDataset
+} from '../actions/selections'
+
 import { signup, signin } from '../actions/session'
 
 const mapStateToProps = (state: Store) => {
   const { ui, myDatasets } = state
   const hasDatasets = myDatasets.value.length !== 0
+  // if we clear the selection, we still need a default dataset to display.
+  // let's always use the first dataset in the list, for now
+  const firstDataset = hasDatasets && myDatasets.value[0]
   const { qriCloudAuthenticated, hasAcceptedTOS } = ui
   return {
+    firstDataset,
     qriCloudAuthenticated,
     hasAcceptedTOS,
     hasDatasets
@@ -26,5 +35,7 @@ export default connect(mapStateToProps, {
   signin,
   acceptTOS,
   setQriCloudAuthenticated,
+  clearSelection,
+  setWorkingDataset,
   setModal
 })(Routes)

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -6,6 +6,7 @@ import { apiActionTypes } from '../store/api'
 export const SELECTIONS_SET_ACTIVE_TAB = 'SELECTIONS_SET_ACTIVE_TAB'
 export const SELECTIONS_SET_SELECTED_LISTITEM = 'SELECTIONS_SET_SELECTED_LISTITEM'
 export const SELECTIONS_SET_WORKING_DATASET = 'SELECTIONS_SET_WORKING_DATASET'
+export const SELECTIONS_CLEAR = 'SELECTIONS_CLEAR'
 
 const initialState: Selections = {
   peername: localStore().getItem('peername') || '',
@@ -23,6 +24,25 @@ const [, ADD_SUCC] = apiActionTypes('add')
 
 export default (state = initialState, action: AnyAction) => {
   switch (action.type) {
+    case SELECTIONS_CLEAR:
+      localStore().setItem('peername', '')
+      localStore().setItem('name', '')
+      localStore().setItem('isLinked', 'false')
+      localStore().setItem('published', 'false')
+      localStore().setItem('activeTab', 'status')
+      localStore().setItem('component', '')
+      localStore().setItem('commit', '')
+      localStore().setItem('commitComponent', '')
+      return {
+        peername: '',
+        name: '',
+        isLinked: false,
+        published: false,
+        activeTab: 'status',
+        component: '',
+        commit: '',
+        commitComponent: ''
+      }
     case SELECTIONS_SET_ACTIVE_TAB:
       const { activeTab } = action.payload
       localStore().setItem('activeTab', activeTab)

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -8,6 +8,7 @@ import DatasetContainer from './containers/DatasetContainer'
 
 export default function Routes (props: any) {
   const {
+    firstDataset,
     hasAcceptedTOS,
     qriCloudAuthenticated,
     hasDatasets,
@@ -15,8 +16,24 @@ export default function Routes (props: any) {
     acceptTOS,
     signup,
     signin,
+    setWorkingDataset,
+    clearSelection,
     setModal
   } = props
+
+  // TODO (ramfox): create a new action that does all this
+  // also, we should wait until a user has been authorized before
+  // fetching any datasets
+  const onSuccess = () => {
+    new Promise(resolve => {
+      clearSelection()
+      resolve()
+    })
+      .then(async () => {
+        if (firstDataset) setWorkingDataset(firstDataset.peername, firstDataset.name, firstDataset.isLinked, firstDataset.published)
+      })
+      .then(async () => setQriCloudAuthenticated())
+  }
 
   return (
     <Switch>
@@ -32,14 +49,14 @@ export default function Routes (props: any) {
         <Route exact path='/signup' render={() => {
           if (!hasAcceptedTOS) return <Redirect to='/' />
           if (qriCloudAuthenticated) return <Redirect to='/dataset' />
-          return <Signup signup={signup} onSuccess={setQriCloudAuthenticated} />
+          return <Signup signup={signup} onSuccess={onSuccess} />
         }} />
 
         {/* Sign In */}
         <Route exact path='/signin' render={() => {
           if (!hasAcceptedTOS) return <Redirect to='/' />
           if (qriCloudAuthenticated) return <Redirect to='/dataset' />
-          return <Signin signin={signin} onSuccess={setQriCloudAuthenticated} />
+          return <Signin signin={signin} onSuccess={onSuccess} />
         }} />
 
         {/* Dataset */}


### PR DESCRIPTION
This should be refactored and thought through a bit more.

The first issue: we should be waiting for authorization before fetching a user's datasets.

This commit also adds pressing `enter` while in the password field to continue on signin (but only if we are in a state to submit)

closes #166 
closes #167 