### PR TITLE
fix(*): Lots o fixes

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -46,7 +46,6 @@ export function fetchWorkingDatasetDetails (): ApiActionThunk {
     const whenOk = chainSuccess(dispatch, getState)
     let response: AnyAction
     response = await fetchWorkingDataset()(dispatch, getState)
-
     // if the response returned in error, check the error
     // if it's 422, it means the dataset exists, it's just not linked to the filesystem
     if (getActionType(response) === 'failure') {
@@ -123,7 +122,8 @@ export function fetchMyDatasets (page: number = 1, pageSize: number = pageSizeDe
     const state = getState()
     const { page: confirmedPage, doNotFetch } = actionWithPagination(page, state.myDatasets.pageInfo)
 
-    if (doNotFetch) return new Promise(resolve => resolve())
+    // we need to emit a 'success' type, or our chainSuccess functions will fail
+    if (doNotFetch) return new Promise(resolve => resolve({ type: 'SUCCESS' }))
 
     const listAction: ApiAction = {
       type: 'list',
@@ -234,7 +234,8 @@ export function fetchWorkingHistory (page: number = 1, pageSize: number = pageSi
 
     const { page: confirmedPage, doNotFetch } = actionWithPagination(page, state.workingDataset.history.pageInfo)
 
-    if (doNotFetch) return new Promise(resolve => resolve())
+    // we need to emit a 'success' type, or our chainSuccess functions will fail
+    if (doNotFetch) return new Promise(resolve => resolve({ type: 'SUCCESS' }))
 
     const { selections, myDatasets } = getState()
     const { peername, name } = selections
@@ -294,7 +295,8 @@ export function fetchBody (page: number = 1, pageSize: number = bodyPageSizeDefa
 
     const { page: confirmedPage, doNotFetch } = actionWithPagination(page, workingDataset.components.body.pageInfo)
 
-    if (doNotFetch) return new Promise(resolve => resolve())
+    // we need to emit a 'success' type, or our chainSuccess functions will fail
+    if (doNotFetch) return new Promise(resolve => resolve({ type: 'SUCCESS' }))
 
     const action = {
       type: 'body',
@@ -327,7 +329,8 @@ export function fetchCommitBody (page: number = 1, pageSize: number = bodyPageSi
 
     const { page: confirmedPage, doNotFetch } = actionWithPagination(page, commitDetails.components.body.pageInfo)
 
-    if (doNotFetch) return new Promise(resolve => resolve())
+    // we need to emit a 'success' type, or our chainSuccess functions will fail
+    if (doNotFetch) return new Promise(resolve => resolve({ type: 'SUCCESS' }))
 
     const action = {
       type: 'commitBody',

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -57,14 +57,7 @@ export function fetchWorkingDatasetDetails (): ApiActionThunk {
     response = await whenOk(fetchWorkingStatus())(response)
     response = await whenOk(fetchBody())(response)
     response = await whenOk(fetchWorkingHistory(-1))(response)
-    const { workingDataset, selections } = getState()
-    const { history } = workingDataset
-    const { commit } = selections
 
-    // if history length changes, select the latest commit
-    if (history.value.length !== 0 && (commit === '' || !history.value.some(c => c.path === commit))) {
-      await dispatch(setSelectedListItem('commit', history.value[0].path))
-    }
     return response
   }
 }

--- a/app/actions/selections.ts
+++ b/app/actions/selections.ts
@@ -2,8 +2,7 @@ import {
   SELECTIONS_SET_ACTIVE_TAB,
   SELECTIONS_SET_SELECTED_LISTITEM,
   SELECTIONS_SET_WORKING_DATASET,
-  SELECTIONS_CLEAR,
-  SELECTIONS_SET_DATASET_PATH
+  SELECTIONS_CLEAR
 } from '../reducers/selections'
 
 export const setActiveTab = (activeTab: string) => {
@@ -36,12 +35,5 @@ export const setWorkingDataset = (peername: string, name: string) => {
 export const clearSelection = () => {
   return {
     type: SELECTIONS_CLEAR
-  }
-}
-
-export const setDatasetPath = (path: string) => {
-  return {
-    type: SELECTIONS_SET_DATASET_PATH,
-    payload: { path }
   }
 }

--- a/app/actions/ui.ts
+++ b/app/actions/ui.ts
@@ -9,7 +9,8 @@ import {
   UI_CLOSE_TOAST,
   UI_SET_MODAL,
   UI_SIGNOUT,
-  UI_HIDE_COMMIT_NUDGE
+  UI_HIDE_COMMIT_NUDGE,
+  UI_SET_DATASET_DIR_PATH
 } from '../reducers/ui'
 
 import { ToastType } from '../models/store'
@@ -72,5 +73,12 @@ export const signout = () => {
 export const setHideCommitNudge = () => {
   return {
     type: UI_HIDE_COMMIT_NUDGE
+  }
+}
+
+export const setDatasetDirPath = (path: string) => {
+  return {
+    type: UI_SET_DATASET_DIR_PATH,
+    path
   }
 }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -207,6 +207,7 @@ class App extends React.Component<AppProps, AppState> {
         classNames="fade"
         component="div"
         timeout={1000}
+        mountOnEnter
         unmountOnExit
       >
         <AppLoading />
@@ -231,8 +232,13 @@ class App extends React.Component<AppProps, AppState> {
   render () {
     const {
       toast,
-      closeToast
+      closeToast,
+      loading
     } = this.props
+
+    if (loading) {
+      return this.renderAppLoading()
+    }
 
     return (
       <div style={{
@@ -240,7 +246,6 @@ class App extends React.Component<AppProps, AppState> {
         position: 'relative',
         overflow: 'hidden'
       }}>
-        {this.renderAppLoading()}
         {this.renderAppError()}
         {this.renderModal()}
         <Router>

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -38,6 +38,8 @@ export interface AppProps {
   selections: Selections
   apiConnection?: number
   hasAcceptedTOS: boolean
+  // the persited directory path to which the user last saved a dataset
+  datasetDirPath: string
   qriCloudAuthenticated: boolean
   toast: IToast
   modal: Modal
@@ -59,7 +61,7 @@ export interface AppProps {
   removeDatasetAndFetch: (peername: string, name: string, removeFiles: boolean) => Promise<ApiAction>
   publishDataset: () => Promise<ApiAction>
   unpublishDataset: () => Promise<ApiAction>
-  setDatasetPath: (path: string) => Action
+  setDatasetDirPath: (path: string) => Action
 }
 
 interface AppState {
@@ -152,10 +154,10 @@ class App extends React.Component<AppProps, AppState> {
       case ModalType.CreateDataset: {
         modalComponent = (
           <CreateDataset
-            datasetPath={this.props.selections.datasetPath}
+            datasetDirPath={this.props.datasetDirPath}
             onSubmit={this.props.initDataset}
             onDismissed={async () => setModal(noModalObject)}
-            setDatasetPath={this.props.setDatasetPath}
+            setDatasetDirPath={this.props.setDatasetDirPath}
           />
         )
         break

--- a/app/components/Body.tsx
+++ b/app/components/Body.tsx
@@ -24,8 +24,7 @@ export interface BodyProps {
 }
 
 function shouldDisplayTable (value: any[] | Object, structure: Structure) {
-  // if it's a CSV, or if JSON with depth of 2, render a table
-  return value && structure && structure.depth === 2
+  return value && structure && (structure.format === 'csv' || structure.format === 'xlsx' || structure.depth === 2)
 }
 
 const extractColumnHeaders = (workingDataset: WorkingDataset): undefined | object => {

--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -201,7 +201,7 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
                 displayName={displayName}
                 name={displayName}
                 icon={icon}
-                disabled={true}
+                disabled={(name !== 'meta' && datasetSelected) && true}
                 tooltip={tooltip}
               />
             )

--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -202,8 +202,10 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
                 name={displayName}
                 icon={icon}
                 selectionType={selectionType}
+                // TODO (ramfox): we should create a 'isDisabled' function and add these specifications & test
                 disabled={!datasetSelected || name !== 'meta' || (name === 'meta' && selectionType !== 'component')}
                 tooltip={tooltip}
+                // ditto, this should relate to the above
                 onClick={(name === 'meta' && datasetSelected && selectionType === 'component') ? onComponentClick : undefined}
               />
             )

--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -60,7 +60,7 @@ export const FileRow: React.FunctionComponent<FileRowProps> = (props) => (
     })}
     onClick={() => {
       if (props.onClick && props.selectionType && props.name) {
-        props.onClick(props.selectionType, props.name)
+        props.onClick(props.selectionType, props.name.toLowerCase())
       }
     }}
   >
@@ -201,8 +201,10 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
                 displayName={displayName}
                 name={displayName}
                 icon={icon}
-                disabled={(name !== 'meta' && datasetSelected) && true}
+                selectionType={selectionType}
+                disabled={!datasetSelected || name !== 'meta' || (name === 'meta' && selectionType !== 'component')}
                 tooltip={tooltip}
+                onClick={(name === 'meta' && datasetSelected && selectionType === 'component') ? onComponentClick : undefined}
               />
             )
           }

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -173,7 +173,7 @@ export default class DatasetList extends React.Component<DatasetListProps> {
                 data-tip='Copy an existing<br/>Qri dataset to your computer'
               >
                 <FontAwesomeIcon icon={faDownload} />&nbsp;&nbsp;
-                <span>Add a Dataset</span>
+                <span>Add from Network</span>
               </div>
               <div
                 className='dataset-list-button btn btn-primary'
@@ -181,7 +181,7 @@ export default class DatasetList extends React.Component<DatasetListProps> {
                 data-tip='Create a new Qri <br/>dataset from a data file'
               >
                 <FontAwesomeIcon icon={faPlus} />&nbsp;&nbsp;
-                <span>New Dataset</span>
+                <span>Create New</span>
               </div>
             </div>
             <div className='filter-input-container'>

--- a/app/components/modals/AddDataset.tsx
+++ b/app/components/modals/AddDataset.tsx
@@ -14,7 +14,7 @@ interface AddByNameProps {
 const AddByName: React.FunctionComponent<AddByNameProps> = ({ datasetName, onChange }) => {
   return (
     <div className='content'>
-      <p>Add a dataset that already exists on Qri</p>
+      <p>Add a datasetthat already exists on the Qri network</p>
       <p>Qri dataset names have the following structure: <strong>peername/dataset name</strong>.</p>
       <p>For example: <strong>chriswhong/usgs_earthquakes</strong></p>
       <TextInput
@@ -37,7 +37,7 @@ interface AddByUrl {
 const AddByUrl: React.FunctionComponent<AddByUrl> = ({ url, onChange }) => {
   return (
     <div className='content'>
-      <p>Add a dataset that already exists on Qri using a <strong>url</strong></p>
+      <p>Add a dataset that already exists on the Qri Network using a <strong>url</strong></p>
       <TextInput
         name='url'
         label='Url'
@@ -167,7 +167,7 @@ const AddDataset: React.FunctionComponent<AddDatasetProps> = ({ onDismissed, onS
   return (
     <Modal
       id="addDataset"
-      title={'Add Dataset'}
+      title={'Add a Dataset from the Network'}
       onDismissed={onDismissed}
       onSubmit={() => {}}
       dismissable={dismissable}

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -15,19 +15,19 @@ import { validateDatasetName } from '../../utils/formValidation'
 interface CreateDatasetProps {
   onDismissed: () => void
   onSubmit: (path: string, name: string, dir: string, mkdir: string) => Promise<ApiAction>
-  datasetPath: string
-  setDatasetPath: (path: string) => Action
+  datasetDirPath: string
+  setDatasetDirPath: (path: string) => Action
 }
 
 const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
   const {
     onDismissed,
     onSubmit,
-    datasetPath: persistedDatasetPath,
-    setDatasetPath: saveDatasetPath
+    datasetDirPath: persistedDatasetDirPath,
+    setDatasetDirPath: saveDatasetDirPath
   } = props
   const [datasetName, setDatasetName] = React.useState('')
-  const [datasetPath, setDatasetPath] = React.useState(persistedDatasetPath)
+  const [datasetDirPath, setDatasetDirPath] = React.useState(persistedDatasetDirPath)
   const [filePath, setFilePath] = React.useState('')
 
   const [dismissable, setDismissable] = React.useState(true)
@@ -41,21 +41,21 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
     datasetNameValidationError ? setDatasetNameError(datasetNameValidationError) : setDatasetNameError('')
 
     // only ready when all three fields are not invalid
-    const ready = datasetPath !== '' && filePath !== '' && !datasetNameValidationError
+    const ready = datasetDirPath !== '' && filePath !== '' && !datasetNameValidationError
     setButtonDisabled(!ready)
-  }, [datasetName, datasetPath, filePath])
+  }, [datasetName, datasetDirPath, filePath])
 
   React.useEffect(() => {
-    // persist the datasetPath
-    saveDatasetPath(datasetPath)
-  }, [datasetPath])
+    // persist the datasetDirPath
+    saveDatasetDirPath(datasetDirPath)
+  }, [datasetDirPath])
 
   // should come from props
   const [error, setError] = React.useState('')
   const [loading, setLoading] = React.useState(false)
 
   // should come from props/actions that has us check if the directory already contains a qri dataset
-  const isQriDataset = (datasetPath: string) => !datasetPath
+  const isQriDataset = (datasetDirPath: string) => !datasetDirPath
 
   const showDirectoryPicker = () => {
     const window = remote.getCurrentWindow()
@@ -69,7 +69,7 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
 
     const selectedPath = directory[0]
 
-    setDatasetPath(selectedPath)
+    setDatasetDirPath(selectedPath)
     const isDataset = isQriDataset(selectedPath)
     if (isDataset) {
       setAlreadyDatasetError('A dataset already exists in this directory.')
@@ -135,7 +135,7 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
     setLoading(true)
     error && setError('')
     if (!onSubmit) return
-    onSubmit(filePath, datasetName, datasetPath, datasetName)
+    onSubmit(filePath, datasetName, datasetDirPath, datasetName)
       .then(() => onDismissed())
       .catch((action: any) => {
         setLoading(false)
@@ -144,7 +144,7 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
       })
   }
 
-  const fullPath = path.join(datasetPath, datasetName)
+  const fullPath = path.join(datasetDirPath, datasetName)
 
   return (
     <Modal
@@ -190,7 +190,7 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
               label='Directory path'
               labelTooltip='Qri will create a new directory for<br/>this dataset&apos;s files at this location.'
               type=''
-              value={datasetPath}
+              value={datasetDirPath}
               onChange={handleChanges}
               maxLength={600}
               errorText={alreadyDatasetError}

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -149,7 +149,7 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
   return (
     <Modal
       id="CreateDataset"
-      title={'New Dataset'}
+      title={'Create a New Dataset'}
       onDismissed={onDismissed}
       onSubmit={() => {}}
       dismissable={dismissable}

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -38,7 +38,7 @@ const AppContainer = connect(
   (state: Store) => {
     const { ui, myDatasets, session, workingDataset, connection, selections } = state
     const { apiConnection } = connection
-    const loading = connection.apiConnection === 0
+    const loading = connection.apiConnection === 0 || session.isLoading
     const hasDatasets = myDatasets.value.length !== 0
     const { id: sessionID, peername } = session
     const { toast, modal } = ui

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -17,7 +17,8 @@ import {
   acceptTOS,
   setQriCloudAuthenticated,
   closeToast,
-  setModal
+  setModal,
+  setDatasetDirPath
 } from '../actions/ui'
 
 import {
@@ -26,8 +27,7 @@ import {
 } from '../actions/session'
 
 import {
-  setWorkingDataset,
-  setDatasetPath
+  setWorkingDataset
 } from '../actions/selections'
 
 const mergeProps = (props: any, actions: any): AppProps => {
@@ -41,7 +41,7 @@ const AppContainer = connect(
     const loading = connection.apiConnection === 0 || session.isLoading
     const hasDatasets = myDatasets.value.length !== 0
     const { id: sessionID, peername } = session
-    const { toast, modal } = ui
+    const { toast, modal, datasetDirPath } = ui
     return {
       hasDatasets,
       loading,
@@ -51,7 +51,8 @@ const AppContainer = connect(
       toast,
       modal,
       workingDataset,
-      apiConnection
+      apiConnection,
+      datasetDirPath
     }
   },
   {
@@ -70,7 +71,7 @@ const AppContainer = connect(
     publishDataset,
     unpublishDataset,
     removeDatasetAndFetch,
-    setDatasetPath
+    setDatasetDirPath
   },
   mergeProps
 )(App)

--- a/app/containers/MetadataEditorContainer.tsx
+++ b/app/containers/MetadataEditorContainer.tsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import MetadataEditor from '../components/MetadataEditor'
 import Store from '../models/store'
 
-import { fsiWrite } from '../actions/api'
+import { fsiWriteAndFetch } from '../actions/api'
 
 const mapStateToProps = (state: Store) => {
   const { workingDataset } = state
@@ -13,7 +13,7 @@ const mapStateToProps = (state: Store) => {
 }
 
 const actions = {
-  fsiWrite
+  fsiWrite: fsiWriteAndFetch
 }
 
 export default connect(mapStateToProps, actions)(MetadataEditor)

--- a/app/containers/SaveFormContainer.tsx
+++ b/app/containers/SaveFormContainer.tsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import SaveForm, { SaveFormProps } from '../components/SaveForm'
-import { saveWorkingDataset } from '../actions/api'
+import { saveWorkingDatasetAndFetch } from '../actions/api'
 import Store from '../models/store'
 import { setCommitTitle, setCommitMessage } from '../actions/mutations'
 
@@ -17,7 +17,7 @@ const mapStateToProps = (state: Store) => {
 }
 
 const actions = {
-  saveWorkingDataset,
+  saveWorkingDataset: saveWorkingDatasetAndFetch,
   setCommitTitle,
   setCommitMessage
 }

--- a/app/models/session.ts
+++ b/app/models/session.ts
@@ -14,4 +14,5 @@ export interface Session {
   poster?: string
   twitter?: string
   peerIDs?: string[]
+  isLoading?: boolean
 }

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -62,6 +62,7 @@ export interface UI {
   toast: Toast
   blockMenus: boolean
   hideCommitNudge: boolean
+  datasetDirPath: string
 }
 
 export type SelectedComponent = 'meta' | 'body' | 'schema' | ''
@@ -74,7 +75,6 @@ export interface Selections {
   component: SelectedComponent
   commit: string
   commitComponent: string
-  datasetPath: string
 }
 
 // info about the current value of a list being paginated

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -16,7 +16,8 @@ const initialSession: Session = {
   peername: '',
   id: '',
   created: '',
-  updated: ''
+  updated: '',
+  isLoading: true
 }
 
 const [SESSION_REQ, SESSION_SUCC, SESSION_FAIL] = apiActionTypes('session')
@@ -26,6 +27,10 @@ const [SIGNIN_REQ, SIGNIN_SUCC, SIGNIN_FAIL] = apiActionTypes('signin')
 const sessionReducer: Reducer = (state = initialSession, action: AnyAction) => { // eslint-disable-line
   switch (action.type) {
     case SESSION_REQ:
+      return {
+        ...state,
+        isLoading: true
+      }
     case SIGNUP_REQ:
     case SIGNIN_REQ:
       return state
@@ -34,12 +39,16 @@ const sessionReducer: Reducer = (state = initialSession, action: AnyAction) => {
     case SIGNIN_SUCC:
       return {
         ...state,
-        ...action.payload.data
+        ...action.payload.data,
+        isLoading: false
       }
     case SESSION_FAIL:
     case SIGNUP_FAIL:
     case SIGNIN_FAIL:
-      return state
+      return {
+        ...state,
+        isLoading: false
+      }
     default:
       return state
   }

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -13,7 +13,6 @@ export const SELECTIONS_SET_ACTIVE_TAB = 'SELECTIONS_SET_ACTIVE_TAB'
 export const SELECTIONS_SET_SELECTED_LISTITEM = 'SELECTIONS_SET_SELECTED_LISTITEM'
 export const SELECTIONS_SET_WORKING_DATASET = 'SELECTIONS_SET_WORKING_DATASET'
 export const SELECTIONS_CLEAR = 'SELECTIONS_CLEAR'
-export const SELECTIONS_SET_DATASET_PATH = 'SELECTIONS_SET_DATASET_PATH'
 
 export const initialState: Selections = {
   peername: localStore().getItem('peername') || '',
@@ -21,8 +20,7 @@ export const initialState: Selections = {
   activeTab: localStore().getItem('activeTab') || 'status',
   component: localStore().getItem('component') as SelectedComponent || '',
   commit: localStore().getItem('commit') || '',
-  commitComponent: localStore().getItem('commitComponent') || '',
-  datasetPath: localStore().getItem('datasetPath') || ''
+  commitComponent: localStore().getItem('commitComponent') || ''
 }
 
 export const [, ADD_SUCC] = apiActionTypes('add')
@@ -175,14 +173,6 @@ export default (state = initialState, action: AnyAction) => {
         peername: action.payload.data.peername,
         name: action.payload.data.name,
         activeTab: 'status'
-      }
-
-    case SELECTIONS_SET_DATASET_PATH:
-      const { path: datasetPath } = action.payload
-      localStore().setItem('datasetPath', datasetPath)
-      return {
-        ...state,
-        datasetPath
       }
 
     default:

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -4,6 +4,11 @@ import localStore from '../utils/localStore'
 import { apiActionTypes } from '../utils/actionType'
 import chooseDefaultComponent from '../utils/chooseDefaultComponent'
 
+import {
+  HISTORY_REQ,
+  HISTORY_SUCC
+} from '../reducers/workingDataset'
+
 export const SELECTIONS_SET_ACTIVE_TAB = 'SELECTIONS_SET_ACTIVE_TAB'
 export const SELECTIONS_SET_SELECTED_LISTITEM = 'SELECTIONS_SET_SELECTED_LISTITEM'
 export const SELECTIONS_SET_WORKING_DATASET = 'SELECTIONS_SET_WORKING_DATASET'
@@ -96,6 +101,28 @@ export default (state = initialState, action: AnyAction) => {
         peername,
         name
       })
+
+    case HISTORY_REQ:
+      if (action.pageInfo.page === 1) {
+        localStore().setItem('commit', '')
+        return {
+          ...state,
+          commit: ''
+        }
+      }
+      return state
+
+    case HISTORY_SUCC:
+      if (state.commit === '') {
+        if (action.payload.data && action.payload.data.length > 0) {
+          localStore().setItem('commit', action.payload.data[0].path)
+          return {
+            ...state,
+            commit: action.payload.data[0].path
+          }
+        }
+      }
+      return state
 
     case COMMIT_SUCC:
       // if the selected commitComponent exists on dataset, no changes needed

--- a/app/reducers/ui.ts
+++ b/app/reducers/ui.ts
@@ -14,6 +14,7 @@ export const UI_CLOSE_TOAST = 'UI_CLOSE_TOAST'
 export const UI_SET_MODAL = 'UI_SET_MODAL'
 export const UI_SIGNOUT = 'UI_SIGNOUT'
 export const UI_HIDE_COMMIT_NUDGE = 'UI_HIDE_COMMIT_NUDGE'
+export const UI_SET_DATASET_DIR_PATH = 'UI_SET_DATASET_PATH'
 
 export const UNAUTHORIZED = 'UNAUTHORIZED'
 
@@ -45,7 +46,8 @@ const initialState = {
   commitSidebarWidth: getSidebarWidth('commitSidebarWidth'),
   toast: defaultToast,
   blockMenus: true,
-  hideCommitNudge: store().getItem(hideCommitNudge) === 'true'
+  hideCommitNudge: store().getItem(hideCommitNudge) === 'true',
+  datasetDirPath: store().getItem('datasetDirPath') || ''
 }
 
 // send an event to electron to block menus on first load
@@ -158,6 +160,13 @@ export default (state = initialState, action: AnyAction) => {
       return {
         ...state,
         showDatasetList: false
+      }
+
+    case UI_SET_DATASET_DIR_PATH:
+      store().setItem('datasetDirPath', action.path)
+      return {
+        ...state,
+        datasetDirPath: action.path
       }
 
     default:

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -45,7 +45,7 @@ const initialState: WorkingDataset = {
 }
 
 export const [DATASET_REQ, DATASET_SUCC, DATASET_FAIL] = apiActionTypes('dataset')
-const [DATASET_HISTORY_REQ, DATASET_HISTORY_SUCC, DATASET_HISTORY_FAIL] = apiActionTypes('history')
+export const [HISTORY_REQ, HISTORY_SUCC, HISTORY_FAIL] = apiActionTypes('history')
 export const [DATASET_STATUS_REQ, DATASET_STATUS_SUCC, DATASET_STATUS_FAIL] = apiActionTypes('status')
 const [DATASET_BODY_REQ, DATASET_BODY_SUCC, DATASET_BODY_FAIL] = apiActionTypes('body')
 const [, RESETOTHERCOMPONENTS_SUCC, RESETOTHERCOMPONENTS_FAIL] = apiActionTypes('resetOtherComponents')
@@ -104,7 +104,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
         isLoading: false
       }
 
-    case DATASET_HISTORY_REQ:
+    case HISTORY_REQ:
       return {
         ...state,
         history: {
@@ -113,7 +113,8 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
           value: action.pageInfo.page === 1 ? [] : state.history.value
         }
       }
-    case DATASET_HISTORY_SUCC:
+
+    case HISTORY_SUCC:
       return {
         ...state,
         hasHistory: true,
@@ -126,7 +127,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
           pageInfo: reducerWithPagination(action, state.history.pageInfo)
         }
       }
-    case DATASET_HISTORY_FAIL:
+    case HISTORY_FAIL:
       return {
         ...state,
         hasHistory: !action.payload.err.message.includes('no history'),

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -84,7 +84,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
         structure: dataset && dataset.structure ? dataset.structure : {},
         isLoading: false,
         components: {
-          body: initialState.components.body,
+          body: state.components.body,
           meta: {
             value: dataset && dataset.meta ? dataset.meta : {}
           },

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -391,6 +391,7 @@ $header-font-size: .9rem;
       width: 100%;
       background:$appBackground;
       flex: 1;
+      position: absolute;
     }
 
     .commit-nudge {

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -7,7 +7,7 @@ import { ThunkDispatch } from 'redux-thunk'
 import Store from '../models/store'
 import mapError from './mapError'
 import { FAILED_TO_FETCH } from '../reducers/connection'
-import { apiActionTypes } from '../utils/actionType'
+import { apiActionTypes, getActionType } from '../utils/actionType'
 import { UNAUTHORIZED } from '../reducers/ui'
 
 // CALL_API is a global, unique constant for passing actions to API middleware
@@ -92,7 +92,7 @@ export function chainSuccess (
   getState: () => Store) {
   return (thunk: ApiActionThunk) => {
     return async (action: AnyAction) => {
-      if (action.type.indexOf(`_SUCCESS`) > 0) {
+      if (getActionType(action) === 'success') {
         return thunk(dispatch, getState)
       }
       throw action
@@ -192,7 +192,6 @@ export const apiMiddleware: Middleware = () => (next: Dispatch<AnyAction>) => as
     let data: APIResponseEnvelope
     let { endpoint = '', method, map = identityFunc, segments, query, body, pageInfo } = action[CALL_API]
     const [REQ_TYPE, SUCC_TYPE, FAIL_TYPE] = apiActionTypes(action.type)
-
     next({ type: REQ_TYPE, pageInfo, segments })
 
     // TODO (chriswhong): Turn this into dev middleware

--- a/test/app/reducers/selections.test.ts
+++ b/test/app/reducers/selections.test.ts
@@ -16,6 +16,11 @@ import SelectionsReducer, {
   REMOVE_SUCC
 } from '../../../app/reducers/selections'
 
+import {
+  HISTORY_REQ,
+  HISTORY_SUCC
+} from '../../../app/reducers/workingDataset'
+
 // TODO (ramfox): test local storage
 // TODO (ramfox): test on non-empty/not initialState
 describe('Body Reducer', () => {
@@ -346,6 +351,92 @@ describe('Body Reducer', () => {
     }
     it(`case ${describe} of ${type}`, () => {
       Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({ ...expected })
+    })
+  })
+
+  const fullState = {
+    peername: 'foo',
+    name: 'bar',
+    activeTab: 'history',
+    component: 'meta',
+    commit: 'baz',
+    commitComponent: 'meta'
+  }
+
+  const historyCases = [
+    {
+      describe: 'HISTORY_REQ & fetching first page',
+      state: fullState,
+      action: {
+        type: HISTORY_REQ,
+        pageInfo: {
+          page: 1
+        }
+      },
+      expectedChange: {
+        commit: ''
+      }
+    },
+    {
+      describe: 'HISTORY_REQ & fetching not first page',
+      state: fullState,
+      action: {
+        type: HISTORY_REQ,
+        pageInfo: {
+          page: 10
+        }
+      },
+      expectedChange: {}
+    },
+    {
+      describe: 'HISTORY_SUCC & already have commit selected',
+      state: fullState,
+      action: {
+        type: HISTORY_SUCC
+      },
+      expectedChange: {}
+    },
+    {
+      describe: 'HISTORY_SUCC & no commits returned',
+      state: {
+        ...fullState,
+        commit: ''
+      },
+      action: {
+        type: HISTORY_SUCC,
+        payload: {
+          data: []
+        }
+      },
+      expectedChange: {}
+    },
+    {
+      describe: 'HISTORY_SUCC & commits returned',
+      state: {
+        commit: ''
+      },
+      action: {
+        type: HISTORY_SUCC,
+        payload: {
+          data: [
+            {
+              path: 'foo'
+            },
+            {
+              path: 'bar'
+            }
+          ]
+        }
+      },
+      expectedChange: {
+        commit: 'foo'
+      }
+    },
+  ]
+
+  historyCases.forEach(({describe, state, action, expectedChange}) => {
+    it(`case ${describe}`, () => {
+      Reducer(SelectionsReducer).withState(state).expect(action).toChangeInState(expectedChange)
     })
   })
 })


### PR DESCRIPTION
closes #274 
closes #279 
closes #272 
closes #277 
closes #281
closes #275 
closes #276 

also:
- final fix on fetching session, keep app in loading state until session returns
- simplify process on reseting components, fixes bugs with saving after meta editing
- we keep going back and forth on this, but I now don't think that dataset_success should write over the body
- refactor Dataset to remove `getDerivedPropsFromState` to `ComponentDidUpdate`
- refactored how we set commits in selection after we fetchHistory for the first time