### PR TITLE
Various fixes and refactoring

### DIFF
--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import moment from 'moment'
-import { Resizable } from '../components/Resizable'
 import { Action } from 'redux'
 import ComponentList from '../components/ComponentList'
 import DatasetComponent from './DatasetComponent'
@@ -9,8 +8,6 @@ import SpinnerWithIcon from './chrome/SpinnerWithIcon'
 import { ApiAction } from '../store/api'
 import { Commit } from '../models/dataset'
 import { CommitDetails as ICommitDetails, ComponentType } from '../models/Store'
-
-import { defaultSidebarWidth } from '../reducers/ui'
 
 export interface CommitDetailsProps {
   peername: string
@@ -39,9 +36,7 @@ const CommitDetails: React.FunctionComponent<CommitDetailsProps> = ({
   selectedCommitPath,
   commit,
   selectedComponent,
-  sidebarWidth,
   setSelectedListItem,
-  setSidebarWidth,
   fetchCommitDetail,
   commitDetails
 }) => {
@@ -119,12 +114,8 @@ const CommitDetails: React.FunctionComponent<CommitDetailsProps> = ({
             </div>
           </div>
           <div className='columns'>
-            <Resizable
-              id='sidebar'
-              width={sidebarWidth}
-              onResize={(width) => { setSidebarWidth('commit', width) }}
-              onReset={() => { setSidebarWidth('commit', defaultSidebarWidth) }}
-              maximumWidth={348}
+            <div
+              className='commit-details-sidebar sidebar'
             >
               <ComponentList
                 status={status}
@@ -133,7 +124,7 @@ const CommitDetails: React.FunctionComponent<CommitDetailsProps> = ({
                 onComponentClick={setSelectedListItem}
                 isLinked
               />
-            </Resizable>
+            </div>
             <div className='content-wrapper'>
               <DatasetComponent isLoading={loading} component={selectedComponent} componentStatus={status[selectedComponent]} history />
             </div>

--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -133,8 +133,11 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
         components.map(({ name, displayName, tooltip, icon }) => {
           if (status[name] && isLinked) {
             const { filepath, status: fileStatus } = status[name]
+
+            // if filepath is the same as the component name, we are looking at a
+            // a commit's component, and should not render a filename
             let filename = ''
-            if (filepath !== 'repo') {
+            if (filepath !== name) {
               filename = filepath.substring((filepath.lastIndexOf('/') + 1))
             }
 

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -219,6 +219,7 @@ export default class Dataset extends React.Component<DatasetProps> {
     const { peername: username, photo: userphoto } = session
     const { showDatasetList, datasetSidebarWidth } = ui
     const {
+      peername,
       name,
       activeTab,
       component: selectedComponent,
@@ -245,7 +246,6 @@ export default class Dataset extends React.Component<DatasetProps> {
     const linkButton = isLinked ? (
       <HeaderColumnButton
         icon={faFolderOpen}
-        tooltip={`Open ${workingDataset.linkpath}`}
         label='Show Files'
         onClick={this.openWorkingDirectory}
       />) : (
@@ -293,7 +293,6 @@ export default class Dataset extends React.Component<DatasetProps> {
           <div className='header-left'>
             <div
               className={classNames('current-dataset', 'header-column', 'sidebar-list-item', { 'expanded': showDatasetList })}
-              data-tip={`${workingDataset.peername}/${workingDataset.name}`}
               onClick={toggleDatasetList}
               style={{ width: datasetSidebarWidth }}
             >
@@ -302,7 +301,7 @@ export default class Dataset extends React.Component<DatasetProps> {
               </div>
               <div className='header-column-text'>
                 <div className="label">{name ? 'Current Dataset' : 'Choose a Dataset'}</div>
-                <div className="name">{name}</div>
+                <div className="name">{peername}/{name}</div>
               </div>
               <div className='header-column-arrow'>
                 {

--- a/app/components/form/TextInput.tsx
+++ b/app/components/form/TextInput.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 
 export interface TextInputProps {
   label?: string
+  labelTooltip?: string
   name: string
   type: string
   value: any
@@ -15,8 +18,22 @@ export interface TextInputProps {
   white?: boolean
 }
 
-const TextInput: React.FunctionComponent<TextInputProps> = ({ label, name, type, value, maxLength, errorText, helpText, showHelpText, onChange, onKeyDown, placeHolder
-}) => {
+const TextInput: React.FunctionComponent<TextInputProps> = (props) => {
+  const {
+    label,
+    labelTooltip,
+    name,
+    type,
+    value,
+    maxLength,
+    errorText,
+    helpText,
+    showHelpText,
+    onChange,
+    onKeyDown,
+    placeHolder
+  } = props
+
   const feedbackColor = errorText ? 'error' : showHelpText && helpText ? 'textMuted' : ''
   const feedback = errorText || (showHelpText &&
     helpText)
@@ -24,7 +41,16 @@ const TextInput: React.FunctionComponent<TextInputProps> = ({ label, name, type,
   return (
     <>
       <div className='text-input-container'>
-        {label && <span className={labelColor}>{label}</span>}
+        {label && <><span className={labelColor}>{label}</span>&nbsp;&nbsp;</>}
+        {labelTooltip && (
+          <span
+            data-tip={labelTooltip}
+            data-for={'modal-tooltip'}
+            className='text-input-tooltip'
+          >
+            <FontAwesomeIcon icon={faInfoCircle} size='sm'/>
+          </span>
+        )}
         <input
           id={name}
           name={name}

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -8,6 +8,7 @@ import Buttons from './Buttons'
 // import Tabs from './Tabs'
 import ButtonInput from '../form/ButtonInput'
 import { DatasetSummary } from '../../models/store'
+import { validateDatasetName } from '../../utils/formValidation'
 
 interface CreateDatasetProps {
   onDismissed: () => void
@@ -23,11 +24,16 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
 
   const [dismissable, setDismissable] = React.useState(true)
   const [buttonDisabled, setButtonDisabled] = React.useState(true)
+  const [datasetNameError, setDatasetNameError] = React.useState('')
   const [alreadyDatasetError, setAlreadyDatasetError] = React.useState('')
 
   React.useEffect(() => {
-    // disable unless all fields have valid
-    const ready = path !== '' && filePath !== '' && datasetName !== ''
+    // validate datasetName and assign error
+    const datasetNameValidationError = validateDatasetName(datasetName)
+    datasetNameValidationError ? setDatasetNameError(datasetNameValidationError) : setDatasetNameError('')
+
+    // only ready when all three fields are not invalid
+    const ready = path !== '' && filePath !== '' && !datasetNameValidationError
     setButtonDisabled(!ready)
   }, [datasetName, path, filePath])
 
@@ -162,7 +168,7 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
             value={datasetName}
             onChange={handleChanges}
             maxLength={600}
-            errorText={alreadyDatasetError}
+            errorText={datasetNameError}
           />
           <div className='flex-space-between'>
             <TextInput

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { remote } from 'electron'
+
 import Modal from './Modal'
+import ExternalLink from '../ExternalLink'
 import { ApiAction } from '../../store/api'
 import TextInput from '../form/TextInput'
 import Error from './Error'
@@ -147,12 +149,15 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
       dismissable={dismissable}
       setDismissable={setDismissable}
     >
-      <div className='content-wrap'>
+      <div className='content-wrap' >
         <div className='content'>
+          <p>Qri will create a directory for your new dataset, containing files linked to each of the dataset&apos;s <ExternalLink href='https://qri.io/docs/concepts/dataset/'>components</ExternalLink>.</p>
+          <p>The data file you specify will become your new dataset&apos;s <ExternalLink href='https://qri.io/docs/reference/dataset/#body'>body</ExternalLink> component.</p>
           <div className='flex-space-between'>
             <TextInput
               name='path'
-              label='Data file'
+              label='Source data file'
+              labelTooltip='Select a CSV or JSON file on your file system.<br/>Qri will import the data and leave the file in place.'
               type=''
               value={filePath}
               onChange={handleChanges}
@@ -163,7 +168,8 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
           </div>
           <TextInput
             name='datasetName'
-            label='Dataset Name'
+            label='Name'
+            labelTooltip='Name will be the primary<br/> way to refer to your dataset.'
             type=''
             value={datasetName}
             onChange={handleChanges}
@@ -173,7 +179,8 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
           <div className='flex-space-between'>
             <TextInput
               name='path'
-              label='Save Path'
+              label='Directory path'
+              labelTooltip='Qri will create a new directory for<br/>this dataset&apos;s files at this location.'
               type=''
               value={path}
               onChange={handleChanges}

--- a/app/components/modals/Modal.tsx
+++ b/app/components/modals/Modal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import classNames from 'classnames'
 import ModalHeader from './header'
+import ReactTooltip from 'react-tooltip'
 
 /**
  * Title bar height in pixels. Values taken from 'app/styles/_variables.scss'.
@@ -224,6 +225,11 @@ const Modal: React.FunctionComponent<ModalProps> = ({ title, dismissable = false
     className
   )
 
+  // we are rendering a second instance of ReactTooltip here because the modal
+  // is displayed in a <dialog> element, which always wants to live above the
+  // rest of the page. To add tooltips in a modal, add data-tip='string' and
+  // data-for='modal-tooltip' (the id of the ReactTooltip instance)
+
   return (
     <dialog
       open={false}
@@ -238,6 +244,14 @@ const Modal: React.FunctionComponent<ModalProps> = ({ title, dismissable = false
           {children}
         </fieldset>
       </form>
+      <ReactTooltip
+        id='modal-tooltip'
+        place='top'
+        type='dark'
+        effect='solid'
+        delayShow={500}
+        multiline
+      />
     </dialog>
   )
 }

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -158,7 +158,7 @@ app.on('ready', () =>
                 label: 'Quit Qri Desktop',
                 accelerator: 'Command+Q',
                 click () {
-                  quitting = true; app.quit()
+                  app.quit()
                 }
               }
             ]
@@ -507,5 +507,9 @@ app.on('ready', () =>
 
       app.on('activate', () => {
         mainWindow.show()
+      })
+
+      app.on('before-quit', () => {
+        quitting = true
       })
     }))

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -66,12 +66,13 @@ export default (state = initialState, action: AnyAction) => {
 
     case SELECTIONS_SET_WORKING_DATASET:
       const { peername, name, isLinked, published } = action.payload
+      const newActiveTab = isLinked ? 'status' : 'history'
+
       localStore().setItem('peername', peername)
       localStore().setItem('name', name)
       localStore().setItem('isLinked', isLinked)
       localStore().setItem('published', published)
-
-      const newActiveTab = isLinked ? 'status' : 'history'
+      localStore().setItem('activeTab', newActiveTab)
 
       return Object.assign({}, state, {
         peername,

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -143,7 +143,7 @@ $header-font-size: .9rem;
       display: flex;
       justify-content: center;
       background-color: rgba(0,0,0,0.1);
-      user-select: none; 
+      user-select: none;
     }
 
     &:hover {
@@ -194,7 +194,7 @@ $header-font-size: .9rem;
     overflow-y: auto;
     height: 100%;
 
-    #sidebar {
+    #sidebar, .sidebar {
       position: relative;
       flex: 0 0 auto;
       border-right: 1px solid $border-color;
@@ -319,7 +319,6 @@ $header-font-size: .9rem;
       white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
-      line-height: 1.6rem;
     }
 
     .subtext {
@@ -404,6 +403,7 @@ $header-font-size: .9rem;
 .sidebar-list-item {
   border-bottom: $list-item-bottom-border;
   display: flex;
+  align-items: center;
 }
 
 .sidebar-list-header  {
@@ -426,7 +426,6 @@ $header-font-size: .9rem;
 
   .status-column {
     text-align: center;
-    line-height: 2.9rem;
     width: 30px;
   }
 
@@ -472,6 +471,10 @@ $header-font-size: .9rem;
     height: 60px;
     padding: $sidebar-item-padding;
     border-bottom: $list-item-bottom-border;
+  }
+
+  .commit-details-sidebar {
+    width: 200px;
   }
 }
 

--- a/app/scss/_forms.scss
+++ b/app/scss/_forms.scss
@@ -497,11 +497,11 @@ button.input {
   -o-transition: all .2s ease-in;
   -webkit-transition: all .2s ease-in;
   transition: all .2s ease-in;
-  color: $primary-muted;
+  color: $primary;
   border: none;
   cursor: pointer;
   &:hover {
-    color: $primary;
+    color: $primary-dark;
   }
 }
 

--- a/app/scss/_welcome.scss
+++ b/app/scss/_welcome.scss
@@ -91,3 +91,11 @@
 .text-input-container {
   width: 100%
 }
+
+.text-input-tooltip {
+  svg {
+    path {
+      fill: #c1c1c1;
+    }
+  }
+}

--- a/app/utils/formValidation.ts
+++ b/app/utils/formValidation.ts
@@ -1,40 +1,50 @@
 type ValidationError = string | null
 
+export const ERR_INVALID_USERNAME_CHARACTERS: ValidationError = 'Usernames may only include a-z, 0-9, _ , and -'
+export const ERR_INVALID_USERNAME_LENGTH: ValidationError = 'Username must be 50 characters or fewer'
+
 // validators return an error message or null
 export const validateUsername = (username: string): ValidationError => {
   if (username) {
     const invalidCharacters = !(/^[a-z0-9_-]+$/.test(username))
-    if (invalidCharacters) return 'Usernames may only include a-z, 0-9, _ , and -'
+    if (invalidCharacters) return ERR_INVALID_USERNAME_CHARACTERS
 
     const tooLong = username.length > 50
-    if (tooLong) return 'Username must be 50 characters or less'
+    if (tooLong) return ERR_INVALID_USERNAME_LENGTH
   }
   return null
 }
+
+export const ERR_INVALID_EMAIL: ValidationError = 'Enter a valid email address'
 
 export const validateEmail = (email: string): ValidationError => {
   if (email) {
     const invalidEmail = !(/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
-    if (invalidEmail) return 'Enter a valid email address'
+    if (invalidEmail) return ERR_INVALID_EMAIL
   }
   return null
 }
+
+export const ERR_INVALID_PASSWORD_LENGTH: ValidationError = 'Password must be at least 8 characters'
 
 export const validatePassword = (password: string) => {
   if (password) {
     const tooShort = password && password.length < 8
-    if (tooShort) return 'Password must be at least 8 characters'
+    if (tooShort) return ERR_INVALID_PASSWORD_LENGTH
   }
   return null
 }
 
+export const ERR_INVALID_DATASETNAME_CHARACTERS: ValidationError = 'Dataset names may only include a-z, 0-9, and _'
+export const ERR_INVALID_DATASETNAME_LENGTH: ValidationError = 'Username must be 100 characters or fewer'
+
 export const validateDatasetName = (name: string): ValidationError => {
   if (name) {
     const invalidCharacters = !(/^[a-z0-9_]+$/.test(name))
-    if (invalidCharacters) return 'Dataset names may only include a-z, 0-9, and _'
+    if (invalidCharacters) return ERR_INVALID_DATASETNAME_CHARACTERS
 
     const tooLong = name.length > 100
-    if (tooLong) return 'Username must be 100 characters or fewer'
+    if (tooLong) return ERR_INVALID_DATASETNAME_LENGTH
   }
   return null
 }

--- a/app/utils/formValidation.ts
+++ b/app/utils/formValidation.ts
@@ -27,3 +27,14 @@ export const validatePassword = (password: string) => {
   }
   return null
 }
+
+export const validateDatasetName = (name: string): ValidationError => {
+  if (name) {
+    const invalidCharacters = !(/^[a-z0-9_]+$/.test(name))
+    if (invalidCharacters) return 'Dataset names may only include a-z, 0-9, and _'
+
+    const tooLong = name.length > 100
+    if (tooLong) return 'Username must be 100 characters or fewer'
+  }
+  return null
+}

--- a/test/app/utils/formValidation.test.ts
+++ b/test/app/utils/formValidation.test.ts
@@ -1,0 +1,139 @@
+import {
+  validateUsername,
+  validateEmail,
+  validatePassword,
+  validateDatasetName,
+  ERR_INVALID_USERNAME_CHARACTERS,
+  ERR_INVALID_USERNAME_LENGTH,
+  ERR_INVALID_EMAIL,
+  ERR_INVALID_PASSWORD_LENGTH,
+  ERR_INVALID_DATASETNAME_CHARACTERS,
+  ERR_INVALID_DATASETNAME_LENGTH
+} from '../../../app/utils/formValidation'
+
+describe('formValidation', () => {
+  const usernameGoodCases = [
+    'foo_bar',
+    'foo27',
+    'foo-bar',
+    'sp4vsihuof65kgyhcmv0agbjgcwljfufkjidk5wmqhl0mxg61n'
+  ]
+
+  usernameGoodCases.forEach((string) => {
+    it(`validateUsername accepts ${string}`, () => {
+      const got = validateUsername(string)
+      expect(got).toBe(null)
+    })
+  })
+
+  const userNameBadCases = [
+    {
+      string: 'foo👋bar',
+      err: ERR_INVALID_USERNAME_CHARACTERS
+    },
+    {
+      string: 'iceman@34',
+      err: ERR_INVALID_USERNAME_CHARACTERS
+    },
+    {
+      string: 'sp4vsihuof65kgyhcmv0agbjgcwljfufkjidk5wmqhl0mxg61n182',
+      err: ERR_INVALID_USERNAME_LENGTH
+    }
+  ]
+
+  userNameBadCases.forEach(({ string, err }) => {
+    it(`validateUsername rejects ${string}`, () => {
+      const got = validateUsername(string)
+      expect(got).toBe(err)
+    })
+  })
+
+  const emailGoodCases = [
+    'foo@bar.com'
+  ]
+
+  emailGoodCases.forEach((string) => {
+    it(`validateEmail accepts ${string}`, () => {
+      const got = validateEmail(string)
+      expect(got).toBe(null)
+    })
+  })
+
+  const emailBadCases = [
+    {
+      string: 'foobar',
+      err: ERR_INVALID_EMAIL
+    },
+    {
+      string: 'foo+bar',
+      err: ERR_INVALID_EMAIL
+    }
+  ]
+
+  emailBadCases.forEach(({ string, err }) => {
+    it(`validateEmail rejects ${string}`, () => {
+      const got = validateEmail(string)
+      expect(got).toBe(err)
+    })
+  })
+
+  const passwordGoodCases = [
+    'someLongPassword'
+  ]
+
+  passwordGoodCases.forEach((string) => {
+    it(`validatePassword accepts ${string}`, () => {
+      const got = validatePassword(string)
+      expect(got).toBe(null)
+    })
+  })
+
+  const passwordBadCases = [
+    {
+      string: 'imShort',
+      err: ERR_INVALID_PASSWORD_LENGTH
+    }
+  ]
+
+  passwordBadCases.forEach(({ string, err }) => {
+    it(`validatePassword rejects ${string}`, () => {
+      const got = validatePassword(string)
+      expect(got).toBe(err)
+    })
+  })
+
+  const datasetNameGoodCases = [
+    'a',
+    'hello_world',
+    'pmfqbx5bhe7w4nbonqj6zu2abb15txq7vc5yfgysawjbdiqaxghvt4iy3rdyhvxg2v52mcsqeh1yymxe6ciz1lsxwmfsqyzdkh'
+  ]
+
+  datasetNameGoodCases.forEach((string) => {
+    it(`validateDatasetName accepts ${string}`, () => {
+      const got = validateDatasetName(string)
+      expect(got).toBe(null)
+    })
+  })
+
+  const datasetNameBadCases = [
+    {
+      string: 'hello-world',
+      err: ERR_INVALID_DATASETNAME_CHARACTERS
+    },
+    {
+      string: '👋🏻',
+      err: ERR_INVALID_DATASETNAME_CHARACTERS
+    },
+    {
+      string: 'pmfqbx5bhe7w4nbonqj6zu2abb15txq7vc5yfgysawjbdiqaxghvt4iy3rdyhvxg2v52mcsqeh1yymxe6ciz1lsxwmfsqyzdkhsdf3182',
+      err: ERR_INVALID_DATASETNAME_LENGTH
+    }
+  ]
+
+  datasetNameBadCases.forEach(({ string, err }) => {
+    it(`validateDatasetName rejects ${string}`, () => {
+      const got = validateDatasetName(string)
+      expect(got).toBe(err)
+    })
+  })
+})

--- a/test/runTests.js
+++ b/test/runTests.js
@@ -1,11 +1,11 @@
-const spawn = require('cross-spawn');
-const path = require('path');
+const spawn = require('cross-spawn')
+const path = require('path')
 
-const s = `\\${path.sep}`;
+const s = `\\${path.sep}`
 const pattern = process.argv[2] === 'e2e'
   ? `test${s}e2e${s}.+\\.spec\\.tsx?`
-  : `test${s}(?!e2e${s})[^${s}]+${s}.+\\.spec\\.tsx?$`;
+  : `test${s}(?!e2e${s})[^${s}]+${s}.+\\.test\\.ts?$`
 
-const result = spawn.sync(path.normalize('./node_modules/.bin/jest'), [pattern], { stdio: 'inherit' });
+const result = spawn.sync(path.normalize('./node_modules/.bin/jest'), [pattern], { stdio: 'inherit' })
 
-process.exit(result.status);
+process.exit(result.status)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,16 +2755,16 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.0, eslint-utils@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
-
-eslint-utils@^1.4.2:
+eslint-utils@1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
   integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
   dependencies:
     eslint-visitor-keys "^1.0.0"
+
+eslint-utils@^1.3.0, eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
@@ -4795,7 +4795,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.15:
+lodash-es@4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==


### PR DESCRIPTION
- Remove header tooltips, show full `peername/name` in current dataset area (Closes #169)
- Fix unable to quit from MacOS dock (Closes #164)
- Fix activeTab localstorage <-> state mismatch (Closes #201)
- Add dataset name validation in `CreateDataset` modal (Closes #202)
- Remove unnecessary text from commit component list, fix width (Closes #52)

- Adds tooltips, new text, and style tweaks to Create Dataset Modal (Closes #190)
![Fullscreen_9_9_19__4_20_PM](https://user-images.githubusercontent.com/1833820/64563626-ce4a5100-d31d-11e9-92e0-3077a7ed5ef2.png)
