### PR TITLE
refactor: Minor ui fixes

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -806,7 +806,7 @@ export function importFile (filePath: string, fileName: string, fileSize: number
       dispatch(setImportFileDetails(fileName, fileSize))
       response = await dispatch(action)
       const { peername, name } = response.payload.data
-
+      
       response = await whenOk(fetchMyDatasets(-1))(response)
       dispatch(setWorkingDataset(peername, name))
       dispatch(setActiveTab('history'))

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -694,16 +694,18 @@ export function removeDataset (
 // remove the specified dataset, then refresh the dataset list
 export function removeDatasetAndFetch (peername: string, name: string, isLinked: boolean, keepFiles: boolean): ApiActionThunk {
   return async (dispatch, getState) => {
-    const whenOk = chainSuccess(dispatch, getState)
+    // const whenOk = chainSuccess(dispatch, getState)
     let response: Action
 
     try {
       response = await removeDataset(peername, name, isLinked, keepFiles)(dispatch, getState)
-      // reset pagination
-      response = await whenOk(fetchMyDatasets(-1))(response)
     } catch (action) {
-      throw action
+      if (!action.payload.err.message.contains('directory not empty')) {
+        throw action
+      }
     }
+    // reset pagination
+    response = await fetchMyDatasets(-1)(dispatch, getState)
     return response
   }
 }

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -694,7 +694,6 @@ export function removeDataset (
 // remove the specified dataset, then refresh the dataset list
 export function removeDatasetAndFetch (peername: string, name: string, isLinked: boolean, keepFiles: boolean): ApiActionThunk {
   return async (dispatch, getState) => {
-    // const whenOk = chainSuccess(dispatch, getState)
     let response: Action
 
     try {
@@ -808,7 +807,6 @@ export function importFile (filePath: string, fileName: string, fileSize: number
       dispatch(setImportFileDetails(fileName, fileSize))
       response = await dispatch(action)
       const { peername, name } = response.payload.data
-      
       response = await whenOk(fetchMyDatasets(-1))(response)
       dispatch(setWorkingDataset(peername, name))
       dispatch(setActiveTab('history'))

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -16,7 +16,6 @@ import Navbar from './Navbar'
 import AppError from './AppError'
 import AppLoading from './AppLoading'
 import AddDataset from './modals/AddDataset'
-import ExportVersion from './modals/ExportVersion'
 import LinkDataset from './modals/LinkDataset'
 import RemoveDataset from './modals/RemoveDataset'
 import CreateDataset from './modals/CreateDataset'
@@ -211,22 +210,6 @@ class App extends React.Component<AppProps, AppState> {
         break
       }
 
-      case ModalType.ExportVersion: {
-        modalComponent = (
-          <ExportVersion
-            peername={modal.peername}
-            name={modal.name}
-            path={modal.path}
-            title={modal.title}
-            timestamp={modal.timestamp}
-            exportPath={this.props.exportPath}
-            setExportPath={this.props.setExportPath}
-            onDismissed={async () => setModal(noModalObject)}
-          />
-        )
-        break
-      }
-
       case ModalType.LinkDataset: {
         const { peername, name } = this.props.workingDataset
         modalComponent = (
@@ -235,6 +218,8 @@ class App extends React.Component<AppProps, AppState> {
             name={name}
             onSubmit={this.props.linkDataset}
             onDismissed={async () => setModal(noModalObject)}
+            setDatasetDirPath={this.props.setDatasetDirPath}
+            datasetDirPath={this.props.datasetDirPath}
           />
         )
         break

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -74,7 +74,11 @@ export interface AppProps {
   setDatasetDirPath: (path: string) => Action
   signout: () => Action
   setRoute: (route: string) => Action
+<<<<<<< HEAD
   importFile: (filePath: string, fileName: string, fileSize: number) => Promise<ApiAction>
+=======
+  importFile: (bodypath: string) => Promise<ApiAction>
+>>>>>>> wip: set up import action
 }
 
 interface AppState {
@@ -312,12 +316,17 @@ class App extends React.Component<AppProps, AppState> {
             return
           }
 
+<<<<<<< HEAD
           const {
             path: filePath,
             name: fileName,
             size: fileSize
           } = event.dataTransfer.files[0]
           importFile(filePath, fileName, fileSize)
+=======
+          const filePath = event.dataTransfer.files[0].path
+          importFile(filePath)
+>>>>>>> wip: set up import action
         }}
         className='drag-drop'
         id='drag-drop'

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -73,11 +73,7 @@ export interface AppProps {
   setDatasetDirPath: (path: string) => Action
   signout: () => Action
   setRoute: (route: string) => Action
-<<<<<<< HEAD
   importFile: (filePath: string, fileName: string, fileSize: number) => Promise<ApiAction>
-=======
-  importFile: (bodypath: string) => Promise<ApiAction>
->>>>>>> wip: set up import action
 }
 
 interface AppState {
@@ -301,17 +297,12 @@ class App extends React.Component<AppProps, AppState> {
             return
           }
 
-<<<<<<< HEAD
           const {
             path: filePath,
             name: fileName,
             size: fileSize
           } = event.dataTransfer.files[0]
           importFile(filePath, fileName, fileSize)
-=======
-          const filePath = event.dataTransfer.files[0].path
-          importFile(filePath)
->>>>>>> wip: set up import action
         }}
         className='drag-drop'
         id='drag-drop'

--- a/app/components/ComponentList.tsx
+++ b/app/components/ComponentList.tsx
@@ -86,7 +86,7 @@ export const FileRow: React.FunctionComponent<FileRowProps> = (props) => {
         <div className='text'>{props.displayName}</div>
         <div className='subtext'>{props.filename}</div>
       </div>
-      <div className='status-column'>
+      <div className={classNames('status-column', { 'disabled': props.disabled })}>
         {statusIcon}
       </div>
     </div>
@@ -169,6 +169,26 @@ const ComponentList: React.FunctionComponent<ComponentListProps> = (props: Compo
     datasetSelected,
     fsiPath
   } = props
+
+  if (!fsiPath) {
+    return (
+      <div>
+        {components.map(({ name, displayName, tooltip, icon }) => {
+          return <FileRow
+            key={name}
+            displayName={displayName}
+            name={name}
+            icon={icon}
+            selected={false}
+            disabled={true}
+            tooltip={tooltip}
+            onClick={undefined}
+          />
+        })}
+
+      </div>
+    )
+  }
 
   const isEnabled = (name: string): boolean => {
     return (datasetSelected && selectionType === 'component' && (name === 'meta' || name === 'structure' || name === 'readme' || name === 'transform' || name === 'commit'))

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -243,7 +243,7 @@ class Dataset extends React.Component<DatasetProps> {
         <div className='main-content-flex'>
           <div className='transition-group' >
             <CSSTransition
-              in={!hasDatasets}
+              in={!peername && !name}
               classNames='fade'
               timeout={300}
               mountOnEnter

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -186,8 +186,8 @@ class Dataset extends React.Component<DatasetProps> {
         />) : (
         <HeaderColumnButton
           id='linkButton'
-          label='link to filesystem'
-          tooltip='Link this dataset to a folder on your computer'
+          label='checkout'
+          tooltip='Checkout this dataset to a folder on your computer'
           icon={(
             <span className='fa-layers fa-fw'>
               <FontAwesomeIcon icon={faFile} size='lg'/>

--- a/app/components/DatasetReference.tsx
+++ b/app/components/DatasetReference.tsx
@@ -82,11 +82,7 @@ const DatasetReference: React.FunctionComponent<DatasetReferenceProps> = (props)
     setNewName(value)
   }
 
-<<<<<<< HEAD
-  // when the input is focused, scroll all the way to the left
-=======
   // when the input is focused, set the cursor to the left, and scroll all the way to the left
->>>>>>> feat: add dataset rename
   const onFocus = () => {
     const el = document.getElementById('dataset-name-input') as HTMLInputElement
     el.scrollLeft = 0

--- a/app/components/DatasetReference.tsx
+++ b/app/components/DatasetReference.tsx
@@ -82,7 +82,11 @@ const DatasetReference: React.FunctionComponent<DatasetReferenceProps> = (props)
     setNewName(value)
   }
 
+<<<<<<< HEAD
   // when the input is focused, scroll all the way to the left
+=======
+  // when the input is focused, set the cursor to the left, and scroll all the way to the left
+>>>>>>> feat: add dataset rename
   const onFocus = () => {
     const el = document.getElementById('dataset-name-input') as HTMLInputElement
     el.scrollLeft = 0

--- a/app/components/UnlinkedDataset.tsx
+++ b/app/components/UnlinkedDataset.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faUnlink } from '@fortawesome/free-solid-svg-icons'
 
 import { Modal, ModalType } from '../models/modals'
 
@@ -12,14 +10,19 @@ const UnlinkedDataset: React.FunctionComponent<UnlinkedDatasetProps> = ({ setMod
   <div className={'unlinked-dataset'}>
     <div className={'message-container'}>
       <div>
-        <h4>This is an Unlinked Dataset</h4>
-        <p>To use the status tab, link the dataset to your filesystem.</p>
+        <h4>&apos;Checkout&apos; your dataset!</h4>
+        <p>You can edit and update your dataset in Qri Desktop!</p> <p>First, <a href='#' onClick={(e) => {
+          e.preventDefault()
+          setModal({ type: ModalType.LinkDataset })
+        }}>checkout</a> the dataset to a folder on your computer. This just means Qri will add the dataset files to a folder on your computer in a place where Qri or you can edit them.</p>
+        <p>In Qri, you can edit your dataset, add metadata, add a readme, go crazy!</p>
+        <p>When you are happy with your progress, &apos;commit&apos; a version, creating a snapshot that you can always return to!</p>
+        <p>Think of your &apos;checked out&apos; dataset as a scratch pad: a place you can experiment, but don&apos;t have to worry, because you can easily return to the previous version using Qri.</p>
         <a href='#' onClick={(e) => {
           e.preventDefault()
           setModal({ type: ModalType.LinkDataset })
-        }}>Link this Dataset</a>
+        }}>Checkout this Dataset</a>
       </div>
-      <FontAwesomeIcon icon={faUnlink} color='#777'/>
     </div>
   </div>
 )

--- a/app/components/modals/LinkDataset.tsx
+++ b/app/components/modals/LinkDataset.tsx
@@ -6,16 +6,19 @@ import TextInput from '../form/TextInput'
 import Error from './Error'
 import Buttons from './Buttons'
 import ButtonInput from '../form/ButtonInput'
+import { Action } from 'redux'
 
 interface LinkDatasetProps {
   peername: string
   name: string
   onDismissed: () => void
   onSubmit: (peername: string, name: string, dir: string) => Promise<ApiAction>
+  setDatasetDirPath: (path: string) => Action
+  datasetDirPath: string
 }
 
-const LinkDataset: React.FunctionComponent<LinkDatasetProps> = ({ peername, name, onDismissed, onSubmit }) => {
-  const [path, setPath] = React.useState('')
+const LinkDataset: React.FunctionComponent<LinkDatasetProps> = ({ peername, name, onDismissed, onSubmit, datasetDirPath, setDatasetDirPath }) => {
+  const [path, setPath] = React.useState(datasetDirPath)
   const [datasetDirectory, setDatasetDirectory] = React.useState(name)
 
   const [dismissable, setDismissable] = React.useState(true)
@@ -25,6 +28,9 @@ const LinkDataset: React.FunctionComponent<LinkDatasetProps> = ({ peername, name
   React.useEffect(() => {
     // if path is empty, disable the button
     setButtonDisabled(!path)
+    if (!path) {
+      setDatasetDirPath(path)
+    }
   }, [path])
 
   // should come from props

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -179,17 +179,6 @@ export default (state = initialState, action: AnyAction) => {
         name: action.payload.data.name
       }
 
-    case IMPORT_SUCC:
-      localStore().setItem('peername', action.payload.data.peername)
-      localStore().setItem('name', action.payload.data.name)
-      localStore().setItem('activeTab', 'history')
-      return {
-        ...state,
-        peername: action.payload.data.peername,
-        name: action.payload.data.name,
-        activeTab: 'history'
-      }
-
     default:
       return state
   }

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -179,6 +179,17 @@ export default (state = initialState, action: AnyAction) => {
         name: action.payload.data.name
       }
 
+    case IMPORT_SUCC:
+      localStore().setItem('peername', action.payload.data.peername)
+      localStore().setItem('name', action.payload.data.name)
+      localStore().setItem('activeTab', 'history')
+      return {
+        ...state,
+        peername: action.payload.data.peername,
+        name: action.payload.data.name,
+        activeTab: 'history'
+      }
+
     default:
       return state
   }

--- a/app/scss/_buttons.scss
+++ b/app/scss/_buttons.scss
@@ -5,7 +5,9 @@
 //
 
 .btn {
-  display: inline-block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   font-weight: $btn-font-weight;
   text-align: center;
   white-space: nowrap;

--- a/app/scss/_chrome.scss
+++ b/app/scss/_chrome.scss
@@ -176,8 +176,8 @@
 
 .spinner-button {
   width: 60px;
-  height: 30px;
-  padding-bottom: 5px;
+  height: 23px;
+  padding-top: 4px;
   text-align: center;
   font-size: 10px;
   display: inline-block;

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -416,16 +416,9 @@ $header-font-size: .9rem;
   height: 100%;
 
   .message-container {
-    // h4 {
-    //   color: #777;
-    //   font-weight: 500;
-    // }
-
-    // color: #777;
     display: flex;
     flex-direction: row;
     padding: 19px;
-    // border: 2px solid #E9F0F7;
     max-width: 475px;
     margin: 150px auto;
     border-radius: 5px;

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -416,16 +416,16 @@ $header-font-size: .9rem;
   height: 100%;
 
   .message-container {
-    h4 {
-      color: #777;
-      font-weight: 500;
-    }
+    // h4 {
+    //   color: #777;
+    //   font-weight: 500;
+    // }
 
-    color: #777;
+    // color: #777;
     display: flex;
     flex-direction: row;
     padding: 19px;
-    border: 2px solid #E9F0F7;
+    // border: 2px solid #E9F0F7;
     max-width: 475px;
     margin: 150px auto;
     border-radius: 5px;

--- a/app/scss/_sidebar-layout.scss
+++ b/app/scss/_sidebar-layout.scss
@@ -132,6 +132,9 @@
   }
 
   .status-column {
+    &.disabled {
+      display: none;
+    }
     text-align: center;
     width: 30px;
   }
@@ -146,7 +149,12 @@
   }
 
   &.disabled {
+    cursor: default;
     color: #ccc;
+
+    &:hover {
+      border-left: 2px solid transparent;
+    }
 
     .icon-column {
       color: #ccc;


### PR DESCRIPTION
Need to merge @chriswhong 's `streamline-import` branch first

closes #342 
closes #355 
closes #351 

Also: show `NoDataset` page, only if there is no dataset selected

Rather then waiting to see if any datasets are loaded, show the NoDatasets component in the Dataset page if there is no dataset selected.

This is an interim step, eventually we won't show the dataset page when there is no dataset selected.
