### PR TITLE
feat(backend): log backend output to tmp/io.qri.desktop/qri.log

### DIFF
--- a/app/backend.js
+++ b/app/backend.js
@@ -1,12 +1,42 @@
 const childProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
+const os = require('os')
+const { dialog } = require('electron')
+
 
 // BackendProcess runs the qri backend binary in connected'ed mode, to handle api requests.
 class BackendProcess {
   constructor () {
     this.qriBinPath = null
     this.process = null
+
+    if (process.env.NODE_ENV === 'development') {
+      // if we're in dev mode write to this process
+      this.out = process.stdout
+      this.err = process.stderr
+    } else {
+      try {
+        const dirPath = path.join(os.tmpdir(), 'io.qri.desktop')
+        const logPath = path.join(dirPath, 'qri.log')
+        
+        if (!fs.existsSync(dirPath)) {
+          fs.mkdirSync(dirPath)
+        }
+        this.out = fs.openSync(logPath, 'a')
+        this.err = fs.openSync(logPath, 'a')
+      } catch (err) {
+        dialog.showMessageBox({
+          type: 'error',
+          title: 'error setting up backend logging',
+          message: 'We couldn\'t configure the backend to log to a temporary directory. \nThis might not be a big deal, but it also may be a sign of problems with qri interacting with your filesystem',
+          detail: err
+        })
+        // fall back to writing to stdout & stderr
+        this.out = process.stdout
+        this.err = process.stderr
+      }
+    }
   }
 
   maybeStartup () {
@@ -28,7 +58,7 @@ class BackendProcess {
 
   launchProcess () {
     try {
-      this.process = childProcess.spawn(this.qriBinPath, ['connect', '--setup'], {})
+      this.process = childProcess.spawn(this.qriBinPath, ['connect', '--setup'], { stdio: ['ignore', this.out, this.err] })
       this.process.on('error', (err) => { this.handleEvent('error', err) })
       this.process.on('exit', (err) => { this.handleEvent('exit', err) })
       this.process.on('close', (err) => { this.handleEvent('close', err) })


### PR DESCRIPTION
closes #246.

When running the complied app, you should now be able to search your filesystem for `io.qri.desktop` and see a file called `qri.log`. It'll be in your tmp directory.