### PR TITLE
refactor(readme): imperfect solution to line jump

### DIFF
--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -293,7 +293,7 @@ class Dataset extends React.Component<DatasetProps> {
     return (
       <>
         <div className='details-bar-wrapper'
-          style={{ 'left': showDetailsBar ? 0 : datasetSidebarWidth * -2 }}
+          style={{ 'left': showDetailsBar ? 59 : datasetSidebarWidth * -3 }}
         >
           <div className='details-bar-inner'
             style={{ 'opacity': showDetailsBar ? 1 : 0 }}

--- a/app/components/ReadMe.tsx
+++ b/app/components/ReadMe.tsx
@@ -19,9 +19,19 @@ export interface ReadmeProps {
 
 const Readme: React.FunctionComponent<ReadmeProps> = (props) => {
   const { value, peername, name, write } = props
-
   const [internalValue, setInternalValue] = React.useState(value)
   const [debouncedValue] = useDebounce(internalValue, DEBOUNCE_TIMER)
+
+  React.useEffect(() => {
+    window.addEventListener('focus', onFocus)
+    return () => {
+      window.removeEventListener('focus', onFocus)
+    }
+  })
+
+  const onFocus = () => {
+    setInternalValue(value)
+  }
 
   React.useEffect(() => {
     if (debouncedValue !== value) {
@@ -49,7 +59,7 @@ const Readme: React.FunctionComponent<ReadmeProps> = (props) => {
   return (
     <SimpleMDE
       id="readme-editor"
-      value={value}
+      value={internalValue}
       onChange={handleChange}
       options={{
         spellChecker: false,

--- a/app/reducers/commitDetail.ts
+++ b/app/reducers/commitDetail.ts
@@ -27,6 +27,9 @@ const initialState: CommitDetails = {
     },
     structure: {
       value: {}
+    },
+    readme: {
+      value: {}
     }
   },
   stats: []
@@ -65,6 +68,9 @@ const commitDetailsReducer: Reducer = (state = initialState, action: AnyAction):
           },
           commit: {
             value: dataset.commit
+          },
+          readme: {
+            value: dataset.readme
           }
         }
       }

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -455,10 +455,14 @@ $header-font-size: .9rem;
   height: 100%;
   background: $appBackground;
   border-right: 1px solid $border-color;
-  -webkit-transition-duration: 0.3s;
-  -moz-transition-duration: 0.3s;
-  -o-transition-duration: 0.3s;
-  transition-duration: 0.3s;
+  // -webkit-transition-duration: 0.3s;
+  // -moz-transition-duration: 0.3s;
+  // -o-transition-duration: 0.3s;
+  // transition-duration: 0.3s;
+  transition: left 0.3s;
+  &:active {
+    transition: left 0.3s, opacity 0.3s 0.3s;
+  }
 }
 
 .details-bar-inner {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11903,7 +11903,7 @@ raw-loader@^2.0.0:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-rc-progress@^2.5.2:
+rc-progress@2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/rc-progress/-/rc-progress-2.5.2.tgz#ab01ba4e5d2fa36fc9f6f058b10b720e7315560c"
   integrity sha512-ajI+MJkbBz9zYDuE9GQsY5gsyqPF7HFioZEDZ9Fmc+ebNZoiSeSJsTJImPFCg0dW/5WiRGUy2F69SX1aPtSJgA==


### PR DESCRIPTION
For now, since it's pretty unlikely that someone will be editing the readme on the app and in their own editor at the same time, let's refactor the readme so that the line-jump error is fixed.

This refactor waits until we are focused on the window before checking if the given value is diffferent then the value we are displaying on the page. If it is, then we replace the display value with the given value. It's not perfect and there are some rendering issues, but this is a good stop-gap.

This also fixes the DetailsBar formatting issues

closes #345 
closes #366 