### PR TITLE
fix: handle windows paths

### DIFF
--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Action } from 'redux'
+import path from 'path'
 import classNames from 'classnames'
 import { clipboard, shell, MenuItemConstructorOptions } from 'electron'
 import ContextMenuArea from 'react-electron-contextmenu'
@@ -138,7 +139,7 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
             // a commit's component, and should not render a filename
             let filename = ''
             if (filepath !== name) {
-              filename = filepath.substring((filepath.lastIndexOf('/') + 1))
+              filename = path.basename(filepath)
             }
 
             const fileRow = (


### PR DESCRIPTION
Handles windows file paths when displaying component filenames, and when parsing filename during create dataset.  (Closes #217 )