### PR TITLE
refactor: clean up state loading flow

### DIFF
--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -74,6 +74,7 @@ export interface AppProps {
   signout: () => Action
   setRoute: (route: string) => Action
   importFile: (filePath: string, fileName: string, fileSize: number) => Promise<ApiAction>
+  fetchWorkingDatasetDetails: () => Promise<ApiAction>
 }
 
 interface AppState {
@@ -131,6 +132,14 @@ class App extends React.Component<AppProps, AppState> {
   componentDidUpdate (prevProps: AppProps) {
     if (this.props.session.id === '' && prevProps.apiConnection === 0 && this.props.apiConnection === 1) {
       this.props.bootstrap()
+    }
+
+    // listen for changes to current dataset, fetch data on change
+    if ((this.props.selections.peername !== prevProps.selections.peername) || (this.props.selections.name !== prevProps.selections.name)) {
+      // if the paths are the same, don't get data (dataset was renamed)
+      if (this.props.workingDataset.path === prevProps.workingDataset.path) return
+      this.props.fetchWorkingDatasetDetails()
+      return
     }
 
     // this "wires up" all of the tooltips, must be called on update, as tooltips

--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -88,7 +88,8 @@ const CommitDetails: React.FunctionComponent<CommitDetailsProps> = ({
   }, 250)
 
   React.useEffect(() => {
-    if (selectedCommitPath !== '') {
+    // only fetch data if the workingCommit does not match selected path
+    if (selectedCommitPath !== commitDetails.path) {
       fetchCommitDetail()
         .then(() => {
           if (isLogError) setLogError(false)

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -82,8 +82,6 @@ class Dataset extends React.Component<DatasetProps> {
     ipcRenderer.on('reload', () => {
       remote.getCurrentWindow().reload()
     })
-
-    this.props.fetchWorkingDatasetDetails()
   }
 
   componentWillUnmount () {

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -82,10 +82,10 @@ const Navbar: React.FunctionComponent<NavbarProps> = (props: NavbarProps) => {
   }
 
   React.useEffect(() => {
-    document.addEventListener('click', (e) => handleClick(e))
+    document.addEventListener('click', handleClick)
 
     return () => {
-      document.removeEventListener('click', (e) => handleClick(e))
+      document.removeEventListener('click', handleClick)
     }
   })
 

--- a/app/components/chrome/HeaderColumnButtonDropdown.tsx
+++ b/app/components/chrome/HeaderColumnButtonDropdown.tsx
@@ -29,10 +29,10 @@ const HeaderColumnButtonDropdown: React.FunctionComponent<HeaderColumnButtonDrop
   }
 
   React.useEffect(() => {
-    document.addEventListener('click', (e) => handleClick(e))
+    document.addEventListener('click', handleClick)
 
     return () => {
-      document.removeEventListener('click', (e) => handleClick(e))
+      document.removeEventListener('click', handleClick)
     }
   })
 

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -11,7 +11,8 @@ import {
   publishDataset,
   unpublishDataset,
   removeDatasetAndFetch,
-  importFile
+  importFile,
+  fetchWorkingDatasetDetails
 } from '../actions/api'
 
 import {
@@ -81,7 +82,8 @@ const AppContainer = connect(
     setDatasetDirPath,
     signout,
     setRoute,
-    importFile
+    importFile,
+    fetchWorkingDatasetDetails
   },
   mergeProps
 )(App)

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -17,7 +17,7 @@ const initialState: WorkingDataset = {
   peername: '',
   name: '',
   status: {},
-  isLoading: true,
+  isLoading: false,
   fsiPath: '',
   published: true,
   hasHistory: true,
@@ -69,8 +69,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
       }
       return {
         ...initialState,
-        peername: action.segments.peername,
-        name: action.segments.name
+        isLoading: true
       }
     case DATASET_SUCC: // when adding a new dataset, set it as the new workingDataset
       const { name, path, peername, published, dataset, fsiPath } = action.payload.data
@@ -115,8 +114,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
         return state
       }
       return {
-        ...initialState,
-        isLoading: false
+        ...initialState
       }
 
     case HISTORY_REQ:


### PR DESCRIPTION
Closes #363 

Refactors flow of data loading API calls to prevent unnecessary calls when navigating around the app.  
- Listener for workingDataset fetch is moved up to `App` level
- Ensured that renaming a dataset would not cause a fetch (it used to because the name and peername had changed)
- Switching between status and history tabs no longer causes any fetching
- Switching between Collection and Dataset view no longer causes any fetching
