### PR TITLE
feat: 2d schema layout

### DIFF
--- a/app/components/KeyValueTable.tsx
+++ b/app/components/KeyValueTable.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+
+interface KeyValueTableProps {
+  data: any
+  filterKeys?: string[]
+}
+
+const KeyValueTable: React.FunctionComponent<KeyValueTableProps> = ({ data, filterKeys }) => (
+  <div className='keyvalue-table-wrap'>
+    <table className='keyvalue-table'>
+      <tbody>
+        {Object.keys(data).map((key) => {
+          if (filterKeys && filterKeys.includes(key)) return null
+          const value = data[key]
+
+          return (
+            <tr key={key} className='keyvalue-table-row'>
+              <td className='keyvalue-table-key'>{key}</td>
+              <td>{value}</td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  </div>
+)
+
+export default KeyValueTable

--- a/app/components/Metadata.tsx
+++ b/app/components/Metadata.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import ExternalLink from './ExternalLink'
+import KeyValueTable from './KeyValueTable'
 import SpinnerWithIcon from './chrome/SpinnerWithIcon'
 import { standardFields } from './MetadataEditor'
 import { Meta, Citation, License, User } from '../models/dataset'
@@ -43,20 +44,7 @@ const renderArrayItemsTable = (value: any[]) => {
   return (
     <div className='array-items-table-container'>
       {
-        value.map((item, i) => (
-          <div key={i} className='metadata-viewer-table-wrap'>
-            <table className='metadata-viewer-table '>
-              <tbody>
-                {Object.keys(item).map((key: string) => (
-                  <tr key={key} className='metadata-viewer-row'>
-                    <td className='metadata-viewer-key'>{key}</td>
-                    <td>{item[key]}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        ))
+        value.map((item, i) => (<div key={i}><KeyValueTable data={item} /></div>))
       }
     </div>
   )
@@ -72,8 +60,8 @@ const renderMultiStructured = (value: User[] | Citation[]) => {
 
 const renderTable = (keys: string[], data: Meta) => {
   return (
-    <div className='metadata-viewer-table-wrap'>
-      <table className='metadata-viewer-table'>
+    <div className='keyvalue-table-wrap'>
+      <table className='keyvalue-table'>
         <tbody>
           {keys.map((key) => {
             const value = data[key]
@@ -102,8 +90,8 @@ const renderTable = (keys: string[], data: Meta) => {
             }
 
             return (
-              <tr key={key} className='metadata-viewer-row'>
-                <td className='metadata-viewer-key'>{key}</td>
+              <tr key={key} className='keyvalue-table-row'>
+                <td className='keyvalue-table-key'>{key}</td>
                 <td>{cellContent}</td>
               </tr>
             )

--- a/app/components/Schema.tsx
+++ b/app/components/Schema.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
+import TwoDSchemaLayout from './TwoDSchemaLayout'
 import ReactJson from 'react-json-view'
 
-import { Dataset } from '../models/dataset'
 import SpinnerWithIcon from './chrome/SpinnerWithIcon'
 
 interface SchemaProps {
-  schema: Dataset['schema']
+  schema: any
 }
 
 const Schema: React.FunctionComponent<SchemaProps> = ({ schema }) => {
@@ -13,14 +13,21 @@ const Schema: React.FunctionComponent<SchemaProps> = ({ schema }) => {
     return <SpinnerWithIcon loading={true} />
   }
 
+  // render TwoDSchemaLayout only if schema meets specific criteria
+  const is2D = schema && schema.items && schema.items.items
+
+  const schemaContent = is2D
+    ? <TwoDSchemaLayout schema={schema} />
+    : <ReactJson
+      name={null}
+      src={schema}
+      enableClipboard={false}
+      displayDataTypes={false}
+    />
+
   return (
     <div className='content'>
-      <ReactJson
-        name={null}
-        src={schema}
-        enableClipboard={false}
-        displayDataTypes={false}
-      />
+      {schemaContent}
     </div>
   )
 }

--- a/app/components/TwoDSchemaLayout.tsx
+++ b/app/components/TwoDSchemaLayout.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFont, faToggleOn } from '@fortawesome/free-solid-svg-icons'
+
+import KeyValueTable from './KeyValueTable'
+
+interface RowProps {
+  column: ColumnProperties
+}
+
+const buildOtherKeywordsTable = (column: any) => {
+  const filterKeys = ['title', 'type', 'description']
+  const hasOtherKeys = Object.keys(column).filter(d => !filterKeys.includes(d)).length > 0
+  return hasOtherKeys ? <KeyValueTable data={column} filterKeys={filterKeys}/> : null
+}
+
+interface TypeLabelProps {
+  type: string | undefined
+}
+
+const TypeLabel: React.FunctionComponent<TypeLabelProps> = ({ type }) => {
+  let icon
+  switch (type) {
+    case 'string':
+      icon = <FontAwesomeIcon icon={faFont} size='xs'/>
+      break
+    case 'number':
+      icon = <div className='text-glyph'>1.0</div>
+      break
+    case 'integer':
+      icon = <div className='text-glyph'>1</div>
+      break
+    case 'boolean':
+      icon = <FontAwesomeIcon icon={faToggleOn} size='xs'/>
+      break
+    default:
+      icon = ''
+  }
+
+  return (<span className='type-label'><div className='type-icon'>{icon}</div>&nbsp;&nbsp;{type}</span>)
+}
+
+const Row: React.FunctionComponent<RowProps> = ({ column }) => {
+  // let typeContent
+
+  return (
+    <div className='row'>
+      <div className='cell'>{column.title}</div>
+      <div className='cell'>
+        <TypeLabel type={column.type}/>
+      </div>
+      <div className='cell'>{column.description}</div>
+      <div className='cell other-keywords'>{buildOtherKeywordsTable(column)}</div>
+    </div>
+  )
+}
+
+interface ColumnProperties {
+  title?: string
+  type?: string
+  [key: string]: any
+}
+
+interface TwoDSchemaLayoutProps {
+  schema: {
+    items: {
+      items: ColumnProperties[]
+    }
+  }
+}
+
+const TwoDSchemaLayout: React.FunctionComponent<TwoDSchemaLayoutProps> = ({ schema }) => {
+  if (schema && schema.items && schema.items) {
+    const columns = schema.items.items
+    return (
+      <div className='twod-schema-layout'>
+        <div className='flex-table'>
+          <div className='row header-row'>
+            <div className='cell'>Title</div>
+            <div className='cell'>Type</div>
+            <div className='cell'>Description</div>
+            <div className='cell capitalize other-keywords'>Other</div>
+          </div>
+          { columns.map((column: ColumnProperties, i: number) => {
+            return <Row key={i} column={column} />
+          })}
+        </div>
+      </div>
+    )
+  }
+
+  return null
+}
+
+export default TwoDSchemaLayout

--- a/app/components/form/MultiStructuredInput.tsx
+++ b/app/components/form/MultiStructuredInput.tsx
@@ -115,7 +115,7 @@ const MultiStructuredInput: React.FunctionComponent<MultiStructuredInputProps> =
 
       <div className='multi-structured-input-container'>
         <div className='list'>
-          <div className='multi-structured-input'>
+          <div className='multi-structured-input flex-table'>
             <div className='row header-row'>
               {
                 headerRowValues.map((d: string) => (

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -109,8 +109,10 @@ export default (state = initialState, action: AnyAction) => {
         commitComponent: chooseDefaultComponent(action.payload.data.dataset)
       }
     case DATASET_SUCC:
+      // special handling for schema since it's not a top-level component
+      const selectedComponent = state.component === 'schema' ? 'structure' : state.component
       // if the selected component exists on dataset, no changes needed
-      if (action.payload.data.dataset[state.component] || (state.component === 'body' && action.payload.data.dataset['bodyPath'])) return state
+      if (action.payload.data.dataset[selectedComponent] || (state.component === 'body' && action.payload.data.dataset['bodyPath'])) return state
 
       return {
         ...state,

--- a/app/scss/_schema.scss
+++ b/app/scss/_schema.scss
@@ -1,6 +1,6 @@
 //
 // SCSS for Schema components
-// 
+//
 // EditSchema
 // schema
 
@@ -25,4 +25,46 @@
   border-radius: 2px;
   border: 1px solid $primary-muted;
   margin: 5px 14px;
+}
+
+.twod-schema-layout {
+  .flex-table {
+    .cell {
+      display: inline-flex;
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .header-row {
+      font-weight: 500;
+      padding: 0;
+      margin-bottom: 9px;
+      border-bottom: 1px solid $border-color
+    }
+
+    .row {
+      display: flex;
+      padding: 10px 0;
+      border-bottom: 1px solid #eaeaea;
+    }
+
+    .other-keywords {
+      flex-basis: 20%;
+    }
+  }
+
+  .type-icon {
+    display: inline-block;
+    min-width: 20px;
+    display: inline-block;
+    min-width: 15px;
+    text-align: center;
+    color: #ababab;
+  }
+
+  .text-glyph {
+    font-size: 0.6rem;
+    font-weight: 700;
+  }
 }

--- a/app/scss/_site.scss
+++ b/app/scss/_site.scss
@@ -748,5 +748,30 @@ b {
 }
 
 .capitalize {
-  text-transform: capitalize 
+  text-transform: capitalize
+}
+
+// keyvalue table
+
+.keyvalue-table-wrap {
+  width: 100%;
+  border-radius: 3px;
+  border: 1px solid #eee;
+  overflow: hidden;
+
+  .keyvalue-table {
+    width: 100%;
+
+    .keyvalue-table-row {
+      border-bottom: 1px solid #eee;
+
+      .keyvalue-table-key {
+        padding: 8px 8px;
+        font-size: .8rem;
+        font-weight: 600;
+        width: 112px;
+        text-align: right;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adds a simple tabular layout for csv `schema` components.  If the working dataset's `schema` looks like a qri's common csv format, it will render a table instead of the JSON viewer.

`title`,`type`, and `description` are first class keys, all others are displayed in a simple key-value table.

Closes #49 

![Qri_Desktop_and_Comparing_master___schema-layout_·_qri-io_desktop_and_desktop_—_Electron_Helper_◂_node____nvm_versions_node_v12_1_0_bin_yarn_dev_—_129×43](https://user-images.githubusercontent.com/1833820/65635004-782c0d80-dfad-11e9-93f9-7f7af146990f.png)
