### PR TITLE
feat: publish and unpublish modals

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -1,7 +1,8 @@
 import { Action, AnyAction } from 'redux'
 
 import { CALL_API, ApiAction, ApiActionThunk, chainSuccess, ApiResponseAction } from '../store/api'
-import { DatasetSummary, WorkingDataset, ComponentType, PageInfo } from '../models/store'
+import { DatasetSummary, ComponentStatus, ComponentState, ComponentType, PageInfo } from '../models/store'
+import { Dataset, Commit } from '../models/dataset'
 import { openToast } from './ui'
 import { setWorkingDataset, setSelectedListItem, clearSelection, setActiveTab } from './selections'
 import {
@@ -474,9 +475,10 @@ export function initDatasetAndFetch (sourcebodypath: string, name: string, dir: 
   }
 }
 
-export function publishDataset (dataset: WorkingDataset): ApiActionThunk {
-  const { peername, name } = dataset
+export function publishDataset (): ApiActionThunk {
   return async (dispatch, getState) => {
+    const { workingDataset } = getState()
+    const { peername, name, linkpath } = workingDataset
     const whenOk = chainSuccess(dispatch, getState)
     const action = {
       type: 'publish',
@@ -494,7 +496,7 @@ export function publishDataset (dataset: WorkingDataset): ApiActionThunk {
       let response: Action
       response = await dispatch(action)
       await whenOk(fetchWorkingDataset())(response)
-      response = await dispatch(setWorkingDataset(dataset.peername, dataset.name, dataset.linkpath !== 'repo', true))
+      response = await dispatch(setWorkingDataset(peername, name, linkpath !== 'repo', true))
     } catch (action) {
       throw action
     }
@@ -503,9 +505,10 @@ export function publishDataset (dataset: WorkingDataset): ApiActionThunk {
   }
 }
 
-export function unpublishDataset (dataset: WorkingDataset): ApiActionThunk {
-  const { peername, name } = dataset
+export function unpublishDataset (): ApiActionThunk {
   return async (dispatch, getState) => {
+    const { workingDataset } = getState()
+    const { peername, name, linkpath } = workingDataset
     const whenOk = chainSuccess(dispatch, getState)
     const action = {
       type: 'unpublish',
@@ -523,7 +526,7 @@ export function unpublishDataset (dataset: WorkingDataset): ApiActionThunk {
       let response: Action
       response = await dispatch(action)
       await whenOk(fetchWorkingDataset())(response)
-      response = await dispatch(setWorkingDataset(dataset.peername, dataset.name, dataset.linkpath !== 'repo', false))
+      response = await dispatch(setWorkingDataset(peername, name, linkpath !== 'repo', false))
     } catch (action) {
       throw action
     }

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -1,8 +1,7 @@
 import { Action, AnyAction } from 'redux'
 
 import { CALL_API, ApiAction, ApiActionThunk, chainSuccess, ApiResponseAction } from '../store/api'
-import { DatasetSummary, ComponentStatus, ComponentState, ComponentType, PageInfo } from '../models/store'
-import { Dataset, Commit } from '../models/dataset'
+import { DatasetSummary, ComponentType, PageInfo } from '../models/store'
 import { openToast } from './ui'
 import { setWorkingDataset, setSelectedListItem, clearSelection, setActiveTab } from './selections'
 import {
@@ -495,7 +494,7 @@ export function publishDataset (): ApiActionThunk {
     try {
       let response: Action
       response = await dispatch(action)
-      await whenOk(fetchWorkingDataset())(response)
+      await whenOk(fetchWorkingDatasetDetails())(response)
       response = await dispatch(setWorkingDataset(peername, name, linkpath !== 'repo', true))
     } catch (action) {
       throw action
@@ -525,7 +524,7 @@ export function unpublishDataset (): ApiActionThunk {
     try {
       let response: Action
       response = await dispatch(action)
-      await whenOk(fetchWorkingDataset())(response)
+      await whenOk(fetchWorkingDatasetDetails())(response)
       response = await dispatch(setWorkingDataset(peername, name, linkpath !== 'repo', false))
     } catch (action) {
       throw action

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -13,6 +13,8 @@ import AddDataset from './modals/AddDataset'
 import LinkDataset from './modals/LinkDataset'
 import RemoveDataset from './modals/RemoveDataset'
 import CreateDataset from './modals/CreateDataset'
+import PublishDataset from './modals/PublishDataset'
+import UnpublishDataset from './modals/UnpublishDataset'
 import RoutesContainer from '../containers/RoutesContainer'
 
 // import models
@@ -50,7 +52,8 @@ export interface AppProps {
   pingApi: () => Promise<ApiAction>
   setModal: (modal: Modal) => Action
   removeDatasetAndFetch: (peername: string, name: string, removeFiles: boolean) => Promise<ApiAction>
-
+  publishDataset: () => Promise<ApiAction>
+  unpublishDataset: () => Promise<ApiAction>
 }
 
 interface AppState {
@@ -117,7 +120,6 @@ class App extends React.Component<AppProps, AppState> {
   private renderModal (): JSX.Element | null {
     const { modal, setModal } = this.props
     if (!modal) return null
-
     let modalComponent = <div />
 
     switch (modal.type) {
@@ -126,6 +128,32 @@ class App extends React.Component<AppProps, AppState> {
           <RemoveDataset
             modal={modal}
             onSubmit={this.props.removeDatasetAndFetch}
+            onDismissed={async () => setModal(noModalObject)}
+          />
+        )
+        break
+      }
+
+      case ModalType.PublishDataset: {
+        const { peername, name } = this.props.workingDataset
+        modalComponent = (
+          <PublishDataset
+            peername={peername}
+            name={name}
+            onSubmit={this.props.publishDataset}
+            onDismissed={async () => setModal(noModalObject)}
+          />
+        )
+        break
+      }
+
+      case ModalType.UnpublishDataset: {
+        const { peername, name } = this.props.workingDataset
+        modalComponent = (
+          <UnpublishDataset
+            peername={peername}
+            name={name}
+            onSubmit={this.props.unpublishDataset}
             onDismissed={async () => setModal(noModalObject)}
           />
         )

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -4,9 +4,10 @@ import classNames from 'classnames'
 import ContextMenuArea from 'react-electron-contextmenu'
 import { shell, MenuItemConstructorOptions } from 'electron'
 
+import { CurrentDataset } from './Dataset'
 import { MyDatasets, WorkingDataset } from '../models/store'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faUnlink, faTimes } from '@fortawesome/free-solid-svg-icons'
+import { faUnlink, faTimes, faDownload, faPlus, faFileAlt } from '@fortawesome/free-solid-svg-icons'
 
 import { Modal, ModalType } from '../models/modals'
 
@@ -63,9 +64,11 @@ export default class DatasetList extends React.Component<DatasetListProps> {
       workingDataset,
       setModal,
       setWorkingDataset,
+      toggleDatasetList,
       myDatasets
     } = this.props
     const { filter, value: datasets } = myDatasets
+    const { peername, name } = workingDataset
 
     const filteredDatasets = datasets.filter(({ peername, name, title }) => {
       // if there's a non-empty filter string, only show matches on peername, name, and title
@@ -80,8 +83,6 @@ export default class DatasetList extends React.Component<DatasetListProps> {
 
       return true
     })
-
-    console.log(filteredDatasets)
 
     const listContent = filteredDatasets.length > 0
       ? filteredDatasets.map(({ peername, name, title, fsipath, published }) => {
@@ -120,6 +121,9 @@ export default class DatasetList extends React.Component<DatasetListProps> {
             })}
             onClick={() => setWorkingDataset(peername, name, !!fsipath, published)}
           >
+            <div className='icon-column'>
+              <FontAwesomeIcon icon={faFileAlt} size='lg'/>
+            </div>
             <div className='text-column'>
               <div className='text'>{peername}/{name}</div>
               <div className='subtext'>{title || <br/>}</div>
@@ -141,48 +145,61 @@ export default class DatasetList extends React.Component<DatasetListProps> {
       : `You have ${filteredDatasets.length} local dataset${datasets.length > 1 ? 's' : ''}`
 
     return (
-      <div className='dataset-sidebar' >
-        <div>
-          <div id='buttons'>
-            <div
-              className='dataset-list-button'
-              onClick={() => { setModal({ type: ModalType.AddDataset }) }}
-              data-tip='Add an existing<br/>Qri dataset'
-            >
-              <span>Add a Dataset</span>
+      <>
+        <div id='dataset-list-header'>
+          <CurrentDataset
+            onClick={toggleDatasetList}
+            expanded={true}
+            peername={peername}
+            name={name}
+          />
+        </div>
+        <div className='dataset-sidebar' >
+          <div id='dataset-list-filter' className='sidebar-list-item'>
+            <div id='dataset-list-buttons'>
+              <div
+                className='dataset-list-button btn btn-primary'
+                onClick={() => { setModal({ type: ModalType.AddDataset }) }}
+                data-tip='Add an existing<br/>Qri dataset'
+              >
+                <FontAwesomeIcon icon={faDownload} />&nbsp;&nbsp;
+                <span>Add a Dataset</span>
+              </div>
+              <div
+                className='dataset-list-button btn btn-primary'
+                onClick={() => { setModal({ type: ModalType.CreateDataset }) }}
+                data-tip='Create a new Qri <br/>dataset from a data file'
+              >
+                <FontAwesomeIcon icon={faPlus} />&nbsp;&nbsp;
+                <span>New Dataset</span>
+              </div>
             </div>
-            <div
-              className='dataset-list-button'
-              onClick={() => { setModal({ type: ModalType.CreateDataset }) }}
-              data-tip='Create a new Qri <br/>dataset from a data file'
-            >
-              <span>New Dataset</span></div>
+            <div className='filter-input-container'>
+              <input
+                type='text'
+                name='filter'
+                placeholder='Filter datasets'
+                value={filter}
+                onChange={(e) => this.handleFilterChange(e)}
+              />
+              { filter !== '' &&
+                <a
+                  className='close'
+                  onClick={this.clearFilter}
+                  aria-label='close'
+                  role='button' ><FontAwesomeIcon icon={faTimes} size='lg'/>
+                </a>
+              }
+            </div>
+          </div>
+          <div id='list' onScroll={(e) => this.handleScroll(e)}>
+            {listContent}
+          </div>
+          <div id='list-footer'>
+            <div className='strong-message'>{countMessage}</div>
           </div>
         </div>
-        <div id='dataset-list-header' className='sidebar-list-item'>
-          <input
-            type='text'
-            name='filter'
-            placeholder='Filter datasets'
-            value={filter}
-            onChange={(e) => this.handleFilterChange(e)}
-          />
-          { filter !== '' &&
-            <a
-              className='close'
-              onClick={this.clearFilter}
-              aria-label='close'
-              role='button' ><FontAwesomeIcon icon={faTimes} size='lg'/>
-            </a>
-          }
-        </div>
-        <div id='list' onScroll={(e) => this.handleScroll(e)}>
-          {listContent}
-        </div>
-        <div id='list-footer'>
-          <div className='strong-message'>{countMessage}</div>
-        </div>
-      </div>
+      </>
     )
   }
 }

--- a/app/components/chrome/HeaderColumnButtonDropdown.tsx
+++ b/app/components/chrome/HeaderColumnButtonDropdown.tsx
@@ -15,11 +15,16 @@ const HeaderColumnButtonDropdown: React.FunctionComponent<HeaderColumnButtonDrop
   const dropdown: any = React.useRef(null)
 
   const handleClick = (e: MouseEvent) => {
+    // check whether an app-wide click is in this component
     if (dropdown.current !== null && dropdown.current.contains(e.target)) {
+      // if it's in this component, but is a dropdown item, close the dropdown
+      const element = e.target as HTMLElement
+      if (element.tagName === 'LI') setShowMenu(false)
+
       // inside click
       return
     }
-    // outside click
+    // close the dropdown if the click happened outside of this component
     setShowMenu(false)
   }
 
@@ -58,9 +63,7 @@ const HeaderColumnButtonDropdown: React.FunctionComponent<HeaderColumnButtonDrop
       </div>
       {showMenu && (
         <ul className='dropdown'>
-          {items.map((elem, i) => (
-            <li key={i}>{elem}</li>
-          ))}
+          {items.map((elem) => (elem))}
         </ul>)
       }
     </div>

--- a/app/components/modals/PublishDataset.tsx
+++ b/app/components/modals/PublishDataset.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react'
+
+import Modal from './Modal'
+import Buttons from './Buttons'
+
+import { ApiAction } from '../../store/api'
+
+interface PublishDatasetProps {
+  peername: string
+  name: string
+  onDismissed: () => void
+  onSubmit: () => Promise<ApiAction>
+}
+
+const PublishDataset: React.FunctionComponent<PublishDatasetProps> = (props) => {
+  const { peername, name, onDismissed, onSubmit } = props
+  const [dismissable, setDismissable] = React.useState(true)
+
+  // should come from props
+  const [error, setError] = React.useState('')
+  const [loading, setLoading] = React.useState(false)
+
+  const handleSubmit = () => {
+    setDismissable(false)
+    setLoading(true)
+    error && setError('')
+    if (!onSubmit) return
+    onSubmit()
+      .then(() => onDismissed())
+      .catch((action: any) => {
+        setLoading(false)
+        setDismissable(true)
+        setError(action.payload.err.message)
+      })
+  }
+
+  return (
+    <Modal
+      id='PublishDataset'
+      title={'Publish Dataset'}
+      onDismissed={onDismissed}
+      onSubmit={() => {}}
+      dismissable={dismissable}
+      setDismissable={setDismissable}
+    >
+      <div className='content-wrap' >
+        <div className='content'>
+          <h4>Publish <span className='code-highlight'>{peername}/{name}</span></h4>
+          <p><i>Publishing will make your dataset visible to anyone on the internet</i></p>
+        </div>
+      </div>
+
+      <Buttons
+        cancelText='cancel'
+        onCancel={onDismissed}
+        submitText='Publish'
+        onSubmit={handleSubmit}
+        disabled={false}
+        loading={loading}
+      />
+    </Modal>
+  )
+}
+
+export default PublishDataset

--- a/app/components/modals/UnpublishDataset.tsx
+++ b/app/components/modals/UnpublishDataset.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react'
+
+import Modal from './Modal'
+import Buttons from './Buttons'
+
+import { ApiAction } from '../../store/api'
+
+interface PublishDatasetProps {
+  peername: string
+  name: string
+  onDismissed: () => void
+  onSubmit: () => Promise<ApiAction>
+}
+
+const PublishDataset: React.FunctionComponent<PublishDatasetProps> = (props) => {
+  const { peername, name, onDismissed, onSubmit } = props
+  const [dismissable, setDismissable] = React.useState(true)
+
+  // should come from props
+  const [error, setError] = React.useState('')
+  const [loading, setLoading] = React.useState(false)
+
+  const handleSubmit = () => {
+    setDismissable(false)
+    setLoading(true)
+    error && setError('')
+    if (!onSubmit) return
+    onSubmit()
+      .then(() => onDismissed())
+      .catch((action: any) => {
+        setLoading(false)
+        setDismissable(true)
+        setError(action.payload.err.message)
+      })
+  }
+
+  return (
+    <Modal
+      id='UnpublishDataset'
+      title={'Unpublish Dataset'}
+      onDismissed={onDismissed}
+      onSubmit={() => {}}
+      dismissable={dismissable}
+      setDismissable={setDismissable}
+    >
+      <div className='content-wrap' >
+        <div className='content'>
+          <p>Unpublish <span className='code-highlight'>{peername}/{name}</span></p>
+          <p>Unpublishing will remove your dataset from the Qri network</p>
+        </div>
+      </div>
+
+      <Buttons
+        cancelText='cancel'
+        onCancel={onDismissed}
+        submitText='Unpublish'
+        onSubmit={handleSubmit}
+        disabled={false}
+        loading={loading}
+      />
+    </Modal>
+  )
+}
+
+export default PublishDataset

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -8,6 +8,8 @@ import {
   initDatasetAndFetch,
   linkDataset,
   pingApi,
+  publishDataset,
+  unpublishDataset,
   removeDatasetAndFetch
 } from '../actions/api'
 
@@ -64,6 +66,8 @@ const AppContainer = connect(
     setApiConnection,
     setWorkingDataset,
     setModal,
+    publishDataset,
+    unpublishDataset,
     removeDatasetAndFetch
   },
   mergeProps

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -81,7 +81,7 @@ app.on('ready', () =>
 
       mainWindow = new BrowserWindow({
         show: false,
-        width: 1024,
+        width: process.env.NODE_ENV === 'development' ? 1424 : 1024,
         height: 728,
         minWidth: 960,
         minHeight: 660,

--- a/app/models/modals.ts
+++ b/app/models/modals.ts
@@ -3,7 +3,9 @@ export enum ModalType {
   CreateDataset,
   AddDataset,
   LinkDataset,
-  RemoveDataset
+  RemoveDataset,
+  PublishDataset,
+  UnpublishDataset
 }
 
 interface CreateDatasetModal {
@@ -22,6 +24,14 @@ interface LinkDatasetModal {
   dirPath?: string
 }
 
+interface PublishDataset {
+  type: ModalType.PublishDataset
+}
+
+interface UnpublishDataset {
+  type: ModalType.UnpublishDataset
+}
+
 export interface RemoveDatasetModal {
   type: ModalType.RemoveDataset
   peername: string
@@ -33,4 +43,10 @@ export interface HideModal {
   type: ModalType.NoModal
 }
 
-export type Modal = CreateDatasetModal | AddDatasetModal | LinkDatasetModal | RemoveDatasetModal | HideModal
+export type Modal = CreateDatasetModal
+| AddDatasetModal
+| LinkDatasetModal
+| RemoveDatasetModal
+| PublishDataset
+| UnpublishDataset
+| HideModal

--- a/app/scss/_dataset-list.scss
+++ b/app/scss/_dataset-list.scss
@@ -1,18 +1,64 @@
-.dataset-list {
-  #dataset-list-header {
-    input {
-      width: 100%;
-      border: none;
-      padding: 9px;
+#dataset-list {
+  display: flex;
+  flex-direction: column;
+  z-index: 110;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 250px;
+  background-color: #fff;
 
-      &:focus {
-        outline-width: 0;
+  #dataset-list-header {
+    height: 50px;
+  }
+
+  #dataset-list-filter {
+    display: flex;
+    flex-direction: column;
+    padding: 12px 10px;
+    margin: 0 -5px;
+
+    #dataset-list-buttons {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+
+      .dataset-list-button {
+        flex: 1;
+        text-align: center;
+        margin: 0 5px 10px 5px;
+        font-weight: 400;
+        font-size: .8rem;
+        padding: 0.5rem;
+        min-width: unset;
       }
     }
 
-    a {
-      padding: 9px;
+    .filter-input-container {
+      width: 100%;
+      display: flex;
+      input {
+        width: 100%;
+        border: 1px solid #e1e4e8;
+        border-radius: 3px;
+        padding: 2px 5px;
+        margin: 0 5px;
+
+        &:focus {
+          outline: none;
+          border-color: $primary;
+          box-shadow: 0 0 0 1px #afafaf4d;
+        }
+      }
     }
+  }
+
+  a {
+    position: absolute;
+    right: 18px;
+    line-height: 1.7rem;
   }
 
   #list {
@@ -28,23 +74,6 @@
     .strong-message {
       font-weight: 500;
       font-size: 0.8rem;
-    }
-  }
-
-  #buttons {
-    display: flex;
-    justify-content: space-between;
-    border-bottom: $list-item-bottom-border;
-
-    .dataset-list-button {
-      flex: 1;
-      text-align: center;
-      border-right: $list-item-bottom-border;
-      padding: 4px;
-
-      &:last-child {
-        border-right: none;
-      }
     }
   }
 }

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -31,6 +31,7 @@ $header-font-size: .9rem;
     flex-direction: row;
     flex-grow: 0;
     flex-shrink: 0;
+    z-index: 102;
 
     // Header Dropdown Menu
 
@@ -291,17 +292,6 @@ $header-font-size: .9rem;
     }
   }
 
-  .dataset-list {
-    z-index: 110;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    width: 250px;
-    background-color: #fff;
-    padding-top: 50px;
-  }
-
   .user-image {
     height: 16px;
     width: 16px;
@@ -453,7 +443,6 @@ $header-font-size: .9rem;
   .icon-column {
     flex-basis: 27px;
     text-align: center;
-    color: #315379;
     display: flex;
     align-self: center;
   }

--- a/app/scss/_dialog.scss
+++ b/app/scss/_dialog.scss
@@ -1,19 +1,15 @@
 dialog {
+  padding: 0;
   border: solid 1px $border-color;
   border-radius: 5px;
-
   background: $appBackground;
-
   opacity: 1;
-
   position: absolute;
   top: 0;
   bottom: 0;
   right: 0;
   left: 0;
-
   z-index: $zindex-modal;
-
   width: 500px;
 
   &::backdrop {
@@ -23,13 +19,13 @@ dialog {
   }
 
   .dialog-header {
-    height: 50px;
+    padding: 0 1.5rem;
+    height: 60px;
     border-bottom: solid 1px $border-color;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    padding: $spacer $spacer $spacer $spacer;
 
     h1 {
       font-weight: $font-weight-bold;
@@ -45,8 +41,6 @@ dialog {
       border: 0;
       height: 18px;
       width: 18px;
-
-      margin: $spacer * -1.5 $spacer * -1 0 auto;
       padding: 0;
       background: transparent;
 
@@ -64,7 +58,7 @@ dialog {
   }
 
   form {
-    padding: $spacer;
+    padding: 1.5rem;
 
     .row {
       display: flex;
@@ -101,6 +95,10 @@ dialog {
 
       .content-bottom {
         flex: 0;
+      }
+
+      h4 {
+        font-weight: 600;
       }
     }
 


### PR DESCRIPTION
** Contains work from #226, merge that first **

Adds modals for dataset publish and unpublish. (Closes #192)

![Screenshot_9_13_19__5_11_PM](https://user-images.githubusercontent.com/1833820/64895097-8e4edb00-d649-11e9-80c8-7162ccc65c90.png)

Refactors the layout and style of the dataset list
  - Fixes a z-index issue where dropdowns in header were appearing behind the data table
  - Adds an icon next to each dataset in the list, can be used in the future for status, etc
  - Turns the add and new buttons into proper buttons, adding glyphs to each

![Screenshot_9_13_19__5_12_PM](https://user-images.githubusercontent.com/1833820/64895134-a161ab00-d649-11e9-8738-1502d7d2f36e.png)
