### PR TITLE
refactor: standardize fsiPath, isLinked, linkpath, simplify selections

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -1,7 +1,7 @@
 import { Action, AnyAction } from 'redux'
 
 import { CALL_API, ApiAction, ApiActionThunk, chainSuccess, ApiResponseAction } from '../store/api'
-import { DatasetSummary, ComponentType, PageInfo } from '../models/store'
+import { DatasetSummary, ComponentType, PageInfo, MyDatasets } from '../models/store'
 import { openToast } from './ui'
 import { setWorkingDataset, setSelectedListItem, clearSelection, setActiveTab } from './selections'
 import {
@@ -16,6 +16,15 @@ import getActionType from '../utils/actionType'
 
 const pageSizeDefault = 50
 const bodyPageSizeDefault = 100
+
+// look up the peername/name in myDatasets, return boolean for existence of fsiPath
+const lookupFsi = (peername: string | null, name: string | null, myDatasets: MyDatasets) => {
+  const dataset = myDatasets.value.find((dataset) => {
+    return dataset.peername === peername && dataset.name === name
+  })
+
+  return dataset && !!dataset.fsiPath
+}
 
 export function pingApi (): ApiActionThunk {
   return async (dispatch) => {
@@ -58,8 +67,8 @@ export function fetchWorkingDatasetDetails (): ApiActionThunk {
 export function fetchModifiedComponents (): ApiActionThunk {
   return async (dispatch, getState) => {
     const { selections, workingDataset } = getState()
-    const { path } = workingDataset
-    const { peername, name, isLinked } = selections
+    const { path, fsiPath } = workingDataset
+    const { peername, name } = selections
 
     let response: Action
 
@@ -68,7 +77,7 @@ export function fetchModifiedComponents (): ApiActionThunk {
       [CALL_API]: {
         endpoint: '',
         method: 'GET',
-        params: { fsi: isLinked },
+        params: { fsi: !!fsiPath },
         segments: {
           peername,
           name
@@ -87,7 +96,7 @@ export function fetchModifiedComponents (): ApiActionThunk {
           page: 1,
           pageSize: bodyPageSizeDefault
         },
-        params: { fsi: isLinked },
+        params: { fsi: !!fsiPath },
         segments: {
           peername,
           name,
@@ -145,8 +154,10 @@ export function fetchMyDatasets (page: number = 1, pageSize: number = pageSizeDe
 
 export function fetchWorkingDataset (): ApiActionThunk {
   return async (dispatch, getState) => {
-    const { selections } = getState()
-    const { peername, name, isLinked } = selections
+    const { selections, myDatasets } = getState()
+    const { peername, name } = selections
+
+    const fsi = lookupFsi(peername, name, myDatasets)
 
     if (peername === '' || name === '') {
       return Promise.reject(new Error('no peername or name selected'))
@@ -157,7 +168,7 @@ export function fetchWorkingDataset (): ApiActionThunk {
       [CALL_API]: {
         endpoint: '',
         method: 'GET',
-        params: { fsi: isLinked },
+        params: { fsi },
         segments: {
           peername,
           name
@@ -250,14 +261,17 @@ export function fetchWorkingHistory (page: number = 1, pageSize: number = pageSi
 
     if (bailEarly) return new Promise(resolve => resolve())
 
-    const { selections } = getState()
-    const { peername, name, isLinked } = selections
+    const { selections, myDatasets } = getState()
+    const { peername, name } = selections
+
+    const fsi = lookupFsi(peername, name, myDatasets)
+
     const action = {
       type: 'history',
       [CALL_API]: {
         endpoint: 'history',
         method: 'GET',
-        params: { fsi: isLinked },
+        params: { fsi },
         segments: {
           peername: peername,
           name: name
@@ -277,13 +291,13 @@ export function fetchWorkingHistory (page: number = 1, pageSize: number = pageSi
 export function fetchWorkingStatus (): ApiActionThunk {
   return async (dispatch, getState) => {
     const { workingDataset } = getState()
-    const { peername, name, linkpath } = workingDataset
+    const { peername, name, fsiPath } = workingDataset
     const action = {
       type: 'status',
       [CALL_API]: {
         endpoint: 'status',
         method: 'GET',
-        params: { fsi: linkpath !== '' },
+        params: { fsi: !!fsiPath },
         segments: {
           peername: peername,
           name: name
@@ -304,8 +318,8 @@ interface ActionWithPaginationRes {
 export function fetchBody (page: number = 1, pageSize: number = bodyPageSizeDefault, invalidatePagination: boolean = false): ApiActionThunk {
   return async (dispatch, getState) => {
     const { workingDataset, selections } = getState()
-    const { peername, name, isLinked } = selections
-    const { path } = workingDataset
+    const { peername, name } = selections
+    const { path, fsiPath } = workingDataset
 
     const { page: confirmedPage, bailEarly } = actionWithPagination(invalidatePagination, page, workingDataset.components.body.pageInfo)
 
@@ -320,7 +334,7 @@ export function fetchBody (page: number = 1, pageSize: number = bodyPageSizeDefa
           page: confirmedPage,
           pageSize
         },
-        params: { fsi: isLinked },
+        params: { fsi: !!fsiPath },
         segments: {
           peername,
           name,
@@ -421,9 +435,7 @@ export function addDatasetAndFetch (peername: string, name: string): ApiActionTh
     try {
       response = await addDataset(peername, name)(dispatch, getState)
       response = await whenOk(fetchMyDatasets())(response)
-      const action = response as ApiResponseAction
-      const { isLinked, published } = action.payload.data.find((dataset: DatasetSummary) => dataset.name === name && dataset.peername === peername)
-      dispatch(setWorkingDataset(peername, name, isLinked, published))
+      dispatch(setWorkingDataset(peername, name))
       dispatch(setActiveTab('history'))
       dispatch(setSelectedListItem('component', 'meta'))
     } catch (action) {
@@ -463,8 +475,8 @@ export function initDatasetAndFetch (sourcebodypath: string, name: string, dir: 
       response = await whenOk(fetchMyDatasets())(response)
       const action = response as ApiResponseAction
       const { data } = action.payload
-      const { peername, isLinked, published } = data.find((dataset: DatasetSummary) => dataset.name === name)
-      dispatch(setWorkingDataset(peername, name, isLinked, published))
+      const { peername } = data.find((dataset: DatasetSummary) => dataset.name === name)
+      dispatch(setWorkingDataset(peername, name))
       dispatch(setActiveTab('status'))
       dispatch(setSelectedListItem('component', 'meta'))
     } catch (action) {
@@ -477,7 +489,7 @@ export function initDatasetAndFetch (sourcebodypath: string, name: string, dir: 
 export function publishDataset (): ApiActionThunk {
   return async (dispatch, getState) => {
     const { workingDataset } = getState()
-    const { peername, name, linkpath } = workingDataset
+    const { peername, name } = workingDataset
     const whenOk = chainSuccess(dispatch, getState)
     const action = {
       type: 'publish',
@@ -495,7 +507,7 @@ export function publishDataset (): ApiActionThunk {
       let response: Action
       response = await dispatch(action)
       await whenOk(fetchWorkingDatasetDetails())(response)
-      response = await dispatch(setWorkingDataset(peername, name, linkpath !== 'repo', true))
+      response = await dispatch(setWorkingDataset(peername, name))
     } catch (action) {
       throw action
     }
@@ -507,7 +519,7 @@ export function publishDataset (): ApiActionThunk {
 export function unpublishDataset (): ApiActionThunk {
   return async (dispatch, getState) => {
     const { workingDataset } = getState()
-    const { peername, name, linkpath } = workingDataset
+    const { peername, name } = workingDataset
     const whenOk = chainSuccess(dispatch, getState)
     const action = {
       type: 'unpublish',
@@ -525,7 +537,7 @@ export function unpublishDataset (): ApiActionThunk {
       let response: Action
       response = await dispatch(action)
       await whenOk(fetchWorkingDatasetDetails())(response)
-      response = await dispatch(setWorkingDataset(peername, name, linkpath !== 'repo', false))
+      response = await dispatch(setWorkingDataset(peername, name))
     } catch (action) {
       throw action
     }

--- a/app/actions/mappingFuncs.ts
+++ b/app/actions/mappingFuncs.ts
@@ -2,9 +2,7 @@ import { Dataset, Commit } from '../models/dataset'
 import { DatasetSummary, ComponentStatus, ComponentState } from '../models/store'
 
 export function mapDataset (data: Record<string, string>): Dataset {
-  const dataset = data as Dataset
-  dataset.isLinked = !!dataset.fsiPath
-  return dataset
+  return data
 }
 
 export function mapRecord (data: any): Record<string, string> {
@@ -17,7 +15,7 @@ export function mapDatasetSummary (data: any[]): DatasetSummary[] {
     peername: ref.peername,
     name: ref.name,
     path: ref.path,
-    fsipath: ref.fsiPath,
+    fsiPath: ref.fsiPath,
     published: ref.published
   }))
 }

--- a/app/actions/selections.ts
+++ b/app/actions/selections.ts
@@ -22,14 +22,12 @@ export const setSelectedListItem = (type: string, selectedListItem: string) => {
   }
 }
 
-export const setWorkingDataset = (peername: string, name: string, isLinked: boolean, published: boolean) => {
+export const setWorkingDataset = (peername: string, name: string) => {
   return {
     type: SELECTIONS_SET_WORKING_DATASET,
     payload: {
       peername,
-      name,
-      isLinked,
-      published
+      name
     }
   }
 }

--- a/app/actions/workingDataset.ts
+++ b/app/actions/workingDataset.ts
@@ -29,14 +29,14 @@ export const resetBody: any = () => {
 export const resetOtherComponents = (): ApiActionThunk => {
   return async (dispatch, getState) => {
     const { selections } = getState()
-    const { peername, name, isLinked } = selections
+    const { peername, name } = selections
 
     const action = {
       type: 'resetOtherComponents',
       [CALL_API]: {
         endpoint: '',
         method: 'GET',
-        params: { fsi: isLinked },
+        params: { fsi: true }, // isLinked
         segments: {
           peername,
           name

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -41,7 +41,7 @@ export interface AppProps {
   fetchMyDatasets: (page?: number, pageSize?: number) => Promise<ApiAction>
   addDataset: (peername: string, name: string) => Promise<ApiAction>
   linkDataset: (peername: string, name: string, dir: string) => Promise<ApiAction>
-  setWorkingDataset: (peername: string, name: string, isLinked: boolean) => Promise<ApiAction>
+  setWorkingDataset: (peername: string, name: string) => Promise<ApiAction>
   initDataset: (path: string, name: string, format: string) => Promise<ApiAction>
   acceptTOS: () => Action
   setQriCloudAuthenticated: () => Action

--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -108,7 +108,7 @@ const CommitDetails: React.FunctionComponent<CommitDetailsProps> = ({
                 selectedComponent={selectedComponent}
                 selectionType={'commitComponent' as ComponentType}
                 onComponentClick={setSelectedListItem}
-                isLinked
+                fsiPath={'isLinked'}
               />
             </div>
             <div className='content-wrapper'>

--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -85,8 +85,7 @@ interface ComponentListProps {
   onComponentClick: (type: ComponentType, activeTab: string) => Action
   discardChanges?: (component: ComponentType) => ApiActionThunk
   selectionType: ComponentType
-  isLinked?: boolean
-  linkpath?: string
+  fsiPath?: string
 }
 
 const components = [
@@ -120,9 +119,8 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
     selectedComponent,
     onComponentClick,
     selectionType,
-    isLinked,
     discardChanges,
-    linkpath
+    fsiPath
   } = props
 
   return (
@@ -132,7 +130,7 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
       </div>
       {
         components.map(({ name, displayName, tooltip, icon }) => {
-          if (status[name] && isLinked) {
+          if (status[name] && !!fsiPath) {
             const { filepath, status: fileStatus } = status[name]
 
             // if filepath is the same as the component name, we are looking at a
@@ -157,15 +155,15 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
               />
             )
 
-            if (discardChanges && linkpath) {
+            if (discardChanges && fsiPath) {
               const menuItems: MenuItemConstructorOptions[] = [
                 {
                   label: 'Open in Finder',
-                  click: () => { shell.showItemInFolder(`${linkpath}/${filename}`) }
+                  click: () => { shell.showItemInFolder(`${fsiPath}/${filename}`) }
                 },
                 {
                   label: 'Copy File Path',
-                  click: () => { clipboard.writeText(`${linkpath}/${filename}`) }
+                  click: () => { clipboard.writeText(`${fsiPath}/${filename}`) }
                 }
               ]
 

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -213,12 +213,12 @@ export default class Dataset extends React.Component<DatasetProps> {
   }
 
   openWorkingDirectory () {
-    shell.openItem(this.props.workingDataset.linkpath)
+    shell.openItem(this.props.workingDataset.fsiPath)
   }
 
   publishUnpublishDataset () {
-    const { setModal, selections } = this.props
-    const { published } = selections
+    const { workingDataset, setModal } = this.props
+    const { published } = workingDataset
 
     published
       ? setModal({ type: ModalType.UnpublishDataset })
@@ -234,14 +234,13 @@ export default class Dataset extends React.Component<DatasetProps> {
       peername,
       name,
       activeTab,
-      component: selectedComponent,
-      published
+      component: selectedComponent
     } = selections
 
-    // don't use isLinked from selections
-    const isLinked = workingDataset.linkpath !== ''
+    const { status, published, fsiPath } = workingDataset
 
-    const { status } = workingDataset
+    // isLinked is derived from fsiPath and only used locally
+    const isLinked = fsiPath !== ''
 
     // actions
     const {
@@ -372,7 +371,7 @@ export default class Dataset extends React.Component<DatasetProps> {
                 mountOnEnter
                 unmountOnExit
               >
-                <DatasetComponent component={selectedComponent} componentStatus={status[selectedComponent]} isLoading={workingDataset.isLoading} linkpath={this.props.workingDataset.linkpath}/>
+                <DatasetComponent component={selectedComponent} componentStatus={status[selectedComponent]} isLoading={workingDataset.isLoading} fsiPath={this.props.workingDataset.fsiPath}/>
               </CSSTransition>
               <CSSTransition
                 in={activeTab === 'history'}

--- a/app/components/DatasetComponent.tsx
+++ b/app/components/DatasetComponent.tsx
@@ -17,11 +17,11 @@ interface DatasetComponentProps {
   component: SelectedComponent
   componentStatus: ComponentStatus
   history?: boolean
-  linkpath?: string
+  fsiPath?: string
 }
 
 const DatasetComponent: React.FunctionComponent<DatasetComponentProps> = (props: DatasetComponentProps) => {
-  const { component: selectedComponent, componentStatus, isLoading, history = false, linkpath } = props
+  const { component: selectedComponent, componentStatus, isLoading, history = false, fsiPath } = props
 
   const hasParseError = componentStatus && componentStatus.status === 'parse error'
   const component = selectedComponent || 'meta'
@@ -50,7 +50,7 @@ const DatasetComponent: React.FunctionComponent<DatasetComponentProps> = (props:
           appear={true}
         >
           <div id='transition-wrap'>
-            <ParseError linkpath={linkpath || ''} filename={componentStatus && componentStatus.filepath} component={component} />
+            <ParseError fsiPath={fsiPath || ''} filename={componentStatus && componentStatus.filepath} component={component} />
           </div>
         </CSSTransition>
         <CSSTransition

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -16,7 +16,7 @@ interface DatasetListProps {
   workingDataset: WorkingDataset
   toggleDatasetList: () => Action
   setFilter: (filter: string) => Action
-  setWorkingDataset: (peername: string, name: string, isLinked: boolean, published: boolean) => Action
+  setWorkingDataset: (peername: string, name: string) => Action
   fetchMyDatasets: (page: number, pageSize: number) => Promise<AnyAction>
   setModal: (modal: Modal) => void
 }
@@ -85,7 +85,7 @@ export default class DatasetList extends React.Component<DatasetListProps> {
     })
 
     const listContent = filteredDatasets.length > 0
-      ? filteredDatasets.map(({ peername, name, title, fsipath, published }) => {
+      ? filteredDatasets.map(({ peername, name, title, fsiPath }) => {
         let menuItems: MenuItemConstructorOptions[] = [
           {
             label: 'Remove...',
@@ -94,17 +94,17 @@ export default class DatasetList extends React.Component<DatasetListProps> {
                 type: ModalType.RemoveDataset,
                 peername,
                 name,
-                fsipath
+                fsiPath
               })
             }
           }
         ]
 
-        if (fsipath) {
+        if (fsiPath) {
           menuItems = [
             {
               label: 'Reveal in Finder',
-              click: () => { shell.showItemInFolder(fsipath) }
+              click: () => { shell.showItemInFolder(fsiPath) }
             },
             {
               type: 'separator'
@@ -119,7 +119,7 @@ export default class DatasetList extends React.Component<DatasetListProps> {
             className={classNames('sidebar-list-item', 'sidebar-list-item-text', {
               'selected': (peername === workingDataset.peername) && (name === workingDataset.name)
             })}
-            onClick={() => setWorkingDataset(peername, name, !!fsipath, published)}
+            onClick={() => setWorkingDataset(peername, name)}
           >
             <div className='icon-column'>
               <FontAwesomeIcon icon={faFileAlt} size='lg'/>
@@ -129,7 +129,7 @@ export default class DatasetList extends React.Component<DatasetListProps> {
               <div className='subtext'>{title || <br/>}</div>
             </div>
             <div className='status-column' data-tip='unlinked'>
-              {!fsipath && (
+              {!fsiPath && (
                 <FontAwesomeIcon icon={faUnlink} size='sm'/>
               )}
             </div>

--- a/app/components/DatasetSidebar.tsx
+++ b/app/components/DatasetSidebar.tsx
@@ -64,13 +64,12 @@ const DatasetSidebar: React.FunctionComponent<DatasetSidebarProps> = (props) => 
     setHideCommitNudge
   } = props
 
-  const { path, linkpath, history, status } = workingDataset
+  const { path, fsiPath, history, status } = workingDataset
 
   const {
     activeTab,
     component: selectedComponent,
-    commitComponent: selectedCommit,
-    isLinked
+    commitComponent: selectedCommit
   } = selections
 
   const historyLoaded = !!history
@@ -133,8 +132,7 @@ const DatasetSidebar: React.FunctionComponent<DatasetSidebarProps> = (props) => 
               selectedComponent={selectedComponent}
               onComponentClick={setSelectedListItem}
               selectionType={'component' as ComponentType}
-              isLinked={isLinked}
-              linkpath={linkpath}
+              fsiPath={fsiPath}
               discardChanges={discardChanges}
             />
           </div>
@@ -187,7 +185,7 @@ const DatasetSidebar: React.FunctionComponent<DatasetSidebarProps> = (props) => 
         }
       </div>
       {
-        isLinked && activeTab === 'status' && <SaveFormContainer />
+        fsiPath && activeTab === 'status' && <SaveFormContainer />
       }
     </div>
   )

--- a/app/components/ParseError.tsx
+++ b/app/components/ParseError.tsx
@@ -7,16 +7,16 @@ import { shell } from 'electron'
 interface ParseErrorProps {
   component: string
   filename: string
-  linkpath: string
+  fsiPath: string
 }
 
-const ParseError: React.FunctionComponent<ParseErrorProps> = ({ component, filename, linkpath }) => (
+const ParseError: React.FunctionComponent<ParseErrorProps> = ({ component, filename, fsiPath }) => (
   <div className={'unlinked-dataset'}>
     <div className={'message-container'}>
       <div>
         <h4>There are parsing errors in your {component}</h4>
         <p>Fix the errors in your <strong>{filename}</strong> file to be able to view it in Qri Desktop.</p>
-        <Button id='show_errors_in_finder' text="Show in Finder" color="primary" onClick={() => { shell.openItem(linkpath) }} />
+        <Button id='show_errors_in_finder' text="Show in Finder" color="primary" onClick={() => { shell.openItem(fsiPath) }} />
       </div>
     </div>
   </div>

--- a/app/components/modals/RemoveDataset.tsx
+++ b/app/components/modals/RemoveDataset.tsx
@@ -15,7 +15,7 @@ interface RemoveDatasetProps {
 
 const RemoveDataset: React.FunctionComponent<RemoveDatasetProps> = (props: RemoveDatasetProps) => {
   const { modal, onDismissed, onSubmit } = props
-  const { peername, name, fsipath } = modal
+  const { peername, name, fsiPath } = modal
 
   const [shouldRemoveFiles, setShouldRemoveFiles] = React.useState(false)
 
@@ -54,7 +54,7 @@ const RemoveDataset: React.FunctionComponent<RemoveDatasetProps> = (props: Remov
       <div className='content-wrap'>
         <div className='content'>
           <div className='content-main'>Are you sure you want to remove <br/> <div className='code-highlight'>{peername}/{name}</div>&nbsp;?</div>
-          { fsipath &&
+          { fsiPath &&
             <CheckboxInput
               name='shouldRemoveFiles'
               checked={shouldRemoveFiles}
@@ -65,7 +65,7 @@ const RemoveDataset: React.FunctionComponent<RemoveDatasetProps> = (props: Remov
         </div>
       </div>
       <p className='content-bottom submit-message'>
-        { fsipath && shouldRemoveFiles && <span>Qri will delete dataset files in <strong>{fsipath}</strong></span>}
+        { fsiPath && shouldRemoveFiles && <span>Qri will delete dataset files in <strong>{fsiPath}</strong></span>}
       </p>
       <Error text={error} />
       <Buttons

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -454,8 +454,7 @@ app.on('ready', () =>
         fsiPath,
         published
       }) => {
-        const isLinked = !!fsiPath
-        setMenuItemEnabled(['open-working-directory'], isLinked)
+        setMenuItemEnabled(['open-working-directory'], !!fsiPath)
 
         // enable/disable 'view in qri cloud' menu item
         setMenuItemEnabled(['view-on-qri-cloud'], published)

--- a/app/models/modals.ts
+++ b/app/models/modals.ts
@@ -36,7 +36,7 @@ export interface RemoveDatasetModal {
   type: ModalType.RemoveDataset
   peername: string
   name: string
-  fsipath: string
+  fsiPath: string
 }
 
 export interface HideModal {

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -66,8 +66,6 @@ export type SelectedComponent = 'meta' | 'body' | 'schema' | ''
 export interface Selections {
   peername: string | null
   name: string | null
-  isLinked: boolean
-  published: boolean
   activeTab: string
   component: SelectedComponent
   commit: string
@@ -89,7 +87,7 @@ export interface DatasetSummary {
   peername: string
   name: string
   path: string
-  fsipath: string
+  fsiPath: string
   published: boolean
 }
 
@@ -143,7 +141,7 @@ export interface CommitDetails {
 }
 
 export interface WorkingDataset extends CommitDetails {
-  linkpath: string
+  fsiPath: string
   hasHistory: boolean
   published: boolean
   history: {

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -34,6 +34,11 @@ export default (state = initialState, action: AnyAction) => {
     case SIGNIN_SUCC:
     case SIGNUP_SUCC:
     case SELECTIONS_CLEAR:
+      // if the error code is 422, that means the dataset exists
+      // but is not linked to the filesystem.
+      if (action.type === DATASET_FAIL && action.payload.err.code === 422) {
+        return state
+      }
       localStore().setItem('peername', '')
       localStore().setItem('name', '')
       localStore().setItem('activeTab', 'status')

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -12,8 +12,6 @@ export const SELECTIONS_CLEAR = 'SELECTIONS_CLEAR'
 export const initialState: Selections = {
   peername: localStore().getItem('peername') || '',
   name: localStore().getItem('name') || '',
-  isLinked: localStore().getItem('isLinked') === 'true',
-  published: localStore().getItem('published') === 'true',
   activeTab: localStore().getItem('activeTab') || 'status',
   component: localStore().getItem('component') as SelectedComponent || '',
   commit: localStore().getItem('commit') || '',
@@ -28,6 +26,7 @@ export const [, PUBLISH_SUCC] = apiActionTypes('publish')
 export const [, UNPUBLISH_SUCC] = apiActionTypes('unpublish')
 export const [, SIGNIN_SUCC] = apiActionTypes('signin')
 export const [, SIGNUP_SUCC] = apiActionTypes('signup')
+export const [, , HISTORY_FAIL] = apiActionTypes('history')
 
 export default (state = initialState, action: AnyAction) => {
   switch (action.type) {
@@ -37,8 +36,6 @@ export default (state = initialState, action: AnyAction) => {
     case SELECTIONS_CLEAR:
       localStore().setItem('peername', '')
       localStore().setItem('name', '')
-      localStore().setItem('isLinked', 'false')
-      localStore().setItem('published', 'false')
       localStore().setItem('activeTab', 'status')
       localStore().setItem('component', '')
       localStore().setItem('commit', '')
@@ -46,8 +43,6 @@ export default (state = initialState, action: AnyAction) => {
       return {
         peername: '',
         name: '',
-        isLinked: false,
-        published: false,
         activeTab: 'status',
         component: '',
         commit: '',
@@ -75,21 +70,14 @@ export default (state = initialState, action: AnyAction) => {
       return state
 
     case SELECTIONS_SET_WORKING_DATASET:
-      const { peername, name, isLinked, published } = action.payload
-      const newActiveTab = isLinked ? 'status' : 'history'
+      const { peername, name } = action.payload
 
       localStore().setItem('peername', peername)
       localStore().setItem('name', name)
-      localStore().setItem('isLinked', JSON.stringify(!!isLinked))
-      localStore().setItem('published', JSON.stringify(!!published))
-      localStore().setItem('activeTab', newActiveTab)
 
       return Object.assign({}, state, {
         peername,
-        name,
-        isLinked,
-        published,
-        activeTab: newActiveTab
+        name
       })
 
     case COMMIT_SUCC:
@@ -106,7 +94,7 @@ export default (state = initialState, action: AnyAction) => {
     case DATASET_SUCC:
       // if the selected component exists on dataset, no changes needed
       if (action.payload.data.dataset[state.component] || (state.component === 'body' && action.payload.data.dataset['bodyPath'])) return state
-      //
+
       return {
         ...state,
         // get the default component based on the components
@@ -114,48 +102,34 @@ export default (state = initialState, action: AnyAction) => {
         // can return with empty string
         component: chooseDefaultComponent(action.payload.data.dataset)
       }
-      // when a dataset is successfully published, mark as published in the selections
-    case PUBLISH_SUCC:
-      localStore().setItem('published', 'true')
+
+    // if dataset history fails, set active tab to status
+    case HISTORY_FAIL:
       return {
         ...state,
-        published: true
+        activeTab: 'status'
       }
-      // when a dataset is successfully unpublished, mark as unpublished in the selections
-    case UNPUBLISH_SUCC:
-      localStore().setItem('published', 'false')
-      return {
-        ...state,
-        published: false
-      }
+
       // when a new dataset is added from the network, make it the selected dataset
     case ADD_SUCC:
       localStore().setItem('peername', action.payload.data.peername)
       localStore().setItem('name', action.payload.data.name)
-      localStore().setItem('isLinked', JSON.stringify(!!action.payload.data.isLinked))
-      localStore().setItem('published', JSON.stringify(!!action.payload.data.published))
       localStore().setItem('activeTab', 'history')
       return {
         ...state,
         peername: action.payload.data.peername,
         name: action.payload.data.name,
-        isLinked: !!action.payload.data.isLinked,
-        published: !!action.payload.data.published,
         activeTab: 'history'
       }
       // when a new dataset is created, make it the selected dataset
     case INIT_SUCC:
       localStore().setItem('peername', action.payload.data.peername)
       localStore().setItem('name', action.payload.data.name)
-      localStore().setItem('isLinked', JSON.stringify(!!action.payload.data.isLinked))
-      localStore().setItem('published', JSON.stringify(!!action.payload.data.published))
       localStore().setItem('activeTab', 'status')
       return {
         ...state,
         peername: action.payload.data.peername,
         name: action.payload.data.name,
-        isLinked: !!action.payload.data.isLinked,
-        published: !!action.payload.data.published,
         activeTab: 'status'
       }
 

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -54,7 +54,11 @@ export const RESET_BODY = 'RESET_BODY'
 const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction): WorkingDataset | null => {
   switch (action.type) {
     case DATASET_REQ:
-      return initialState
+      return {
+        ...initialState,
+        peername: action.segments.peername,
+        name: action.segments.name
+      }
     case DATASET_SUCC: // when adding a new dataset, set it as the new workingDataset
       const { name, path, peername, published, dataset, fsiPath } = action.payload.data
 

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -11,7 +11,7 @@ const initialState: WorkingDataset = {
   name: '',
   status: {},
   isLoading: true,
-  linkpath: '',
+  fsiPath: '',
   published: true,
   hasHistory: true,
   structure: null,
@@ -72,7 +72,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
         path,
         peername,
         published,
-        linkpath: fsiPath || '',
+        fsiPath: fsiPath || '',
         structure: dataset && dataset.structure ? dataset.structure : {},
         isLoading: false,
         components: {

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -195,7 +195,7 @@ export const apiMiddleware: Middleware = () => (next: Dispatch<AnyAction>) => as
     let { endpoint = '', method, map = identityFunc, segments, params, body, pageInfo } = action[CALL_API]
     const [REQ_TYPE, SUCC_TYPE, FAIL_TYPE] = apiActionTypes(action.type)
 
-    next({ type: REQ_TYPE, pageInfo })
+    next({ type: REQ_TYPE, pageInfo, segments })
 
     // TODO (chriswhong): Turn this into dev middleware
     // // to simulate an API failure response in development, add dummySuccess to the action object

--- a/test/app/reducers/selections.test.ts
+++ b/test/app/reducers/selections.test.ts
@@ -30,14 +30,45 @@ describe('Body Reducer', () => {
     commitComponent: ''
   }
 
-  //
   // DATASET_FAIL
+  it(`DATASET_FAIL with 422 error`, () => {
+    const state = {
+      peername: 'foo',
+      name: 'bar',
+      fsiPath:'wooo'
+    }
+    const action = {
+      type: DATASET_FAIL,
+      payload: {
+        err: {
+          code: 422
+        }
+      }
+    }
+    Reducer(SelectionsReducer).withState(state).expect(action).toReturnState(state)
+  })
+  it(`DATASET_FAIL with any other error`, () => {
+    const state = {
+      peername: 'foo',
+      name: 'bar'
+    }
+    const action = {
+      type: DATASET_FAIL,
+      payload: {
+        err: {
+          code: 500
+        }
+      }
+    }
+    Reducer(SelectionsReducer).withState(state).expect(action).toReturnState(clearState)
+  })
+
+  //
   // SIGNIN_SUCC,
   // SIGNUP_SUCC,
   // SELECTIONS_CLEAR
   //
   const casesClearSelection = [
-    DATASET_FAIL,
     SIGNIN_SUCC,
     SIGNUP_SUCC,
     SELECTIONS_CLEAR

--- a/test/app/reducers/selections.test.ts
+++ b/test/app/reducers/selections.test.ts
@@ -1,6 +1,6 @@
 /* global describe, it, expect */
 import { Reducer } from 'redux-testkit'
-import SelectionsReducer, { 
+import SelectionsReducer, {
   initialState,
   SELECTIONS_SET_ACTIVE_TAB,
   SELECTIONS_SET_SELECTED_LISTITEM,
@@ -11,8 +11,6 @@ import SelectionsReducer, {
   DATASET_SUCC,
   DATASET_FAIL,
   COMMIT_SUCC,
-  PUBLISH_SUCC,
-  UNPUBLISH_SUCC,
   SIGNIN_SUCC,
   SIGNUP_SUCC
 } from '../../../app/reducers/selections'
@@ -26,20 +24,18 @@ describe('Body Reducer', () => {
   const clearState = {
     peername: '',
     name: '',
-    isLinked: false,
-    published: false,
     activeTab: 'status',
     component: '',
     commit: '',
     commitComponent: ''
   }
 
-  // 
+  //
   // DATASET_FAIL
   // SIGNIN_SUCC,
   // SIGNUP_SUCC,
   // SELECTIONS_CLEAR
-  // 
+  //
   const casesClearSelection = [
     DATASET_FAIL,
     SIGNIN_SUCC,
@@ -48,27 +44,27 @@ describe('Body Reducer', () => {
   ]
 
   casesClearSelection.forEach(action => {
-    it (`case ${action}`, () => {
-      Reducer(SelectionsReducer).expect({type: action}).toReturnState(clearState)
+    it(`case ${action}`, () => {
+      Reducer(SelectionsReducer).expect({ type: action }).toReturnState(clearState)
     })
   })
 
-  // 
+  //
   // SELECTIONS_SET_ACTION_TAB
-  // 
-  it ('SELECTIONS_SET_ACTIVE_TAB', () => {
+  //
+  it('SELECTIONS_SET_ACTIVE_TAB', () => {
     const action = {
       type: SELECTIONS_SET_ACTIVE_TAB,
       payload: {
         activeTab: 'history'
       }
     }
-    Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({activeTab: 'history'})
+    Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({ activeTab: 'history' })
   })
 
-  // 
+  //
   // SELECTIONS_SET_SELECTED_LISTITEM
-  // 
+  //
   const casesSelectedListItem = [
     {
       type: 'component',
@@ -84,78 +80,63 @@ describe('Body Reducer', () => {
     }
   ]
 
-  casesSelectedListItem.forEach( c => {
+  casesSelectedListItem.forEach(c => {
     const action = {
       type: SELECTIONS_SET_SELECTED_LISTITEM,
       payload: c
     }
-    it (`case ${c.type} of SELECTIONS_SET_SELECTED_LISTITEM`, () => {
-      Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({[c.type]:c.selectedListItem})
+    it(`case ${c.type} of SELECTIONS_SET_SELECTED_LISTITEM`, () => {
+      Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({ [c.type]: c.selectedListItem })
     })
   })
 
-  // 
+  //
   // SELECTIONS_SET_ACTIVE_TAB
-  // 
-  it ('SELECTIONS_SET_ACTIVE_TAB', () => {
+  //
+  it('SELECTIONS_SET_ACTIVE_TAB', () => {
     const action = {
       type: SELECTIONS_SET_ACTIVE_TAB,
       payload: {
         activeTab: 'history'
       }
     }
-    Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({activeTab: 'history'})
+    Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({ activeTab: 'history' })
   })
 
-  // 
+  //
   // SELECTIONS_SET_WORKING_DATASET
-  // 
+  //
   const casesWorkingDataset = [
     {
-      describe: 'set linked dataset as working dataset',
+      describe: 'set peername and name',
       payload: {
         peername: 'foo',
-        name: 'bar',
-        isLinked: true,
-        published: true
+        name: 'bar'
       },
       expected: {
-        activeTab: 'status'
-      }
-    },
-    {
-      describe: 'set unlinked dataset as working dataset',
-      payload: {
         peername: 'foo',
-        name: 'bar',
-        isLinked: false,
-        published: false
-      },
-      expected: {
-        activeTab: 'history'
+        name: 'bar'
       }
-    },
+    }
   ]
 
-  casesWorkingDataset.forEach( ({describe, payload, expected}) => {
-    it (`case ${describe} of SELECTIONS_SET_WORKING_DATASET`, () => {
+  casesWorkingDataset.forEach(({ describe, payload, expected }) => {
+    it(`case ${describe} of SELECTIONS_SET_WORKING_DATASET`, () => {
       const action = {
         type: SELECTIONS_SET_WORKING_DATASET,
         payload
       }
-      Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({...payload, ...expected})
+      Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({ ...payload, ...expected })
     })
   })
-  
-  // 
+
+  //
   // ADD_SUCC
-  // 
-  it ('ADD_SUCC', () => {
+  //
+  it('ADD_SUCC', () => {
     const expected = {
       peername: 'foo',
-      name: 'bar',
-      isLinked: true,
-      published: false
+      name: 'bar'
     }
     const action = {
       type: ADD_SUCC,
@@ -163,18 +144,16 @@ describe('Body Reducer', () => {
         data: expected
       }
     }
-    Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({...expected, activeTab: 'history'})
+    Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({ ...expected, activeTab: 'history' })
   })
 
-  // 
+  //
   // INIT_SUCC
-  // 
-  it ('INIT_SUCC', () => {
+  //
+  it('INIT_SUCC', () => {
     const expected = {
       peername: 'foo',
-      name: 'bar',
-      isLinked: true,
-      published: false
+      name: 'bar'
     }
     const action = {
       type: INIT_SUCC,
@@ -182,13 +161,13 @@ describe('Body Reducer', () => {
         data: expected
       }
     }
-    Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({...expected, activeTab: 'status'})
+    Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({ ...expected, activeTab: 'status' })
   })
 
-  // 
+  //
   // COMMIT_SUCC
   // DATASET_SUCC
-  // 
+  //
   const datasetCommitCases = [
     {
       type: COMMIT_SUCC,
@@ -291,35 +270,13 @@ describe('Body Reducer', () => {
       }
     }
   ]
-  datasetCommitCases.forEach(({type, describe, payload, expected}) => {
+  datasetCommitCases.forEach(({ type, describe, payload, expected }) => {
     const action = {
       type,
       payload
     }
-    it (`case ${describe} of ${type}`, () => {
-      Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({...expected})
-    })
-  })
-
-  // PUBLISH_SUCC
-  // UNPUBLISH_SUCC
-  const pubCases = [
-    {
-      type: PUBLISH_SUCC,
-      expected: {
-        published: true
-      }
-    },
-    {
-      type: UNPUBLISH_SUCC,
-      expected: {
-        published: false
-      }
-    },
-  ]
-  pubCases.forEach(({type, expected}) => {
-    it (type, () => {
-      Reducer(SelectionsReducer).withState(initialState).expect({type}).toChangeInState({...expected})
+    it(`case ${describe} of ${type}`, () => {
+      Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({ ...expected })
     })
   })
 })


### PR DESCRIPTION
Closes #228, a bug where we observed the create dataset flow resulting in an awkward state requiring a reload.

On investigation, the the error was due to API calls with `?fsi=undefined`.

This PR refactors how we store state for a dataset's linked status, as follows:
- We had 3 different names for linked status: `isLinked` (boolean), `linkpath` (string), and `fsiPath`(string).  These are now fully standardized as `fsiPath`, which is what the API returns (this simplifies mapping functions).  `isLinked` is used only in the `Dataset` component as a local convenience variable.
- `isLinked` and `published` are now removed from `selections`.  They should never have been there as they aren't user selections that need to be persisted, they are simply the state of the `workingDataset` (this also means they are not persisted in localstorage)

`fsi` query params are now being applied correctly, and both unlinked and linked datasets are rendering as expected.