### PR TITLE
feat: persist dataset path

### DIFF
--- a/app/actions/selections.ts
+++ b/app/actions/selections.ts
@@ -2,7 +2,8 @@ import {
   SELECTIONS_SET_ACTIVE_TAB,
   SELECTIONS_SET_SELECTED_LISTITEM,
   SELECTIONS_SET_WORKING_DATASET,
-  SELECTIONS_CLEAR
+  SELECTIONS_CLEAR,
+  SELECTIONS_SET_DATASET_PATH
 } from '../reducers/selections'
 
 export const setActiveTab = (activeTab: string) => {
@@ -35,5 +36,12 @@ export const setWorkingDataset = (peername: string, name: string) => {
 export const clearSelection = () => {
   return {
     type: SELECTIONS_CLEAR
+  }
+}
+
+export const setDatasetPath = (path: string) => {
+  return {
+    type: SELECTIONS_SET_DATASET_PATH,
+    payload: { path }
   }
 }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -55,6 +55,7 @@ export interface AppProps {
   removeDatasetAndFetch: (peername: string, name: string, removeFiles: boolean) => Promise<ApiAction>
   publishDataset: () => Promise<ApiAction>
   unpublishDataset: () => Promise<ApiAction>
+  setDatasetPath: (path: string) => Action
 }
 
 interface AppState {
@@ -158,8 +159,10 @@ class App extends React.Component<AppProps, AppState> {
       case ModalType.CreateDataset: {
         modalComponent = (
           <CreateDataset
+            datasetPath={this.props.selections.datasetPath}
             onSubmit={this.props.initDataset}
             onDismissed={async () => setModal(noModalObject)}
+            setDatasetPath={this.props.setDatasetPath}
           />
         )
         break

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import path from 'path'
+import { Action } from 'redux'
 import { remote } from 'electron'
 
 import Modal from './Modal'
@@ -14,11 +15,19 @@ import { validateDatasetName } from '../../utils/formValidation'
 interface CreateDatasetProps {
   onDismissed: () => void
   onSubmit: (path: string, name: string, dir: string, mkdir: string) => Promise<ApiAction>
+  datasetPath: string
+  setDatasetPath: (path: string) => Action
 }
 
-const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismissed, onSubmit }) => {
+const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
+  const {
+    onDismissed,
+    onSubmit,
+    datasetPath: persistedDatasetPath,
+    setDatasetPath: saveDatasetPath
+  } = props
   const [datasetName, setDatasetName] = React.useState('')
-  const [datasetPath, setDatasetPath] = React.useState('')
+  const [datasetPath, setDatasetPath] = React.useState(persistedDatasetPath)
   const [filePath, setFilePath] = React.useState('')
 
   const [dismissable, setDismissable] = React.useState(true)
@@ -35,6 +44,11 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = ({ onDismisse
     const ready = datasetPath !== '' && filePath !== '' && !datasetNameValidationError
     setButtonDisabled(!ready)
   }, [datasetName, datasetPath, filePath])
+
+  React.useEffect(() => {
+    // persist the datasetPath
+    saveDatasetPath(datasetPath)
+  }, [datasetPath])
 
   // should come from props
   const [error, setError] = React.useState('')

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -26,7 +26,8 @@ import {
 } from '../actions/session'
 
 import {
-  setWorkingDataset
+  setWorkingDataset,
+  setDatasetPath
 } from '../actions/selections'
 
 const mergeProps = (props: any, actions: any): AppProps => {
@@ -68,7 +69,8 @@ const AppContainer = connect(
     setModal,
     publishDataset,
     unpublishDataset,
-    removeDatasetAndFetch
+    removeDatasetAndFetch,
+    setDatasetPath
   },
   mergeProps
 )(App)

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -74,6 +74,7 @@ export interface Selections {
   component: SelectedComponent
   commit: string
   commitComponent: string
+  datasetPath: string
 }
 
 // info about the current value of a list being paginated

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -8,6 +8,7 @@ export const SELECTIONS_SET_ACTIVE_TAB = 'SELECTIONS_SET_ACTIVE_TAB'
 export const SELECTIONS_SET_SELECTED_LISTITEM = 'SELECTIONS_SET_SELECTED_LISTITEM'
 export const SELECTIONS_SET_WORKING_DATASET = 'SELECTIONS_SET_WORKING_DATASET'
 export const SELECTIONS_CLEAR = 'SELECTIONS_CLEAR'
+export const SELECTIONS_SET_DATASET_PATH = 'SELECTIONS_SET_DATASET_PATH'
 
 export const initialState: Selections = {
   peername: localStore().getItem('peername') || '',
@@ -15,7 +16,8 @@ export const initialState: Selections = {
   activeTab: localStore().getItem('activeTab') || 'status',
   component: localStore().getItem('component') as SelectedComponent || '',
   commit: localStore().getItem('commit') || '',
-  commitComponent: localStore().getItem('commitComponent') || ''
+  commitComponent: localStore().getItem('commitComponent') || '',
+  datasetPath: localStore().getItem('datasetPath') || ''
 }
 
 export const [, ADD_SUCC] = apiActionTypes('add')
@@ -136,6 +138,14 @@ export default (state = initialState, action: AnyAction) => {
         peername: action.payload.data.peername,
         name: action.payload.data.name,
         activeTab: 'status'
+      }
+
+    case SELECTIONS_SET_DATASET_PATH:
+      const { path: datasetPath } = action.payload
+      localStore().setItem('datasetPath', datasetPath)
+      return {
+        ...state,
+        datasetPath
       }
 
     default:


### PR DESCRIPTION
Adds `datasetPath` to localStore, adds `setDatasetPath` action, adds `useEffect()` in `CreateDataset` modal to persist the datasetPath immediately after the user chooses a directory.

Closes #251 