### PR TITLE
feat(drag-and-drop): drag and drop a data file to create a dataset

### DIFF
--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -71,6 +71,7 @@ interface AppState {
   currentModal: Modal
   sessionID: string
   peername: string
+  showDragDrop: boolean
 }
 
 const noModalObject: HideModal = {
@@ -84,7 +85,8 @@ class App extends React.Component<AppProps, AppState> {
     this.state = {
       currentModal: noModalObject,
       sessionID: this.props.sessionID,
-      peername: this.props.peername
+      peername: this.props.peername,
+      showDragDrop: false
     }
 
     this.renderModal = this.renderModal.bind(this)
@@ -260,6 +262,41 @@ class App extends React.Component<AppProps, AppState> {
     )
   }
 
+  private renderDragDrop () {
+    return (
+      <div
+        onDragEnter={(event) => {
+          event.stopPropagation()
+          event.preventDefault()
+          this.setState({ showDragDrop: true })
+          console.log('enter')
+        }}
+        onDragOver={(event) => {
+          event.stopPropagation()
+          event.preventDefault()
+          this.setState({ showDragDrop: true })
+          console.log('over')
+        }}
+        onDragLeave={(event) => {
+          event.stopPropagation()
+          event.preventDefault()
+          this.setState({ showDragDrop: false })
+          console.log('leave')
+        }}
+        onDrop={(event) => {
+          this.setState({ showDragDrop: false })
+          console.log(event.dataTransfer.files[0].name)
+          event.preventDefault()
+          console.log('drop')
+        }}
+        className='drag-drop'
+        id='drag-drop'
+      >
+      DRAG AND DROP!
+      </div>
+    )
+  }
+
   render () {
     const {
       toast,
@@ -272,12 +309,17 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     return (
-      <div style={{
-        height: '100%',
-        position: 'relative',
-        overflow: 'hidden'
-      }}>
+      <div className='drag'
+        onDragEnter={() => {
+          this.setState({ showDragDrop: true })
+        }}
+        style={{
+          height: '100%',
+          position: 'relative',
+          overflow: 'hidden'
+        }}>
         {this.renderAppError()}
+        {this.state.showDragDrop && this.renderDragDrop() }
         {this.renderModal()}
         <Router>
           <RoutesContainer />

--- a/app/components/BodyTable.tsx
+++ b/app/components/BodyTable.tsx
@@ -87,6 +87,7 @@ export default class BodyTable extends React.Component<BodyTableProps> {
 
   fetchNextPage (direction: 'up' | 'down') {
     const { body, pageInfo, onFetch } = this.props
+    if (direction === 'down' && pageInfo.fetchedAll === true) { return }
     const page = getNextPageNumber(direction, body, pageInfo.pageSize)
 
     onFetch(page, pageInfo.pageSize)

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -18,6 +18,7 @@ interface CreateDatasetProps {
   onSubmit: (path: string, name: string, dir: string, mkdir: string) => Promise<ApiAction>
   datasetDirPath: string
   setDatasetDirPath: (path: string) => Action
+  filePath: string
 }
 
 const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
@@ -25,11 +26,21 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
     onDismissed,
     onSubmit,
     datasetDirPath: persistedDatasetDirPath,
-    setDatasetDirPath: saveDatasetDirPath
+    setDatasetDirPath: saveDatasetDirPath,
+    filePath: givenFilePath
   } = props
-  const [datasetName, setDatasetName] = React.useState('')
+
+  const validName = (name: string): string => {
+    // cast name to meet our specification
+    // make lower case, snakecase, and remove invalid characters
+    let coercedName = changeCase.lowerCase(name)
+    coercedName = changeCase.snakeCase(name)
+    return coercedName.replace(/^[^a-z0-9_]+$/g, '')
+  }
+
   const [datasetDirPath, setDatasetDirPath] = React.useState(persistedDatasetDirPath)
-  const [filePath, setFilePath] = React.useState('')
+  const [filePath, setFilePath] = React.useState(givenFilePath)
+  const [datasetName, setDatasetName] = React.useState(validName(path.basename(filePath, path.extname(filePath))))
 
   const [dismissable, setDismissable] = React.useState(true)
   const [buttonDisabled, setButtonDisabled] = React.useState(true)
@@ -78,16 +89,6 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
     }
   }
 
-  const tryToSetValidName = (name: string) => {
-    // cast name to meet our specification
-    // make lower case, snakecase, and remove invalid characters
-    let coercedName = changeCase.lowerCase(name)
-    coercedName = changeCase.snakeCase(name)
-    coercedName = coercedName.replace(/^[^a-z0-9_]+$/g, '')
-
-    setDatasetName(coercedName)
-  }
-
   const showFilePicker = () => {
     const window = remote.getCurrentWindow()
     const filePath: string[] | undefined = remote.dialog.showOpenDialog(window, {
@@ -102,7 +103,9 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
     const basename = path.basename(selectedPath)
     const name = basename.split('.')[0]
 
-    name && datasetName === '' && tryToSetValidName(name)
+    if (name && datasetName === '') {
+      setDatasetName(validName(name))
+    }
 
     setFilePath(selectedPath)
     const isDataset = isQriDataset(selectedPath)

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -16,6 +16,7 @@ import {
 import {
   acceptTOS,
   setQriCloudAuthenticated,
+  openToast,
   closeToast,
   setModal,
   setDatasetDirPath,
@@ -66,6 +67,7 @@ const AppContainer = connect(
     addDataset: addDatasetAndFetch,
     initDataset: initDatasetAndFetch,
     linkDataset: linkDatasetAndFetch,
+    openToast,
     closeToast,
     pingApi,
     setWorkingDataset,

--- a/app/reducers/ui.ts
+++ b/app/reducers/ui.ts
@@ -4,6 +4,7 @@ import { ipcRenderer } from 'electron'
 import store from '../utils/localStore'
 import { apiActionTypes } from '../utils/actionType'
 import { SAVE_SUCC, SAVE_FAIL } from '../reducers/mutations'
+import { ModalType } from '../models/modals'
 
 export const UI_TOGGLE_DATASET_LIST = 'UI_TOGGLE_DATASET_LIST'
 export const UI_SET_SIDEBAR_WIDTH = 'UI_SET_SIDEBAR_WIDTH'
@@ -49,7 +50,8 @@ const initialState = {
   blockMenus: true,
   hideCommitNudge: store().getItem(hideCommitNudge) === 'true',
   datasetDirPath: store().getItem('datasetDirPath') || '',
-  exportPath: store().getItem('exportPath') || ''
+  exportPath: store().getItem('exportPath') || '',
+  modal: { type: ModalType.NoModal }
 }
 
 // send an event to electron to block menus on first load

--- a/app/scss/_drag-drop.scss
+++ b/app/scss/_drag-drop.scss
@@ -1,13 +1,35 @@
 .drag-drop {
-  background: rgba($color: #000000, $alpha: .6);
+  background: rgba($color: #ffffff, $alpha: .8);
   position: absolute;
   width: 100%;
   height: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   top: 0;
   right: 0;
   left: 0;
   bottom: 0;
+
+  .inner {
+    width: 80%;
+    height: 70%;
+    border: .5rem dashed rgba($color: #000000, $alpha: .4);
+    border-radius: 5px;
+    display: flex;
+    flex-direction: column;
+    justify-content:center;
+    align-items: center;
+    
+    .icon {
+      color: rgba($color: #000000, $alpha: .4);
+    }
+  }
+  .footer {
+    position: relative;
+    bottom: -5%;
+    background: white;
+    color: rgba($color: #000000, $alpha: 1);
+  }
 }

--- a/app/scss/_drag-drop.scss
+++ b/app/scss/_drag-drop.scss
@@ -1,0 +1,13 @@
+.drag-drop {
+  background: rgba($color: #000000, $alpha: .6);
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+}

--- a/app/scss/_welcome.scss
+++ b/app/scss/_welcome.scss
@@ -15,8 +15,9 @@
     bottom: 0;
   }
 
-#app-loading { z-index: 201 }
-#app-error { z-index: 200 }
+#app-loading { z-index: 250 }
+#app-error { z-index: 249 }
+#drag-drop { z-index: 200 }
 #welcome-page { z-index: 199 }
 #signup-page { z-index: 198 }
 #signin-page { z-index: 197 }

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -24,6 +24,7 @@
 @import "stylesheet";
 
 @import "dataset";
+@import "drag-drop";
 @import "saveform";
 @import "dataset-list";
 @import "welcome";


### PR DESCRIPTION
Drag and drop a csv or json file over the app to create a new dataset.

Long term, dragging and dropping over the app will automatically initialize and save a version of the dataset, choose a name, and save it in a default directory. The finer points of these are still being debated. For now, drag and drop the file in and the user is sent to a modal that is filled out with defaults, giving the users an opportunity to intercept our assumptions. Clicking create initializes a dataset and sends the user to the body of that dataset.

