### PR TITLE
fix: add production html to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "files": [
       "dist/",
       "node_modules/",
-      "app.html",
+      "app.production.html",
       "main.js",
       "main.js.map",
       "package.json"


### PR DESCRIPTION
Adds the correct html file to `files` in `package.json`, fixing the 'Not allowed to load local resource' error we were seeing on the production build