### PR TITLE
feat(detailsBar): let's add a details bar on the dataset body page

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -59,6 +59,7 @@ export function fetchWorkingDatasetDetails (): ApiActionThunk {
     }
     response = await whenOk(fetchWorkingStatus())(response)
     response = await whenOk(fetchBody(-1))(response)
+    response = await whenOk(fetchStats())(response)
     response = await whenOk(fetchWorkingHistory(-1))(response)
 
     return response
@@ -172,6 +173,7 @@ export function fetchCommitDetail (): ApiActionThunk {
     response = await fetchCommitDataset()(dispatch, getState)
     response = await whenOk(fetchCommitStatus())(response)
     response = await whenOk(fetchCommitBody(-1))(response)
+    response = await whenOk(fetchCommitStats())(response)
 
     return response
   }
@@ -346,6 +348,55 @@ export function fetchCommitBody (page: number = 1, pageSize: number = bodyPageSi
       }
     }
     return dispatch(action)
+  }
+}
+
+export function fetchStats ():
+ApiActionThunk {
+  return async (dispatch, getState) => {
+    const { selections, workingDataset } = getState()
+
+    const response = await dispatch({
+      type: 'stats',
+      [CALL_API]: {
+        endpoint: 'stats',
+        method: 'GET',
+        segments: {
+          peername: selections.peername,
+          name: selections.name
+        },
+        query: {
+          fsi: !!workingDataset.fsiPath
+        }
+      }
+    })
+
+    return response
+  }
+}
+
+export function fetchCommitStats ():
+ApiActionThunk {
+  return async (dispatch, getState) => {
+    const { selections } = getState()
+
+    const response = await dispatch({
+      type: 'commitstats',
+      [CALL_API]: {
+        endpoint: 'stats',
+        method: 'GET',
+        segments: {
+          peername: selections.peername,
+          name: selections.name,
+          path: selections.commit
+        },
+        query: {
+          fsi: false
+        }
+      }
+    })
+
+    return response
   }
 }
 

--- a/app/actions/ui.ts
+++ b/app/actions/ui.ts
@@ -11,11 +11,13 @@ import {
   UI_SIGNOUT,
   UI_HIDE_COMMIT_NUDGE,
   UI_SET_DATASET_DIR_PATH,
-  UI_SET_EXPORT_PATH
+  UI_SET_EXPORT_PATH,
+  UI_SET_DETAILS_BAR
 } from '../reducers/ui'
 
 import { ToastType } from '../models/store'
 import { Modal } from '../models/modals'
+import { Details } from '../models/details'
 
 export const toggleDatasetList = () => {
   return {
@@ -88,5 +90,12 @@ export const setExportPath = (path: string) => {
   return {
     type: UI_SET_EXPORT_PATH,
     path
+  }
+}
+
+export const setDetailsBar = (details: Details) => {
+  return {
+    type: UI_SET_DETAILS_BAR,
+    details
   }
 }

--- a/app/components/Body.tsx
+++ b/app/components/Body.tsx
@@ -6,6 +6,8 @@ import { ApiAction } from '../store/api'
 
 import Spinner from './chrome/Spinner'
 import { PageInfo, WorkingDataset } from '../models/store'
+import { Action } from 'redux'
+import { DetailsType, Details } from '../models/details'
 
 export interface BodyProps {
   workingDataset: WorkingDataset
@@ -16,8 +18,12 @@ export interface BodyProps {
   pageInfo: PageInfo
   history: boolean
   format: string
+  details: Details
+  stats: Array<{[key: string]: any}>
+
   fetchBody: (page?: number, pageSize?: number) => Promise<ApiAction>
   fetchCommitBody: (page?: number, pageSize?: number) => Promise<ApiAction>
+  setDetailsBar: (details: {[key: string]: any}) => Action
 }
 
 function shouldDisplayTable (value: any[] | Object, format: string) {
@@ -54,7 +60,10 @@ const Body: React.FunctionComponent<BodyProps> = (props) => {
     history,
     fetchBody,
     format,
-    fetchCommitBody
+    fetchCommitBody,
+    details,
+    setDetailsBar
+    // stats
   } = props
 
   const onFetch = history ? fetchCommitBody : fetchBody
@@ -63,6 +72,23 @@ const Body: React.FunctionComponent<BodyProps> = (props) => {
 
   // if there's no value or format, don't show anything yet
   const showSpinner = !(value && format)
+
+  const handleToggleDetailsBar = (index: number) => {
+    if (details.type === DetailsType.NoDetails) {
+      setDetailsBar({ type: DetailsType.StatDetails, stat: { 'wooo': 'yay' }, index })
+      return
+    }
+    if (details.type === DetailsType.StatDetails) {
+      // if the index is the same, then the user has clicked
+      // on the header twice. The second time, we should
+      // remove the detailsbar
+      if (details.index === index) {
+        setDetailsBar({ type: DetailsType.NoDetails })
+        return
+      }
+      setDetailsBar({ type: DetailsType.StatDetails, stat: { 'wooo': 'yay' }, index })
+    }
+  }
 
   return (
     <div className='transition-group'>
@@ -80,6 +106,7 @@ const Body: React.FunctionComponent<BodyProps> = (props) => {
                 body={value}
                 onFetch={onFetch}
                 pageInfo={pageInfo}
+                setDetailsBar={handleToggleDetailsBar}
               />
               : <BodyJson
                 body={value}

--- a/app/components/Body.tsx
+++ b/app/components/Body.tsx
@@ -7,7 +7,7 @@ import { ApiAction } from '../store/api'
 import Spinner from './chrome/Spinner'
 import { PageInfo, WorkingDataset } from '../models/store'
 import { Action } from 'redux'
-import { DetailsType, Details } from '../models/details'
+import { DetailsType, Details, StatsDetails } from '../models/details'
 
 export interface BodyProps {
   workingDataset: WorkingDataset
@@ -62,8 +62,8 @@ const Body: React.FunctionComponent<BodyProps> = (props) => {
     format,
     fetchCommitBody,
     details,
-    setDetailsBar
-    // stats
+    setDetailsBar,
+    stats
   } = props
 
   const onFetch = history ? fetchCommitBody : fetchBody
@@ -73,12 +73,23 @@ const Body: React.FunctionComponent<BodyProps> = (props) => {
   // if there's no value or format, don't show anything yet
   const showSpinner = !(value && format)
 
+  const makeStatsDetails = (stats: {[key: string]: any}, title: string, index: number): StatsDetails => {
+    return {
+      type: DetailsType.StatsDetails,
+      title: title,
+      index: index,
+      stats: stats
+    }
+  }
+
   const handleToggleDetailsBar = (index: number) => {
+    if (!stats || stats.length === 0) return
+    const statsHeaders = headers as string[]
     if (details.type === DetailsType.NoDetails) {
-      setDetailsBar({ type: DetailsType.StatDetails, stat: { 'wooo': 'yay' }, index })
+      setDetailsBar(makeStatsDetails(stats[index], statsHeaders[index], index))
       return
     }
-    if (details.type === DetailsType.StatDetails) {
+    if (details.type === DetailsType.StatsDetails) {
       // if the index is the same, then the user has clicked
       // on the header twice. The second time, we should
       // remove the detailsbar
@@ -86,7 +97,7 @@ const Body: React.FunctionComponent<BodyProps> = (props) => {
         setDetailsBar({ type: DetailsType.NoDetails })
         return
       }
-      setDetailsBar({ type: DetailsType.StatDetails, stat: { 'wooo': 'yay' }, index })
+      setDetailsBar(makeStatsDetails(stats[index], statsHeaders[index], index))
     }
   }
 

--- a/app/components/BodyTable.tsx
+++ b/app/components/BodyTable.tsx
@@ -11,6 +11,7 @@ interface BodyTableProps {
   headers?: any[]
   body: any[]
   onFetch: (page?: number, pageSize?: number) => Promise<ApiAction>
+  setDetailsBar: (index: number) => void
   pageInfo: PageInfo
 }
 
@@ -94,7 +95,7 @@ export default class BodyTable extends React.Component<BodyTableProps> {
   }
 
   render () {
-    const { body, headers, pageInfo } = this.props
+    const { body, headers, pageInfo, setDetailsBar } = this.props
     const { fetchedAll } = pageInfo
 
     const tableRows = body.map((row, i) => {
@@ -128,7 +129,7 @@ export default class BodyTable extends React.Component<BodyTableProps> {
               {headers && headers.map((d: any, j: number) => {
                 return (
                   <th key={j}>
-                    <div className='cell'>{d}</div>
+                    <div className='cell' onClick={() => setDetailsBar(j)}>{d}</div>
                   </th>
                 )
               })}

--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -185,7 +185,6 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
 
               // add discard changes option of file is modified
               if (fileStatus !== 'unmodified') {
-                console.log(name)
                 menuItems.unshift({
                   label: 'Discard Changes...',
                   click: () => { discardChanges(name as SelectedComponent) }

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -22,6 +22,7 @@ import HeaderColumnButton from './chrome/HeaderColumnButton'
 import DatasetListContainer from '../containers/DatasetListContainer'
 import CommitDetailsContainer from '../containers/CommitDetailsContainer'
 import DatasetSidebarContainer from '../containers/DatasetSidebarContainer'
+import DetailsBarContainer from '../containers/DetailsBarContainer'
 import HeaderColumnButtonDropdown from './chrome/HeaderColumnButtonDropdown'
 
 import {
@@ -43,6 +44,7 @@ export interface DatasetProps {
   setModal: (modal: Modal) => void
   session: Session
   hasDatasets: boolean
+  showDetailsBar: boolean
 
   // actions
   toggleDatasetList: () => Action
@@ -221,7 +223,8 @@ export default class Dataset extends React.Component<DatasetProps> {
     const {
       toggleDatasetList,
       setSidebarWidth,
-      signout
+      signout,
+      showDetailsBar
     } = this.props
 
     let linkButton
@@ -331,6 +334,23 @@ export default class Dataset extends React.Component<DatasetProps> {
           >
             <DatasetSidebarContainer setModal={setModal} />
           </Resizable>
+          <CSSTransition
+            in={showDetailsBar}
+            classNames='slide-from-left'
+            timeout={300}
+            mountOnEnter
+            unmountOnExit
+          >
+            <Resizable
+              id='details'
+              width={datasetSidebarWidth}
+              onResize={(width) => { setSidebarWidth('dataset', width) }}
+              onReset={() => { setSidebarWidth('dataset', defaultSidebarWidth) }}
+              maximumWidth={495}
+            >
+              <DetailsBarContainer />
+            </Resizable>
+          </CSSTransition>
           <div className='content-wrapper'>
             <div className='transition-group' >
               <CSSTransition

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -334,23 +334,23 @@ export default class Dataset extends React.Component<DatasetProps> {
           >
             <DatasetSidebarContainer setModal={setModal} />
           </Resizable>
-          <CSSTransition
-            in={showDetailsBar}
-            classNames='slide-from-left'
-            timeout={300}
-            mountOnEnter
-            unmountOnExit
+          <div className="details-bar-wrapper"
+            style={{ 'left': showDetailsBar ? 0 : datasetSidebarWidth * -1 }}
           >
-            <Resizable
-              id='details'
-              width={datasetSidebarWidth}
-              onResize={(width) => { setSidebarWidth('dataset', width) }}
-              onReset={() => { setSidebarWidth('dataset', defaultSidebarWidth) }}
-              maximumWidth={495}
+            <div className="details-bar-inner"
+              style={{ 'opacity': showDetailsBar ? 1 : 0 }}
             >
-              <DetailsBarContainer />
-            </Resizable>
-          </CSSTransition>
+              <Resizable
+                id='details'
+                width={datasetSidebarWidth}
+                onResize={(width) => { setSidebarWidth('dataset', width) }}
+                onReset={() => { setSidebarWidth('dataset', defaultSidebarWidth) }}
+                maximumWidth={495}
+              >
+                <DetailsBarContainer />
+              </Resizable>
+            </div>
+          </div>
           <div className='content-wrapper'>
             <div className='transition-group' >
               <CSSTransition

--- a/app/components/DetailsBar.tsx
+++ b/app/components/DetailsBar.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react'
 import { Details, DetailsType, StatsDetails } from '../models/details'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTimes } from '@fortawesome/free-solid-svg-icons'
 
 export interface DetailsBarProps {
   details: Details
+  setDetailsBar: (details: Details) => void
 }
 const DetailsBar: React.FunctionComponent<DetailsBarProps> = (props) => {
   const {
-    details
+    details,
+    setDetailsBar
   } = props
   console.log(details)
 
@@ -14,14 +18,31 @@ const DetailsBar: React.FunctionComponent<DetailsBarProps> = (props) => {
     const statsDetails = details as StatsDetails
     return (
       <div>
-        <h2>{statsDetails.title}</h2>
+        <h4>{statsDetails.title}</h4>
         <p>{JSON.stringify(statsDetails.stats)}</p>
       </div>
     )
   }
 
+  const onDismiss = () => {
+    setDetailsBar({ type: DetailsType.NoDetails })
+  }
+
+  const renderHeader = () =>
+    <div className="details-bar-header">
+      <h3>Details</h3>
+      <a
+        className="close"
+        onClick={onDismiss}
+        aria-label="close"
+        role="button"
+      >
+        <FontAwesomeIcon icon={faTimes} size='lg'/>
+      </a>
+    </div>
+
   return <div className='details-bar padding'>
-    <h1>Details</h1>
+    {renderHeader()}
     <div className="details-bar-content margin">
       {details.type === DetailsType.StatsDetails && renderStatsDetails()}
     </div>

--- a/app/components/DetailsBar.tsx
+++ b/app/components/DetailsBar.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import { Details } from '../models/details'
+
+export interface DetailsBarProps {
+  details: Details
+}
+const DetailsBar: React.FunctionComponent<DetailsBarProps> = (props) => {
+  const {
+    details
+  } = props
+  console.log(details)
+  return <div className='details-bar padding'>
+    <h1>Details</h1>
+  </div>
+}
+
+export default DetailsBar

--- a/app/components/DetailsBar.tsx
+++ b/app/components/DetailsBar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Details } from '../models/details'
+import { Details, DetailsType, StatsDetails } from '../models/details'
 
 export interface DetailsBarProps {
   details: Details
@@ -9,8 +9,22 @@ const DetailsBar: React.FunctionComponent<DetailsBarProps> = (props) => {
     details
   } = props
   console.log(details)
+
+  const renderStatsDetails = () => {
+    const statsDetails = details as StatsDetails
+    return (
+      <div>
+        <h2>{statsDetails.title}</h2>
+        <p>{JSON.stringify(statsDetails.stats)}</p>
+      </div>
+    )
+  }
+
   return <div className='details-bar padding'>
     <h1>Details</h1>
+    <div className="details-bar-content margin">
+      {details.type === DetailsType.StatsDetails && renderStatsDetails()}
+    </div>
   </div>
 }
 

--- a/app/containers/BodyContainer.tsx
+++ b/app/containers/BodyContainer.tsx
@@ -10,6 +10,7 @@ const mapStateToProps = (state: Store) => {
   const { workingDataset, commitDetails, selections, ui } = state
   const history = selections.activeTab === 'history'
   const dataset = history ? commitDetails : workingDataset
+  const stats = history ? commitDetails.stats : workingDataset.stats
   const { pageInfo, value } = dataset.components.body
 
   const details = ui.detailsBar
@@ -35,7 +36,8 @@ const mapStateToProps = (state: Store) => {
     format,
     history,
     details,
-    workingDataset
+    workingDataset,
+    stats
   }
 }
 

--- a/app/containers/BodyContainer.tsx
+++ b/app/containers/BodyContainer.tsx
@@ -2,14 +2,17 @@ import { connect } from 'react-redux'
 import { bindActionCreators, Dispatch } from 'redux'
 import Body, { BodyProps } from '../components/Body'
 import Store from '../models/store'
+import { setDetailsBar } from '../actions/ui'
 import { fetchBody, fetchCommitBody } from '../actions/api'
 import path from 'path'
 
 const mapStateToProps = (state: Store) => {
-  const { workingDataset, commitDetails, selections } = state
+  const { workingDataset, commitDetails, selections, ui } = state
   const history = selections.activeTab === 'history'
   const dataset = history ? commitDetails : workingDataset
   const { pageInfo, value } = dataset.components.body
+
+  const details = ui.detailsBar
 
   var format = ''
   if (history) {
@@ -31,6 +34,7 @@ const mapStateToProps = (state: Store) => {
     structure,
     format,
     history,
+    details,
     workingDataset
   }
 }
@@ -40,7 +44,7 @@ const mergeProps = (props: any, actions: any): BodyProps => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
-  return bindActionCreators({ fetchBody, fetchCommitBody }, dispatch)
+  return bindActionCreators({ fetchBody, fetchCommitBody, setDetailsBar }, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Body)

--- a/app/containers/DatasetContainer.tsx
+++ b/app/containers/DatasetContainer.tsx
@@ -18,6 +18,7 @@ import {
   setActiveTab,
   setSelectedListItem
 } from '../actions/selections'
+import { DetailsType } from '../models/details'
 
 const mergeProps = (props: any, actions: any): DatasetProps => {
   return { ...props, ...actions }
@@ -39,6 +40,8 @@ const DatasetContainer = connect(
     } = state
     const hasDatasets = myDatasets.value.length !== 0
     const { setModal } = ownProps
+    const showDetailsBar = ui.detailsBar.type !== DetailsType.NoDetails
+
     return Object.assign({
       ui,
       selections,
@@ -46,7 +49,8 @@ const DatasetContainer = connect(
       mutations,
       setModal,
       hasDatasets,
-      session
+      session,
+      showDetailsBar
     }, ownProps)
   },
   {

--- a/app/containers/DetailsBarContainer.tsx
+++ b/app/containers/DetailsBarContainer.tsx
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux'
 import DetailsBar from '../components/DetailsBar'
+import { setDetailsBar } from '../actions/ui'
 
 const mapStateToProps = (state: any) => {
   const { ui } = state
@@ -9,6 +10,7 @@ const mapStateToProps = (state: any) => {
 }
 
 const actions = {
+  setDetailsBar
 }
 
 export default connect(mapStateToProps, actions)(DetailsBar)

--- a/app/containers/DetailsBarContainer.tsx
+++ b/app/containers/DetailsBarContainer.tsx
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux'
+import DetailsBar from '../components/DetailsBar'
+
+const mapStateToProps = (state: any) => {
+  const { ui } = state
+  return {
+    details: ui.detailsBar
+  }
+}
+
+const actions = {
+}
+
+export default connect(mapStateToProps, actions)(DetailsBar)

--- a/app/models/details.ts
+++ b/app/models/details.ts
@@ -1,0 +1,18 @@
+
+export enum DetailsType {
+  NoDetails,
+  StatDetails
+}
+
+interface StatDetails {
+  type: DetailsType.StatDetails
+  // eventually replace with a Stats interface
+  index: number
+  details: Details
+}
+
+interface NoDetails {
+  type: DetailsType.NoDetails
+}
+
+export type Details = StatDetails | NoDetails

--- a/app/models/details.ts
+++ b/app/models/details.ts
@@ -1,18 +1,19 @@
 
 export enum DetailsType {
   NoDetails,
-  StatDetails
+  StatsDetails
 }
 
-interface StatDetails {
-  type: DetailsType.StatDetails
+export interface StatsDetails {
+  type: DetailsType.StatsDetails
   // eventually replace with a Stats interface
   index: number
-  details: Details
+  title: string
+  stats: {[key: string]: any}
 }
 
-interface NoDetails {
+export interface NoDetails {
   type: DetailsType.NoDetails
 }
 
-export type Details = StatDetails | NoDetails
+export type Details = StatsDetails | NoDetails

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -1,6 +1,7 @@
 import { RouterState } from 'react-router-redux'
 import { Meta, Structure } from './dataset'
 import { Session } from './session'
+import { Details } from './details'
 
 enum ApiConnection {
   neverConnected = 0,
@@ -64,6 +65,7 @@ export interface UI {
   hideCommitNudge: boolean
   datasetDirPath: string
   exportPath: string
+  detailsBar: Details
 }
 
 export type SelectedComponent = 'readme' | 'meta' | 'body' | 'structure' | ''

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -149,6 +149,7 @@ export interface CommitDetails {
       value: Structure
     }
   }
+  stats: Array<{[key: string]: any}>
 }
 
 export interface HistoryItem {

--- a/app/reducers/commitDetail.ts
+++ b/app/reducers/commitDetail.ts
@@ -25,12 +25,14 @@ const initialState: CommitDetails = {
     structure: {
       value: {}
     }
-  }
+  },
+  stats: []
 }
 
 const [COMMITDATASET_REQ, COMMITDATASET_SUCC, COMMITDATASET_FAIL] = apiActionTypes('commitdataset')
 const [COMMITSTATUS_REQ, COMMITSTATUS_SUCC, COMMITSTATUS_FAIL] = apiActionTypes('commitstatus')
 const [COMMITBODY_REQ, COMMITBODY_SUCC, COMMITBODY_FAIL] = apiActionTypes('commitbody')
+const [COMMITSTATS_REQ, COMMITSTATS_SUCC, COMMITSTATS_FAIL] = apiActionTypes('commitstats')
 
 const commitDetailsReducer: Reducer = (state = initialState, action: AnyAction): CommitDetails => {
   switch (action.type) {
@@ -112,6 +114,25 @@ const commitDetailsReducer: Reducer = (state = initialState, action: AnyAction):
             pageInfo: reducerWithPagination(action, state.components.body.pageInfo)
           }
         }
+      }
+
+    case COMMITSTATS_REQ:
+      if (state.peername === action.segments.peername && state.name === action.segments.name) {
+        return state
+      }
+      return {
+        ...state,
+        stats: []
+      }
+    case COMMITSTATS_SUCC:
+      return {
+        ...state,
+        stats: action.payload.data
+      }
+    case COMMITSTATS_FAIL:
+      return {
+        ...state,
+        stats: []
       }
 
     default:

--- a/app/reducers/ui.ts
+++ b/app/reducers/ui.ts
@@ -6,6 +6,12 @@ import { apiActionTypes } from '../utils/actionType'
 import { SAVE_SUCC, SAVE_FAIL } from '../reducers/mutations'
 import { ModalType } from '../models/modals'
 import { DetailsType } from '../models/details'
+import {
+  SELECTIONS_SET_SELECTED_LISTITEM,
+  SELECTIONS_SET_WORKING_DATASET,
+  SELECTIONS_CLEAR,
+  SELECTIONS_SET_ACTIVE_TAB
+} from './selections'
 
 export const UI_TOGGLE_DATASET_LIST = 'UI_TOGGLE_DATASET_LIST'
 export const UI_SET_SIDEBAR_WIDTH = 'UI_SET_SIDEBAR_WIDTH'
@@ -126,6 +132,16 @@ export default (state = initialState, action: AnyAction) => {
       return {
         ...state,
         detailsBar: action.details
+      }
+
+    // if we change screens
+    case SELECTIONS_SET_WORKING_DATASET:
+    case SELECTIONS_CLEAR:
+    case SELECTIONS_SET_ACTIVE_TAB:
+    case SELECTIONS_SET_SELECTED_LISTITEM:
+      return {
+        ...state,
+        detailsBar: { type: DetailsType.NoDetails }
       }
 
     // listen for SAVE_SUCC and SAVE_FAIL to set the toast

--- a/app/reducers/ui.ts
+++ b/app/reducers/ui.ts
@@ -5,6 +5,7 @@ import store from '../utils/localStore'
 import { apiActionTypes } from '../utils/actionType'
 import { SAVE_SUCC, SAVE_FAIL } from '../reducers/mutations'
 import { ModalType } from '../models/modals'
+import { DetailsType } from '../models/details'
 
 export const UI_TOGGLE_DATASET_LIST = 'UI_TOGGLE_DATASET_LIST'
 export const UI_SET_SIDEBAR_WIDTH = 'UI_SET_SIDEBAR_WIDTH'
@@ -17,6 +18,7 @@ export const UI_SIGNOUT = 'UI_SIGNOUT'
 export const UI_HIDE_COMMIT_NUDGE = 'UI_HIDE_COMMIT_NUDGE'
 export const UI_SET_DATASET_DIR_PATH = 'UI_SET_DATASET_DIR_PATH'
 export const UI_SET_EXPORT_PATH = 'UI_SET_EXPORT_PATH'
+export const UI_SET_DETAILS_BAR = 'UI_SET_DETAILS_BAR'
 
 export const UNAUTHORIZED = 'UNAUTHORIZED'
 
@@ -51,7 +53,8 @@ const initialState = {
   hideCommitNudge: store().getItem(hideCommitNudge) === 'true',
   datasetDirPath: store().getItem('datasetDirPath') || '',
   exportPath: store().getItem('exportPath') || '',
-  modal: { type: ModalType.NoModal }
+  modal: { type: ModalType.NoModal },
+  detailsBar: { type: DetailsType.NoDetails }
 }
 
 // send an event to electron to block menus on first load
@@ -117,6 +120,12 @@ export default (state = initialState, action: AnyAction) => {
       return {
         ...state,
         modal
+      }
+
+    case UI_SET_DETAILS_BAR:
+      return {
+        ...state,
+        detailsBar: action.details
       }
 
     // listen for SAVE_SUCC and SAVE_FAIL to set the toast

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -43,7 +43,8 @@ const initialState: WorkingDataset = {
       pageSize: 0
     },
     value: []
-  }
+  },
+  stats: []
 }
 
 export const [DATASET_REQ, DATASET_SUCC, DATASET_FAIL] = apiActionTypes('dataset')
@@ -51,6 +52,7 @@ export const [HISTORY_REQ, HISTORY_SUCC, HISTORY_FAIL] = apiActionTypes('history
 export const [DATASET_STATUS_REQ, DATASET_STATUS_SUCC, DATASET_STATUS_FAIL] = apiActionTypes('status')
 const [DATASET_BODY_REQ, DATASET_BODY_SUCC, DATASET_BODY_FAIL] = apiActionTypes('body')
 const [, RESETOTHERCOMPONENTS_SUCC, RESETOTHERCOMPONENTS_FAIL] = apiActionTypes('resetOtherComponents')
+const [STATS_REQ, STATS_SUCC, STATS_FAIL] = apiActionTypes('stats')
 
 export const RESET_BODY = 'RESET_BODY'
 
@@ -242,6 +244,26 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
         return initialState
       }
       return state
+
+    case STATS_REQ:
+      if (state.peername === action.segments.peername && state.name === action.segments.name) {
+        return state
+      }
+      return {
+        ...state,
+        stats: []
+      }
+    case STATS_SUCC:
+      return {
+        ...state,
+        stats: action.payload.data
+      }
+    case STATS_FAIL:
+      return {
+        ...state,
+        stats: []
+      }
+
     default:
       return state
   }

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -590,22 +590,20 @@ $header-font-size: .9rem;
 }
 
 // DetailsBar
-.details-bar {
+.details-bar-wrapper {
   position: absolute;
-  left: 0;
   height: 100%;
-  overflow-wrap: break-word;
-  height: 100%;
-  font-size: $header-font-size;
-  cursor: default;
-  display: flex;
-  flex-direction: column;
   background: $appBackground;
   border-right: 1px solid $border-color;
+  -webkit-transition-duration: 0.3s;
+  -moz-transition-duration: 0.3s;
+  -o-transition-duration: 0.3s;
+  transition-duration: 0.3s;
 }
 
-#details {
-  position: absolute;
-  left: 0;
-  height: 100%;
+.details-bar-inner {
+  -webkit-transition-duration: 0.6s;
+  -moz-transition-duration: 0.6s;
+  -o-transition-duration: 0.6s;
+  transition-duration: 0.6s;
 }

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -607,3 +607,8 @@ $header-font-size: .9rem;
   -o-transition-duration: 0.6s;
   transition-duration: 0.6s;
 }
+
+.details-bar-content {
+  overflow-y: scroll;
+  overflow-wrap: break-word;
+}

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -612,3 +612,41 @@ $header-font-size: .9rem;
   overflow-y: scroll;
   overflow-wrap: break-word;
 }
+
+.details-bar-header {
+  padding-left: 0 1.5rem;
+  height: 60px;
+  border-bottom: solid 1px $border-color;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  h3 {
+    margin: 0;
+    padding: 0;
+    padding-left: $spacer;
+  }
+
+  .close {
+    flex-shrink: 0;
+    position: absolute;
+    top: $spacer;
+    right: $spacer;
+    border: 0;
+    height: 18px;
+    width: 18px;
+    background: transparent;
+
+    color: black;
+    cursor: pointer;
+
+    &:hover {
+      color: $text;
+    }
+
+    &:focus {
+      outline: 0;
+    }
+  }
+}

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -588,3 +588,24 @@ $header-font-size: .9rem;
     letter-spacing: 2px;
   }
 }
+
+// DetailsBar
+.details-bar {
+  position: absolute;
+  left: 0;
+  height: 100%;
+  overflow-wrap: break-word;
+  height: 100%;
+  font-size: $header-font-size;
+  cursor: default;
+  display: flex;
+  flex-direction: column;
+  background: $appBackground;
+  border-right: 1px solid $border-color;
+}
+
+#details {
+  position: absolute;
+  left: 0;
+  height: 100%;
+}

--- a/app/scss/_transitions.scss
+++ b/app/scss/_transitions.scss
@@ -79,24 +79,6 @@
   transition: max-height 300ms, transform 300ms;
 }
 
-.slide-from-left-enter {
-  max-width: 0px;
-}
-
-.slide-from-left-enter-active {
-  max-width: 500px;
-  transition: max-width 300ms, transform 300ms;
-}
-
-.slide-from-left-exit {
-  max-width: 500px;
-}
-
-.slide-from-left-exit-active {
-  max-width: 0px;
-  transition: max-height 300ms, transform 300ms;
-}
-
 // outer div
 .transition-group {
   position:relative;

--- a/app/scss/_transitions.scss
+++ b/app/scss/_transitions.scss
@@ -79,6 +79,24 @@
   transition: max-height 300ms, transform 300ms;
 }
 
+.slide-from-left-enter {
+  max-width: 0px;
+}
+
+.slide-from-left-enter-active {
+  max-width: 500px;
+  transition: max-width 300ms, transform 300ms;
+}
+
+.slide-from-left-exit {
+  max-width: 500px;
+}
+
+.slide-from-left-exit-active {
+  max-width: 0px;
+  transition: max-height 300ms, transform 300ms;
+}
+
 // outer div
 .transition-group {
   position:relative;


### PR DESCRIPTION
First pass:
1) add Details type (with options NoDetails and StatsDetails)
2) add DetailsBar component and container
3) add `setDetailsBar` action that adds the details to the UI state
4) add `DetailsBarContainer` to `Dataset` component
5) add `fetchStats` and `fetchCommitStats` to get the stats from the backend, and store them in the `workingDataset` and `commitDetails` reducers

depends on qri-io/qri#1020