### PR TITLE
feat: init dataset

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -289,14 +289,14 @@ export function fetchWorkingHistory (page: number = 1, pageSize: number = pageSi
 
 export function fetchWorkingStatus (): ApiActionThunk {
   return async (dispatch, getState) => {
-    const { selections } = getState()
-    const { peername, name, isLinked } = selections
+    const { workingDataset } = getState()
+    const { peername, name, linkpath } = workingDataset
     const action = {
       type: 'status',
       [CALL_API]: {
         endpoint: 'status',
         method: 'GET',
-        params: { fsi: isLinked },
+        params: { fsi: linkpath !== '' },
         segments: {
           peername: peername,
           name: name
@@ -448,7 +448,7 @@ export function addDatasetAndFetch (peername: string, name: string): ApiActionTh
   }
 }
 
-export function initDataset (filepath: string, name: string, dir: string): ApiActionThunk {
+export function initDataset (sourcebodypath: string, name: string, dir: string, mkdir: string): ApiActionThunk {
   return async (dispatch) => {
     const action = {
       type: 'init',
@@ -456,9 +456,10 @@ export function initDataset (filepath: string, name: string, dir: string): ApiAc
         endpoint: 'init/',
         method: 'POST',
         params: {
-          filepath,
+          sourcebodypath,
           name,
-          dir
+          dir,
+          mkdir
         }
       }
     }
@@ -466,13 +467,13 @@ export function initDataset (filepath: string, name: string, dir: string): ApiAc
   }
 }
 
-export function initDatasetAndFetch (filepath: string, name: string, format: string): ApiActionThunk {
+export function initDatasetAndFetch (sourcebodypath: string, name: string, dir: string, mkdir: string): ApiActionThunk {
   return async (dispatch, getState) => {
     const whenOk = chainSuccess(dispatch, getState)
     let response: Action
 
     try {
-      response = await initDataset(filepath, name, format)(dispatch, getState)
+      response = await initDataset(sourcebodypath, name, dir, mkdir)(dispatch, getState)
       response = await whenOk(fetchMyDatasets())(response)
     } catch (action) {
       throw action
@@ -595,5 +596,22 @@ export function discardChanges (component: ComponentType): ApiActionThunk {
       throw action
     }
     return response
+  }
+}
+
+export function removeDataset (peername: string, name: string): ApiActionThunk {
+  return async (dispatch) => {
+    const action = {
+      type: 'add',
+      [CALL_API]: {
+        endpoint: 'add',
+        method: 'POST',
+        segments: {
+          peername,
+          name
+        }
+      }
+    }
+    return dispatch(action)
   }
 }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -128,7 +128,6 @@ export default class App extends React.Component<AppProps, AppState> {
             onSubmit={this.props.initDataset}
             onDismissed={async () => setModal(NoModal)}
             setWorkingDataset={this.props.setWorkingDataset}
-            fetchMyDatasets={this.props.fetchMyDatasets}
           />
         </CSSTransition>
         <CSSTransition

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Action } from 'redux'
+import * as _ from 'underscore'
 import classNames from 'classnames'
 import ReactTooltip from 'react-tooltip'
 import { remote, ipcRenderer, shell } from 'electron'
@@ -160,22 +161,26 @@ export default class Dataset extends React.Component<DatasetProps> {
       }
     }
 
-    // make sure that the component we are trying to show actually exists in this version of the dataset
-    // TODO (ramfox): there is a bug here when we try to switch to body, but body hasn't finished fetching yet
-    // this will prematurely decide to switch away from body.
-    if ((workingDatasetIsLoading && !nextProps.workingDataset.isLoading && nextProps.selections.activeTab === 'status') ||
-        (activeTab === 'history' && nextProps.selections.activeTab === 'status')) {
-      const { workingDataset, selections, setSelectedListItem } = nextProps
-      const { component } = selections
-      const { status } = workingDataset
-      if (component === '' || !status[component]) {
-        if (status['meta']) {
-          setSelectedListItem('component', 'meta')
+    if (!_.isEmpty(nextProps.workingDataset.status)) {
+      // make sure that the component we are trying to show actually exists in this version of the dataset
+      // TODO (ramfox): there is a bug here when we try to switch to body, but body hasn't finished fetching yet
+      // this will prematurely decide to switch away from body.
+      if ((workingDatasetIsLoading && !nextProps.workingDataset.isLoading && nextProps.selections.activeTab === 'status') ||
+          (activeTab === 'history' && nextProps.selections.activeTab === 'status')) {
+        const { workingDataset, selections, setSelectedListItem } = nextProps
+        const { component } = selections
+        const { status } = workingDataset
+        console.log('STATUS', status)
+        if (component === '' || !status[component]) {
+          if (status['meta']) {
+            setSelectedListItem('component', 'meta')
+          }
+          if (status['body']) {
+            setSelectedListItem('component', 'body')
+          }
+          console.log('HERE')
+          setSelectedListItem('component', 'schema')
         }
-        if (status['body']) {
-          setSelectedListItem('component', 'body')
-        }
-        setSelectedListItem('component', 'schema')
       }
     }
 

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -170,7 +170,6 @@ export default class Dataset extends React.Component<DatasetProps> {
         const { workingDataset, selections, setSelectedListItem } = nextProps
         const { component } = selections
         const { status } = workingDataset
-        console.log('STATUS', status)
         if (component === '' || !status[component]) {
           if (status['meta']) {
             setSelectedListItem('component', 'meta')
@@ -178,7 +177,6 @@ export default class Dataset extends React.Component<DatasetProps> {
           if (status['body']) {
             setSelectedListItem('component', 'body')
           }
-          console.log('HERE')
           setSelectedListItem('component', 'schema')
         }
       }

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -7,16 +7,16 @@ import Error from './Error'
 import Buttons from './Buttons'
 // import Tabs from './Tabs'
 import ButtonInput from '../form/ButtonInput'
+import { DatasetSummary } from '../../models/store'
 
 interface CreateDatasetProps {
   onDismissed: () => void
-  onSubmit: (path: string, name: string, format: string) => Promise<ApiAction>
+  onSubmit: (path: string, name: string, dir: string, mkdir: string) => Promise<ApiAction>
   setWorkingDataset: (peername: string, name: string, isLinked: boolean, published: boolean) => Promise<ApiAction>
-  fetchMyDatasets: () => Promise<ApiAction>
 }
 
 // setWorkingDataset
-const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismissed, onSubmit, setWorkingDataset, fetchMyDatasets }) => {
+const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismissed, onSubmit, setWorkingDataset }) => {
   const [datasetName, setDatasetName] = React.useState('')
   const [path, setPath] = React.useState('')
   const [filePath, setFilePath] = React.useState('')
@@ -117,11 +117,13 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
     setLoading(true)
     error && setError('')
     if (!onSubmit) return
-    onSubmit(filePath, datasetName, `${path}/${datasetName}`)
-      .then(({ peername, name, isLinked, published }) => {
+    onSubmit(filePath, datasetName, path, datasetName)
+      .then(({ payload }) => {
+        const { data } = payload
+        // make sure the dataset we just added is in the list
+        const { peername, name, fsipath, published } = data.find((dataset: DatasetSummary) => dataset.name === datasetName)
+        setWorkingDataset(peername, name, fsipath !== '', published)
         onDismissed()
-        setWorkingDataset(peername, name, isLinked, published)
-        fetchMyDatasets()
       })
       .catch((action: any) => {
         setLoading(false)

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -65,12 +65,12 @@ export default (state = initialState, action: AnyAction) => {
       // if there is no peername + name in selections, use the first one on the list
       if (state.peername === '' && state.name === '') {
         if (action.payload.data.length === 0) return state
-        const { peername: firstPeername, name: firstName, isLinked: firstIsLinked, published } = action.payload.data[0]
+        const { peername: firstPeername, name: firstName, fsipath: firstIsLinked, published } = action.payload.data[0]
         localStore().setItem('peername', firstPeername)
         localStore().setItem('name', firstName)
-        localStore().setItem('isLinked', firstIsLinked)
+        localStore().setItem('isLinked', JSON.stringify(!!firstIsLinked))
         localStore().setItem('published', published)
-        return Object.assign({}, state, { peername: firstPeername, name: firstName, isLinked: firstIsLinked, published })
+        return Object.assign({}, state, { peername: firstPeername, name: firstName, fsipath: firstIsLinked, published })
       } else {
         return state
       }

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -161,6 +161,13 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
       }
     case DATASET_BODY_SUCC:
       const fetchedAll = action.payload.data.data.length < state.components.body.pageInfo.pageSize
+
+      if (action.payload.request.pageInfo) {
+        if (action.payload.request.pageInfo.page <= state.components.body.pageInfo.page) {
+          return state
+        }
+      }
+
       return {
         ...state,
         components: {

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -213,7 +213,11 @@ export const apiMiddleware: Middleware = () => (next: Dispatch<AnyAction>) => as
     return next({
       type: SUCC_TYPE,
       payload: {
-        data: map(data.data)
+        data: map(data.data),
+        request: {
+          params,
+          pageInfo
+        }
       }
     })
   }


### PR DESCRIPTION
Updates Create Dataset Modal to work with changes in [qri#913](https://github.com/qri-io/qri/pull/913) (Closes #141)

User provides input file, dataset name, path to create linked directory.  On submit, they arrive at the Dataset view looking at a new dataset