### PR TITLE
feat: dataset removal

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -591,19 +591,38 @@ export function discardChanges (component: ComponentType): ApiActionThunk {
   }
 }
 
-export function removeDataset (peername: string, name: string): ApiActionThunk {
+export function removeDataset (peername: string, name: string, removeFiles: boolean = false): ApiActionThunk {
   return async (dispatch) => {
     const action = {
-      type: 'add',
+      type: 'remove',
       [CALL_API]: {
-        endpoint: 'add',
-        method: 'POST',
+        endpoint: 'remove',
+        method: 'DELETE',
         segments: {
           peername,
           name
+        },
+        params: {
+          files: removeFiles
         }
       }
     }
     return dispatch(action)
+  }
+}
+
+// remove the specified dataset, then refresh the dataset list
+export function removeDatasetAndFetch (peername: string, name: string, removeFiles: boolean): ApiActionThunk {
+  return async (dispatch, getState) => {
+    const whenOk = chainSuccess(dispatch, getState)
+    let response: Action
+
+    try {
+      response = await removeDataset(peername, name, removeFiles)(dispatch, getState)
+      response = await whenOk(fetchMyDatasets())(response)
+    } catch (action) {
+      throw action
+    }
+    return response
   }
 }

--- a/app/actions/mappingFuncs.ts
+++ b/app/actions/mappingFuncs.ts
@@ -17,7 +17,7 @@ export function mapDatasetSummary (data: any[]): DatasetSummary[] {
     peername: ref.peername,
     name: ref.name,
     path: ref.path,
-    isLinked: !!ref.fsiPath,
+    fsipath: ref.fsiPath,
     published: ref.published
   }))
 }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -11,6 +11,7 @@ import AppError from './AppError'
 import AppLoading from './AppLoading'
 import AddDataset from './modals/AddDataset'
 import LinkDataset from './modals/LinkDataset'
+import RemoveDataset from './modals/RemoveDataset'
 import CreateDataset from './modals/CreateDataset'
 import RoutesContainer from '../containers/RoutesContainer'
 
@@ -48,6 +49,8 @@ export interface AppProps {
   setApiConnection: (status: number) => Action
   pingApi: () => Promise<ApiAction>
   setModal: (modal: Modal) => Action
+  removeDataset: (peername: string, name: string, dir: string) => Promise<ApiAction>
+
 }
 
 interface AppState {
@@ -109,7 +112,7 @@ class App extends React.Component<AppProps, AppState> {
 
   private renderModal (): JSX.Element | null {
     const { modal, setModal, workingDataset } = this.props
-    const { peername, name } = workingDataset
+    const { peername, name, linkpath } = workingDataset
     const Modal = modal
 
     if (!Modal) return null
@@ -150,6 +153,21 @@ class App extends React.Component<AppProps, AppState> {
             peername={peername}
             name={name}
             onSubmit={this.props.linkDataset}
+            onDismissed={async () => setModal(NoModal)}
+          />
+        </CSSTransition>
+        <CSSTransition
+          in={ModalType.RemoveDataset === Modal.type}
+          classNames='fade'
+          component='div'
+          timeout={300}
+          unmountOnExit
+        >
+          <RemoveDataset
+            peername={peername}
+            name={name}
+            linkpath={linkpath}
+            onSubmit={this.props.removeDataset}
             onDismissed={async () => setModal(NoModal)}
           />
         </CSSTransition>

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -81,10 +81,26 @@ export default class DatasetList extends React.Component<DatasetListProps> {
       return true
     })
 
+    console.log(filteredDatasets)
+
     const listContent = filteredDatasets.length > 0
       ? filteredDatasets.map(({ peername, name, title, fsipath, published }) => {
-        const menuItems: MenuItemConstructorOptions[] = fsipath
-          ? [
+        let menuItems: MenuItemConstructorOptions[] = [
+          {
+            label: 'Remove...',
+            click: () => {
+              setModal({
+                type: ModalType.RemoveDataset,
+                peername,
+                name,
+                fsipath
+              })
+            }
+          }
+        ]
+
+        if (fsipath) {
+          menuItems = [
             {
               label: 'Reveal in Finder',
               click: () => { shell.showItemInFolder(fsipath) }
@@ -92,17 +108,9 @@ export default class DatasetList extends React.Component<DatasetListProps> {
             {
               type: 'separator'
             },
-            {
-              label: 'Remove...',
-              click: () => { setModal({ type: ModalType.RemoveDataset }) }
-            }
+            ...menuItems
           ]
-          : [
-            {
-              label: 'Remove...',
-              click: () => { setModal({ type: ModalType.RemoveDataset }) }
-            }
-          ]
+        }
 
         return (<ContextMenuArea menuItems={menuItems} key={`${peername}/${name}`}>
           <div
@@ -117,7 +125,7 @@ export default class DatasetList extends React.Component<DatasetListProps> {
               <div className='subtext'>{title || <br/>}</div>
             </div>
             <div className='status-column' data-tip='unlinked'>
-              {!!fsipath && (
+              {!fsipath && (
                 <FontAwesomeIcon icon={faUnlink} size='sm'/>
               )}
             </div>
@@ -141,14 +149,14 @@ export default class DatasetList extends React.Component<DatasetListProps> {
               onClick={() => { setModal({ type: ModalType.AddDataset }) }}
               data-tip='Add an existing<br/>Qri dataset'
             >
-              <a href='#'>Add a Dataset</a>
+              <span>Add a Dataset</span>
             </div>
             <div
               className='dataset-list-button'
               onClick={() => { setModal({ type: ModalType.CreateDataset }) }}
               data-tip='Create a new Qri <br/>dataset from a data file'
             >
-              <a href='#'>New Dataset</a></div>
+              <span>New Dataset</span></div>
           </div>
         </div>
         <div id='dataset-list-header' className='sidebar-list-item'>

--- a/app/components/form/CheckboxInput.tsx
+++ b/app/components/form/CheckboxInput.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+
+export interface CheckboxInputProps {
+  label?: string
+  name: string
+  checked: boolean
+  onChange: (name: string, checked: any) => void
+}
+
+const CheckboxInput: React.FunctionComponent<CheckboxInputProps> = ({ label, name, checked, onChange }) => {
+  const labelColor = 'primary'
+  return (
+    <>
+      <div className='checkbox-input-container'>
+        <input
+          id={name}
+          name={name}
+          type='checkbox'
+          className='checkbox-input'
+          checked={checked}
+          onChange={ () => { onChange(name, !checked) }}
+        />
+        {label && <span className={labelColor}>{label}</span>}
+      </div>
+    </>
+  )
+}
+
+export default CheckboxInput

--- a/app/components/modals/RemoveDataset.tsx
+++ b/app/components/modals/RemoveDataset.tsx
@@ -2,19 +2,21 @@ import * as React from 'react'
 
 import CheckboxInput from '../form/CheckboxInput'
 import Modal from './Modal'
+import { RemoveDatasetModal } from '../../../app/models/modals'
 import { ApiAction } from '../../store/api'
 import Error from './Error'
 import Buttons from './Buttons'
 
 interface RemoveDatasetProps {
-  peername: string
-  name: string
-  linkpath: string
+  modal: RemoveDatasetModal
   onDismissed: () => void
-  onSubmit: (peername: string, name: string, dir: string) => Promise<ApiAction>
+  onSubmit: (peername: string, name: string, removeFiles: boolean) => Promise<ApiAction>
 }
 
-const RemoveDataset: React.FunctionComponent<RemoveDatasetProps> = ({ peername, name, onDismissed, onSubmit, linkpath }) => {
+const RemoveDataset: React.FunctionComponent<RemoveDatasetProps> = (props: RemoveDatasetProps) => {
+  const { modal, onDismissed, onSubmit } = props
+  const { peername, name, fsipath } = modal
+
   const [shouldRemoveFiles, setShouldRemoveFiles] = React.useState(false)
 
   const [dismissable, setDismissable] = React.useState(true)
@@ -31,7 +33,7 @@ const RemoveDataset: React.FunctionComponent<RemoveDatasetProps> = ({ peername, 
     setLoading(true)
     error && setError('')
     if (!onSubmit) return
-    onSubmit(peername, name, linkpath)
+    onSubmit(peername, name, shouldRemoveFiles)
       .then(onDismissed)
       .catch((action) => {
         setLoading(false)
@@ -51,8 +53,8 @@ const RemoveDataset: React.FunctionComponent<RemoveDatasetProps> = ({ peername, 
     >
       <div className='content-wrap'>
         <div className='content'>
-          <p>Are you sure you want to remove the dataset &quot;{peername}/{name}&quot;?</p>
-          { linkpath.length > 0 &&
+          <div className='content-main'>Are you sure you want to remove <br/> <div className='code-highlight'>{peername}/{name}</div>&nbsp;?</div>
+          { fsipath &&
             <CheckboxInput
               name='shouldRemoveFiles'
               checked={shouldRemoveFiles}
@@ -62,8 +64,8 @@ const RemoveDataset: React.FunctionComponent<RemoveDatasetProps> = ({ peername, 
           }
         </div>
       </div>
-      <p className='submit-message'>
-        { linkpath.length > 0 && shouldRemoveFiles && `Qri will delete dataset files in "${linkpath}"`}
+      <p className='content-bottom submit-message'>
+        { fsipath && shouldRemoveFiles && <span>Qri will delete dataset files in <strong>{fsipath}</strong></span>}
       </p>
       <Error text={error} />
       <Buttons

--- a/app/components/modals/RemoveDataset.tsx
+++ b/app/components/modals/RemoveDataset.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react'
+
+import CheckboxInput from '../form/CheckboxInput'
+import Modal from './Modal'
+import { ApiAction } from '../../store/api'
+import Error from './Error'
+import Buttons from './Buttons'
+
+interface RemoveDatasetProps {
+  peername: string
+  name: string
+  linkpath: string
+  onDismissed: () => void
+  onSubmit: (peername: string, name: string, dir: string) => Promise<ApiAction>
+}
+
+const RemoveDataset: React.FunctionComponent<RemoveDatasetProps> = ({ peername, name, onDismissed, onSubmit, linkpath }) => {
+  const [shouldRemoveFiles, setShouldRemoveFiles] = React.useState(false)
+
+  const [dismissable, setDismissable] = React.useState(true)
+
+  const [error, setError] = React.useState('')
+  const [loading, setLoading] = React.useState(false)
+
+  const handleChanges = (name: string, value: any) => {
+    setShouldRemoveFiles(value)
+  }
+
+  const handleSubmit = () => {
+    setDismissable(false)
+    setLoading(true)
+    error && setError('')
+    if (!onSubmit) return
+    onSubmit(peername, name, linkpath)
+      .then(onDismissed)
+      .catch((action) => {
+        setLoading(false)
+        setDismissable(true)
+        setError(action.payload.err.message)
+      })
+  }
+
+  return (
+    <Modal
+      id='RemoveDataset'
+      title={`Remove Dataset`}
+      onDismissed={onDismissed}
+      onSubmit={() => {}}
+      dismissable={dismissable}
+      setDismissable={setDismissable}
+    >
+      <div className='content-wrap'>
+        <div className='content'>
+          <p>Are you sure you want to remove the dataset &quot;{peername}/{name}&quot;?</p>
+          { linkpath.length > 0 &&
+            <CheckboxInput
+              name='shouldRemoveFiles'
+              checked={shouldRemoveFiles}
+              onChange={handleChanges}
+              label={'Also remove the dataset\'s files'}
+            />
+          }
+        </div>
+      </div>
+      <p className='submit-message'>
+        { linkpath.length > 0 && shouldRemoveFiles && `Qri will delete dataset files in "${linkpath}"`}
+      </p>
+      <Error text={error} />
+      <Buttons
+        cancelText='cancel'
+        onCancel={onDismissed}
+        submitText='Remove'
+        onSubmit={handleSubmit}
+        disabled={false}
+        loading={loading}
+      />
+    </Modal>
+  )
+}
+
+export default RemoveDataset

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -8,7 +8,7 @@ import {
   initDatasetAndFetch,
   linkDataset,
   pingApi,
-  removeDataset
+  removeDatasetAndFetch
 } from '../actions/api'
 
 import {
@@ -64,7 +64,7 @@ const AppContainer = connect(
     setApiConnection,
     setWorkingDataset,
     setModal,
-    removeDataset
+    removeDatasetAndFetch
   },
   mergeProps
 )(App)

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -7,7 +7,8 @@ import {
   addDatasetAndFetch,
   initDatasetAndFetch,
   linkDataset,
-  pingApi
+  pingApi,
+  removeDataset
 } from '../actions/api'
 
 import {
@@ -62,7 +63,8 @@ const AppContainer = connect(
     pingApi,
     setApiConnection,
     setWorkingDataset,
-    setModal
+    setModal,
+    removeDataset
   },
   mergeProps
 )(App)

--- a/app/models/modals.ts
+++ b/app/models/modals.ts
@@ -6,24 +6,31 @@ export enum ModalType {
   RemoveDataset
 }
 
-export const NoModal = { type: ModalType.NoModal }
-
-export type Modal =
-| {
+interface CreateDatasetModal {
   type: ModalType.CreateDataset
   dirPath?: string
   bodyPath?: string
 }
-| {
+
+interface AddDatasetModal {
   type: ModalType.AddDataset
   initialURL?: string | null
 }
-| {
+
+interface LinkDatasetModal {
   type: ModalType.LinkDataset
   dirPath?: string
 }
-| {
+
+export interface RemoveDatasetModal {
   type: ModalType.RemoveDataset
-  dirPath?: string
+  peername: string
+  name: string
+  fsipath: string
 }
-| { type: ModalType.NoModal }
+
+export interface HideModal {
+  type: ModalType.NoModal
+}
+
+export type Modal = CreateDatasetModal | AddDatasetModal | LinkDatasetModal | RemoveDatasetModal | HideModal

--- a/app/models/modals.ts
+++ b/app/models/modals.ts
@@ -2,7 +2,8 @@ export enum ModalType {
   NoModal,
   CreateDataset,
   AddDataset,
-  LinkDataset
+  LinkDataset,
+  RemoveDataset
 }
 
 export const NoModal = { type: ModalType.NoModal }
@@ -19,6 +20,10 @@ export type Modal =
 }
 | {
   type: ModalType.LinkDataset
+  dirPath?: string
+}
+| {
+  type: ModalType.RemoveDataset
   dirPath?: string
 }
 | { type: ModalType.NoModal }

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -89,7 +89,7 @@ export interface DatasetSummary {
   peername: string
   name: string
   path: string
-  isLinked: boolean
+  fsipath: string
   published: boolean
 }
 

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -424,6 +424,7 @@ $header-font-size: .9rem;
   border-bottom: $list-item-bottom-border;
   display: flex;
   align-items: center;
+  user-select: none;
 }
 
 .sidebar-list-header  {

--- a/app/scss/_dialog.scss
+++ b/app/scss/_dialog.scss
@@ -82,15 +82,26 @@ dialog {
   // the correct tab is active
   // as you click through the tabs, they will transition
   .content-wrap {
-    min-height: 300px;
+    min-height: 180px;
     position: relative;
     display: flex;
     flex-direction: column;
+    padding-bottom: 15px;
 
     .content {
       width: 100%;
-      height: 100%;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
       background: $appBackground;
+
+      .content-main {
+        flex: 1;
+      }
+
+      .content-bottom {
+        flex: 0;
+      }
     }
 
     // #error {

--- a/app/scss/_modal.scss
+++ b/app/scss/_modal.scss
@@ -39,6 +39,7 @@
   }
 
 .submit-message {
+	min-height: 35px;
 	font-size: .8rem;
 	color: #777;
 }

--- a/app/scss/_site.scss
+++ b/app/scss/_site.scss
@@ -730,3 +730,11 @@ b {
 .border {
   border: $border-color solid 2px;
 }
+
+.code-highlight {
+  padding: 2px 8px;
+  background: #f3f3f3;
+  display: inline-block;
+  border-radius: 3px;
+  margin-top: 8px;
+}

--- a/app/scss/_welcome.scss
+++ b/app/scss/_welcome.scss
@@ -109,4 +109,5 @@
 
   span {
     font-size: 0.8rem;
+  }
 }

--- a/app/scss/_welcome.scss
+++ b/app/scss/_welcome.scss
@@ -99,3 +99,14 @@
     }
   }
 }
+
+.checkbox-input-container {
+  display: flex;
+
+  input {
+    margin-right: 5px;
+  }
+
+  span {
+    font-size: 0.8rem;
+}


### PR DESCRIPTION

![Screenshot_9_12_19__7_06_PM](https://user-images.githubusercontent.com/1833820/64826954-79624100-d590-11e9-9ea2-dc2611161f80.png)
- Adds a contextual menu on dataset list items for 'Remove...' (Closes #118)
- Adds a remove dataset modal, asking the user whether they would like remove files (if the dataset is fsi linked)
- Refactors modal types, and the implementation of modals in App.tsx.  All are consolidated under a single CSS transition, and are mounted based on the type of Modal that is currently set in state.

