### PR TITLE
refactor: eliminate unecessary polling render

### DIFF
--- a/app/containers/BodyContainer.tsx
+++ b/app/containers/BodyContainer.tsx
@@ -1,37 +1,17 @@
 import { connect } from 'react-redux'
 import { bindActionCreators, Dispatch } from 'redux'
 import Body, { BodyProps } from '../components/Body'
-import Store, { WorkingDataset } from '../models/store'
+import Store from '../models/store'
 import { fetchBody, fetchCommitBody } from '../actions/api'
 
-const extractColumnHeaders = (workingDataset: WorkingDataset): undefined | object => {
-  const schema = workingDataset.components.schema.value
-
-  if (!schema) {
-    return undefined
-  }
-
-  if (schema && (!schema.items || (schema.items && !schema.items.items))) {
-    return undefined
-  }
-
-  return schema && schema.items && schema.items.items.map((d: { title: string }): string => d.title)
-}
-
-interface BodyContainerProps {
-  history?: boolean
-}
-
-const mapStateToProps = (state: Store, ownProps: BodyContainerProps) => {
-  const { history } = ownProps
+const mapStateToProps = (state: Store) => {
   const { workingDataset, commitDetails, selections } = state
+  const history = selections.activeTab === 'history'
   const dataset = history ? commitDetails : workingDataset
   const { pageInfo, value } = dataset.components.body
 
   const { peername, name, commit: path } = selections
   const { structure } = dataset
-
-  const headers = extractColumnHeaders(workingDataset)
 
   // get data for the currently selected component
   return {
@@ -39,10 +19,10 @@ const mapStateToProps = (state: Store, ownProps: BodyContainerProps) => {
     path,
     name,
     pageInfo,
-    headers,
     value,
     structure,
-    datasetLoading: workingDataset.isLoading
+    history,
+    workingDataset
   }
 }
 
@@ -50,9 +30,8 @@ const mergeProps = (props: any, actions: any): BodyProps => {
   return { ...props, ...actions }
 }
 
-const mapDispatchToProps = (dispatch: Dispatch, ownProps: BodyContainerProps) => {
-  const onFetch = ownProps.history ? fetchCommitBody : fetchBody
-  return bindActionCreators({ onFetch }, dispatch)
+const mapDispatchToProps = (dispatch: Dispatch) => {
+  return bindActionCreators({ fetchBody, fetchCommitBody }, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Body)

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -1,4 +1,5 @@
 import { Reducer, AnyAction } from 'redux'
+import deepEqual from 'deep-equal'
 import { WorkingDataset, DatasetStatus, ComponentStatus } from '../models/store'
 import { apiActionTypes } from '../store/api'
 import { withPagination } from './page'
@@ -136,10 +137,14 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
           obj[component] = { filepath, status, mtime }
           return obj
         }, {})
-      return {
+
+      // if the new status deeply equals the current state, return current
+      // state to prevent unecessary re-rendering
+      return deepEqual(state.status, statusObject) ? state : {
         ...state,
         status: statusObject
       }
+
     case DATASET_STATUS_FAIL:
       return state
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "main.js",
   "scripts": {
     "codecov": "./node_modules/.bin/codecov",
-    "test": "jest --testPathIgnorePatterns=.*\/e2e\/.* --coverage",
+    "test": "jest --testPathIgnorePatterns=.*/e2e/.* --coverage",
     "test-all": "npm run test && npm run build && npm run test-e2e",
     "test-watch": "npm test -- --watch",
     "test-e2e": "cross-env NODE_ENV=test node --trace-warnings ./test/runTests.js e2e",
@@ -118,7 +118,6 @@
   ],
   "homepage": "https://qri.io",
   "devDependencies": {
-    "codecov": "3.5.0",
     "@types/classnames": "2.2.9",
     "@types/enzyme": "3.10.2",
     "@types/history": "4.7.2",
@@ -141,6 +140,7 @@
     "@typescript-eslint/eslint-plugin": "1.11.0",
     "@typescript-eslint/parser": "1.11.0",
     "asar": "2.0.1",
+    "codecov": "3.5.0",
     "concurrently": "4.1.2",
     "cross-env": "5.2.0",
     "css-loader": "3.0.0",
@@ -203,6 +203,7 @@
     "@types/webpack-env": "^1.14.0",
     "babel-loader": "^8.0.6",
     "classnames": "2.2.6",
+    "deep-equal": "1.1.0",
     "electron-debug": "3.0.1",
     "electron-updater": "4.1.2",
     "eslint-utils": "1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3174,6 +3174,18 @@ deep-diff@^0.3.5:
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
   integrity sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=
 
+deep-equal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.0.tgz#3103cdf8ab6d32cf4a8df7865458f2b8d33f3745"
+  integrity sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==
+  dependencies:
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -5121,6 +5133,11 @@ ignore@^5.1.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
+immutable@^4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
+
 import-fresh@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
@@ -5276,6 +5293,11 @@ is-accessor-descriptor@^1.0.0:
   integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-arguments@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
+  integrity sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -8371,6 +8393,13 @@ regexp-tree@^0.1.13:
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.13.tgz#5b19ab9377edc68bc3679256840bb29afc158d7f"
   integrity sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==
 
+regexp.prototype.flags@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz#6b30724e306a27833eeb171b66ac8890ba37e41c"
+  integrity sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==
+  dependencies:
+    define-properties "^1.1.2"
+
 regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
@@ -8879,7 +8908,7 @@ shallow-clone@^1.0.0:
     kind-of "^5.0.0"
     mixin-object "^2.0.1"
 
-shallowequal@^1.0.2:
+shallowequal@^1.0.2, shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==


### PR DESCRIPTION
Eliminates the rendering that was occurring on each successful poll of `/status`.  

The reducer now performs a `deepCopy` and will return the original state unless something has changed in the API response.

This PR also moves logic for extracting column headers out of the Body container and into the Body component.
