### PR TITLE
chore: restore hot module reloading

### DIFF
--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { hot } from 'react-hot-loader/root'
 import { Action } from 'redux'
 import { CSSTransition } from 'react-transition-group'
 import { HashRouter as Router } from 'react-router-dom'
@@ -55,7 +56,7 @@ interface AppState {
   peername: string
 }
 
-export default class App extends React.Component<AppProps, AppState> {
+class App extends React.Component<AppProps, AppState> {
   constructor (props: AppProps) {
     super(props)
 
@@ -216,3 +217,5 @@ export default class App extends React.Component<AppProps, AppState> {
     )
   }
 }
+
+export default hot(App)

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -20,7 +20,7 @@ module.exports = merge(baseConfig, {
 
   entry: [
     'react-hot-loader/patch',
-    `webpack-hot-middleware/client?path=http://localhost:${port}/__webpack_hmr&reload=true`,
+    `webpack-hot-middleware/client?path=http://localhost:${port}/__webpack_hmr`,
     './app/index'
   ],
 
@@ -51,7 +51,8 @@ module.exports = merge(baseConfig, {
           {
             loader: MiniCssExtractPlugin.loader,
             options: {
-              publicPath: '../'
+              publicPath: '../',
+              hmr: process.env.NODE_ENV === 'development'
             }
           },
           'css-loader',


### PR DESCRIPTION
Restores webpack hot module reloading for both `js` and `scss` changes