### PR TITLE
fix(App, Dataset, Remove): fix eventListener leak and clearing selection after a remove

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -56,7 +56,7 @@ export function fetchWorkingDatasetDetails (): ApiActionThunk {
       if (response.payload.err.code !== 422) {
         return response
       }
-      response = await fetchWorkingDataset(false)(dispatch, getState)
+      response = await fetchWorkingDataset()(dispatch, getState)
     }
     response = await whenOk(fetchWorkingStatus())(response)
     response = await whenOk(fetchBody(-1))(response)

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -442,9 +442,17 @@ export function saveWorkingDatasetAndFetch (): ApiActionThunk {
     const whenOk = chainSuccess(dispatch, getState)
     let response: Action
 
-    response = await saveWorkingDataset()(dispatch, getState)
-    response = await whenOk(fetchWorkingDatasetDetails())(response)
-
+    try {
+      response = await saveWorkingDataset()(dispatch, getState)
+      const path = response.payload.data.dataset.path
+      response = await whenOk(fetchWorkingDatasetDetails())(response)
+      dispatch(setSelectedListItem('commit', path))
+      dispatch(setActiveTab('history'))
+      dispatch(setSelectedListItem('commitComponent', DEFAULT_SELECTED_COMPONENT))
+    } catch (action) {
+      dispatch(openToast('error', action.payload.err.message))
+      throw action
+    }
     return response
   }
 }

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -1,7 +1,7 @@
 import { Action, AnyAction } from 'redux'
 
-import { CALL_API, ApiAction, ApiActionThunk, chainSuccess, ApiResponseAction } from '../store/api'
-import { DatasetSummary, SelectedComponent, MyDatasets } from '../models/store'
+import { CALL_API, ApiAction, ApiActionThunk, chainSuccess } from '../store/api'
+import { SelectedComponent, MyDatasets } from '../models/store'
 import { actionWithPagination } from '../utils/pagination'
 import { openToast, setImportFileDetails } from './ui'
 import { setWorkingDataset, setSelectedListItem, setActiveTab, setRoute, clearSelection } from './selections'
@@ -148,7 +148,6 @@ export function fetchWorkingDataset (): ApiActionThunk {
     if (peername === '' || name === '') {
       return Promise.reject(new Error('no peername or name selected'))
     }
-
     // look up the peername + name in myDatasets to determine whether it is FSI linked
     const dataset = myDatasets.value.find((d) => (d.peername === peername) && (d.name === name))
     if (!dataset) {
@@ -450,7 +449,7 @@ export function saveWorkingDatasetAndFetch (): ApiActionThunk {
   }
 }
 
-export function addDataset (peername: string, name: string, path: string): ApiActionThunk {
+export function addDataset (peername: string, name: string): ApiActionThunk {
   return async (dispatch) => {
     const action = {
       type: 'add',
@@ -461,9 +460,6 @@ export function addDataset (peername: string, name: string, path: string): ApiAc
           peername,
           name
         },
-        query: {
-          dir: path
-        },
         map: mapDataset
       }
     }
@@ -471,62 +467,21 @@ export function addDataset (peername: string, name: string, path: string): ApiAc
   }
 }
 
-export function addDatasetAndFetch (peername: string, name: string, path: string): ApiActionThunk {
+export function addDatasetAndFetch (peername: string, name: string): ApiActionThunk {
   return async (dispatch, getState) => {
     const whenOk = chainSuccess(dispatch, getState)
     let response: Action
 
     try {
-      response = await addDataset(peername, name, path)(dispatch, getState)
+      response = await addDataset(peername, name)(dispatch, getState)
       // reset pagination
       response = await whenOk(fetchMyDatasets(-1))(response)
       dispatch(setWorkingDataset(peername, name))
       dispatch(setActiveTab('history'))
       dispatch(setSelectedListItem('component', DEFAULT_SELECTED_COMPONENT))
-    } catch (action) {
-      throw action
-    }
-    return response
-  }
-}
-
-export function initDataset (sourcebodypath: string, name: string, dir: string, mkdir: string): ApiActionThunk {
-  return async (dispatch) => {
-    const action = {
-      type: 'init',
-      [CALL_API]: {
-        endpoint: 'init/',
-        method: 'POST',
-        query: {
-          sourcebodypath,
-          name,
-          dir,
-          mkdir
-        },
-        map: mapDataset
-      }
-    }
-    return dispatch(action)
-  }
-}
-
-export function initDatasetAndFetch (sourcebodypath: string, name: string, dir: string, mkdir: string): ApiActionThunk {
-  return async (dispatch, getState) => {
-    const whenOk = chainSuccess(dispatch, getState)
-    let response: Action
-
-    try {
-      response = await initDataset(sourcebodypath, name, dir, mkdir)(dispatch, getState)
-      // reset pagination
-      response = await whenOk(fetchMyDatasets(-1))(response)
-      const action = response as ApiResponseAction
-      const { data } = action.payload
-      const { peername } = data.find((dataset: DatasetSummary) => dataset.name === name)
-      dispatch(setWorkingDataset(peername, name))
-      dispatch(setActiveTab('status'))
-      dispatch(setSelectedListItem('component', DEFAULT_SELECTED_COMPONENT))
       dispatch(setRoute('/dataset'))
     } catch (action) {
+      dispatch(openToast('error', action.payload.err.message))
       throw action
     }
     return response

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -4,7 +4,7 @@ import { CALL_API, ApiAction, ApiActionThunk, chainSuccess, ApiResponseAction } 
 import { DatasetSummary, SelectedComponent, MyDatasets } from '../models/store'
 import { actionWithPagination } from '../utils/pagination'
 import { openToast, setImportFileDetails } from './ui'
-import { setWorkingDataset, setSelectedListItem, setActiveTab, setRoute } from './selections'
+import { setWorkingDataset, setSelectedListItem, setActiveTab, setRoute, clearSelection } from './selections'
 import {
   mapDataset,
   mapRecord,
@@ -712,6 +712,7 @@ export function removeDatasetAndFetch (peername: string, name: string, isLinked:
       }
     }
     // reset pagination
+    dispatch(clearSelection())
     response = await fetchMyDatasets(-1)(dispatch, getState)
     return response
   }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -56,10 +56,9 @@ export interface AppProps {
   children: JSX.Element[] | JSX.Element
   bootstrap: () => Promise<ApiAction>
   fetchMyDatasets: (page?: number, pageSize?: number) => Promise<ApiAction>
-  addDataset: (peername: string, name: string, path: string) => Promise<ApiAction>
+  addDataset: (peername: string, name: string) => Promise<ApiAction>
   linkDataset: (peername: string, name: string, dir: string) => Promise<ApiAction>
   setWorkingDataset: (peername: string, name: string) => Promise<ApiAction>
-  initDataset: (path: string, name: string, format: string) => Promise<ApiAction>
   acceptTOS: () => Action
   setQriCloudAuthenticated: () => Action
   signup: (username: string, email: string, password: string) => Promise<ApiAction>
@@ -216,10 +215,8 @@ class App extends React.Component<AppProps, AppState> {
       case ModalType.CreateDataset: {
         modalComponent = (
           <CreateDataset
-            datasetDirPath={this.props.datasetDirPath}
-            onSubmit={this.props.initDataset}
+            onSubmit={this.props.importFile}
             onDismissed={async () => setModal(noModalObject)}
-            setDatasetDirPath={this.props.setDatasetDirPath}
             filePath={modal.bodyPath ? modal.bodyPath : ''}
           />
         )
@@ -229,10 +226,8 @@ class App extends React.Component<AppProps, AppState> {
       case ModalType.AddDataset: {
         modalComponent = (
           <AddDataset
-            datasetDirPath={this.props.datasetDirPath}
             onSubmit={this.props.addDataset}
             onDismissed={async () => setModal(noModalObject)}
-            setDatasetDirPath={this.props.setDatasetDirPath}
           />
         )
         break

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -152,9 +152,15 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     // listen for changes to current dataset, fetch data on change
-    if ((this.props.selections.peername !== prevProps.selections.peername) || (this.props.selections.name !== prevProps.selections.name)) {
+    if (!(this.props.selections.peername === '' || this.props.selections.name === '') && (
+      (this.props.selections.peername !== prevProps.selections.peername) || (this.props.selections.name !== prevProps.selections.name))
+    ) {
       // if the paths are the same, don't get data (dataset was renamed)
-      if (this.props.workingDataset.path === prevProps.workingDataset.path) return
+      if (
+        !(this.props.workingDataset.peername === '' || this.props.workingDataset.name === '') && (this.props.workingDataset.path === prevProps.workingDataset.path)
+      ) {
+        return
+      }
       this.props.fetchWorkingDatasetDetails()
       return
     }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -102,21 +102,30 @@ class App extends React.Component<AppProps, AppState> {
     this.renderModal = this.renderModal.bind(this)
     this.renderAppLoading = this.renderAppLoading.bind(this)
     this.renderAppError = this.renderAppError.bind(this)
+    this.handleCreateDataset = this.handleCreateDataset.bind(this)
+    this.handleAddDataset = this.handleAddDataset.bind(this)
+    this.handleSelectRoute = this.handleSelectRoute.bind(this)
+  }
+
+  private handleCreateDataset () {
+    this.props.setModal({ type: ModalType.CreateDataset })
+  }
+
+  private handleAddDataset () {
+    this.props.setModal({ type: ModalType.AddDataset })
+  }
+
+  private handleSelectRoute (e: any, route: string) {
+    this.props.setRoute(route)
   }
 
   componentDidMount () {
     // handle ipc events from electron menus
-    ipcRenderer.on('create-dataset', () => {
-      this.props.setModal({ type: ModalType.CreateDataset })
-    })
+    ipcRenderer.on('create-dataset', this.handleCreateDataset)
 
-    ipcRenderer.on('add-dataset', () => {
-      this.props.setModal({ type: ModalType.AddDataset })
-    })
+    ipcRenderer.on('add-dataset', this.handleAddDataset)
 
-    ipcRenderer.on('select-route', (e: any, route: string) => {
-      this.props.setRoute(route)
-    })
+    ipcRenderer.on('select-route', this.handleSelectRoute)
 
     setInterval(() => {
       if (this.props.apiConnection !== 1 || this.props.selections.peername === '' || this.props.selections.name === '') {
@@ -127,6 +136,14 @@ class App extends React.Component<AppProps, AppState> {
     if (this.props.apiConnection === 1) {
       this.props.bootstrap()
     }
+  }
+
+  componentWillUnmount () {
+    ipcRenderer.removeListener('create-dataset', this.handleCreateDataset)
+
+    ipcRenderer.on('add-dataset', this.handleAddDataset)
+
+    ipcRenderer.on('select-route', this.handleSelectRoute)
   }
 
   componentDidUpdate (prevProps: AppProps) {

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -56,22 +56,19 @@ export interface DatasetProps {
 const logo = require('../assets/qri-blob-logo-tiny.png') //eslint-disable-line
 
 class Dataset extends React.Component<DatasetProps> {
-  super () {
-    this.openWorkingDirectory = this.openWorkingDirectory.bind(this)
-    this.publishUnpublishDataset = this.publishUnpublishDataset.bind(this)
-    this.handleShowStatus = this.handleShowStatus.bind(this)
-    this.handleShowHistory = this.handleShowHistory.bind(this)
-    this.handleReload = this.handleReload.bind(this)
+  constructor (props: DatasetProps) {
+    super(props);
+
+    [
+      'openWorkingDirectory',
+      'publishUnpublishDataset',
+      'handleShowStatus',
+      'handleShowHistory',
+      'handleReload'
+    ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
   componentDidMount () {
-    // poll for status
-    this.statusInterval = setInterval(() => {
-      if (this.props.workingDataset.peername !== '' || this.props.workingDataset.name !== '') {
-        this.props.fetchWorkingStatus()
-      }
-    }, defaultPollInterval)
-
     // electron menu events
     ipcRenderer.on('show-status', this.handleShowStatus)
 
@@ -96,6 +93,12 @@ class Dataset extends React.Component<DatasetProps> {
 
     ipcRenderer.removeListener('reload', this.handleReload)
   }
+
+  statusInterval = setInterval(() => {
+    if (this.props.workingDataset.peername !== '' || this.props.workingDataset.name !== '') {
+      this.props.fetchWorkingStatus()
+    }
+  }, defaultPollInterval)
 
   handleShowStatus () {
     this.props.setActiveTab('status')

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -49,6 +49,7 @@ export interface DatasetProps {
   fetchWorkingDatasetDetails: () => Promise<ApiAction>
   fetchWorkingStatus: () => Promise<ApiAction>
   fetchBody: (page: number) => Promise<ApiAction>
+  setRoute: (route: string) => Action
   fetchWorkingDataset: () => Promise<ApiAction>
 }
 
@@ -167,7 +168,7 @@ class Dataset extends React.Component<DatasetProps> {
 
   render () {
     // unpack all the things
-    const { ui, selections, workingDataset, setModal, hasDatasets, session } = this.props
+    const { ui, selections, workingDataset, setModal, hasDatasets, session, setRoute } = this.props
     const { peername: username } = session
     const { datasetSidebarWidth } = ui
     const {
@@ -267,7 +268,7 @@ class Dataset extends React.Component<DatasetProps> {
               mountOnEnter
               unmountOnExit
             >
-              <NoDatasets setModal={setModal} />
+              <NoDatasets setModal={setModal} setRoute={setRoute} />
             </CSSTransition>
             <CSSTransition
               in={!datasetSelected && hasDatasets}

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -202,7 +202,7 @@ class Dataset extends React.Component<DatasetProps> {
           icon={faFolderOpen}
           label='Show Files'
           onClick={this.openWorkingDirectory}
-        />) : (
+        />) : username === peername && (
         <HeaderColumnButton
           id='linkButton'
           label='checkout'
@@ -286,7 +286,7 @@ class Dataset extends React.Component<DatasetProps> {
               mountOnEnter
               unmountOnExit
             >
-              <UnlinkedDataset setModal={setModal}/>
+              <UnlinkedDataset setModal={setModal} inNamespace={username === peername}/>
             </CSSTransition>
             <CSSTransition
               in={datasetSelected && activeTab === 'status' && isLinked}

--- a/app/components/Dataset.tsx
+++ b/app/components/Dataset.tsx
@@ -55,6 +55,14 @@ export interface DatasetProps {
 const logo = require('../assets/qri-blob-logo-tiny.png') //eslint-disable-line
 
 class Dataset extends React.Component<DatasetProps> {
+  super () {
+    this.openWorkingDirectory = this.openWorkingDirectory.bind(this)
+    this.publishUnpublishDataset = this.publishUnpublishDataset.bind(this)
+    this.handleShowStatus = this.handleShowStatus.bind(this)
+    this.handleShowHistory = this.handleShowHistory.bind(this)
+    this.handleReload = this.handleReload.bind(this)
+  }
+
   componentDidMount () {
     // poll for status
     this.statusInterval = setInterval(() => {
@@ -63,29 +71,41 @@ class Dataset extends React.Component<DatasetProps> {
       }
     }, defaultPollInterval)
 
-    this.openWorkingDirectory = this.openWorkingDirectory.bind(this)
-    this.publishUnpublishDataset = this.publishUnpublishDataset.bind(this)
-
     // electron menu events
-    ipcRenderer.on('show-status', () => {
-      this.props.setActiveTab('status')
-    })
+    ipcRenderer.on('show-status', this.handleShowStatus)
 
-    ipcRenderer.on('show-history', () => {
-      this.props.setActiveTab('history')
-    })
+    ipcRenderer.on('show-history', this.handleShowHistory)
 
     ipcRenderer.on('open-working-directory', this.openWorkingDirectory)
 
     ipcRenderer.on('publish-unpublish-dataset', this.publishUnpublishDataset)
 
-    ipcRenderer.on('reload', () => {
-      remote.getCurrentWindow().reload()
-    })
+    ipcRenderer.on('reload', this.handleReload)
   }
 
   componentWillUnmount () {
     clearInterval(this.statusInterval)
+    ipcRenderer.removeListener('show-status', this.handleShowStatus)
+
+    ipcRenderer.removeListener('show-history', this.handleShowHistory)
+
+    ipcRenderer.removeListener('open-working-directory', this.openWorkingDirectory)
+
+    ipcRenderer.removeListener('publish-unpublish-dataset', this.publishUnpublishDataset)
+
+    ipcRenderer.removeListener('reload', this.handleReload)
+  }
+
+  handleShowStatus () {
+    this.props.setActiveTab('status')
+  }
+
+  handleShowHistory () {
+    this.props.setActiveTab('history')
+  }
+
+  handleReload () {
+    remote.getCurrentWindow().reload()
   }
 
   componentDidUpdate (prevProps: DatasetProps) {

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -40,6 +40,9 @@ const ImportProgressBar: React.FunctionComponent<ImportProgressBarProps> = ({ du
       return
     }
     timer = setTimeout(increase, timeForOnePercent)
+    return () => {
+      clearTimeout(timer)
+    }
   }, [ percent ])
 
   React.useEffect(() => {

--- a/app/components/DatasetReference.tsx
+++ b/app/components/DatasetReference.tsx
@@ -101,7 +101,7 @@ const DatasetReference: React.FunctionComponent<DatasetReferenceProps> = (props)
           onChange={handleInputChange}
           autoFocus
           onFocus={onFocus}
-          pattern='^[a-z0-9_]+$'
+          pattern='^(?![0_9])[a-z0-9_]{1,144}$'
         /> }
         { !nameEditing && (<>{name}</>)}
       </div>

--- a/app/components/NoDatasets.tsx
+++ b/app/components/NoDatasets.tsx
@@ -1,21 +1,27 @@
 import * as React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faDownload, faPlus } from '@fortawesome/free-solid-svg-icons'
+import { faDownload, faPlus, faFile } from '@fortawesome/free-solid-svg-icons'
 
 import { Modal, ModalType } from '../models/modals'
 import WelcomeTemplate from './WelcomeTemplate'
+import { Action } from 'redux'
 
 interface NoDatasetsProps {
   setModal: (modal: Modal) => void
+  setRoute: (route: string) => Action
 }
 
-const NoDatasets: React.FunctionComponent<NoDatasetsProps> = ({ setModal }) =>
+const NoDatasets: React.FunctionComponent<NoDatasetsProps> = ({ setModal, setRoute }) =>
   <WelcomeTemplate
-    title='Let&apos;s get some datasets'
-    subtitle='To get started, add an existing Qri dataset or create a new one from a data file'
+    title=''
+    subtitle=''
     id='no-datasets-page'
     showLogo={false}
   >
+    <div id='choose_dataset' className='no-datasets-options' onClick={async () => setRoute('collection')}>
+      <h5><FontAwesomeIcon icon={faFile} />&nbsp;&nbsp;Explore a Dataset</h5>
+      <p>Pick a dataset to explore from the Collections page.</p>
+    </div>
     <div id='create_dataset' className='no-datasets-options' onClick={() => setModal({ type: ModalType.CreateDataset })}>
       <h5><FontAwesomeIcon icon={faDownload} />&nbsp;&nbsp;Create a Dataset</h5>
       <p>Choose a data file on your computer to create a new Qri dataset.</p>

--- a/app/components/UnlinkedDataset.tsx
+++ b/app/components/UnlinkedDataset.tsx
@@ -1,28 +1,42 @@
 import * as React from 'react'
 
 import { Modal, ModalType } from '../models/modals'
+import ExternalLink from './ExternalLink'
 
 interface UnlinkedDatasetProps {
   setModal: (modal: Modal) => void
+  inNamespace: boolean
 }
 
-const UnlinkedDataset: React.FunctionComponent<UnlinkedDatasetProps> = ({ setModal }) => (
+const UnlinkedDataset: React.FunctionComponent<UnlinkedDatasetProps> = ({ setModal, inNamespace = true }) => (
   <div className={'unlinked-dataset'}>
     <div className={'message-container'}>
-      <div>
-        <h4>&apos;Checkout&apos; your dataset!</h4>
-        <p>You can edit and update your dataset in Qri Desktop!</p> <p>First, <a href='#' onClick={(e) => {
-          e.preventDefault()
-          setModal({ type: ModalType.LinkDataset })
-        }}>checkout</a> the dataset to a folder on your computer. This just means Qri will add the dataset files to a folder on your computer in a place where Qri or you can edit them.</p>
-        <p>In Qri, you can edit your dataset, add metadata, add a readme, go crazy!</p>
-        <p>When you are happy with your progress, &apos;commit&apos; a version, creating a snapshot that you can always return to!</p>
-        <p>Think of your &apos;checked out&apos; dataset as a scratch pad: a place you can experiment, but don&apos;t have to worry, because you can easily return to the previous version using Qri.</p>
-        <a href='#' onClick={(e) => {
-          e.preventDefault()
-          setModal({ type: ModalType.LinkDataset })
-        }}>Checkout this Dataset</a>
-      </div>
+      {
+        inNamespace
+          ? <div>
+            <h4>&apos;Checkout&apos; your dataset!</h4>
+            <p>You can edit and update your dataset in Qri Desktop!</p> <p>First, <a href='#' onClick={(e) => {
+              e.preventDefault()
+              setModal({ type: ModalType.LinkDataset })
+            }}>checkout</a> the dataset to a folder on your computer. This just means Qri will add the dataset files to a folder on your computer in a place where Qri or you can edit them.</p>
+            <p>In Qri, you can edit your dataset, add metadata, add a readme, go crazy!</p>
+            <p>When you are happy with your progress, &apos;commit&apos; a version, creating a snapshot that you can always return to!</p>
+            <p>Think of your &apos;checked out&apos; dataset as a scratch pad: a place you can experiment, but don&apos;t have to worry, because you can easily return to the previous version using Qri.</p>
+            <a href='#' onClick={(e) => {
+              e.preventDefault()
+              setModal({ type: ModalType.LinkDataset })
+            }}>Checkout this Dataset</a>
+          </div>
+          : <div>
+            <h4>You are viewing another user&apos;s dataset!</h4>
+            <p>
+            If you want to make edits to this dataset, you will need to import the data as your own. Head over to the &apos;History&apos; tab and right-click on whichever version you want to work with. Export it, unzip the contents, and import the body file by dragging and dropping it over the app. The dataset is now yours!
+            </p>
+            <p>
+            We are working on streamlining this process! If you have any thoughts or suggestions please reach out to us on <ExternalLink href='https://github.com/qri-io/desktop/issues'>Github</ExternalLink> or <ExternalLink href='https://discordapp.com/invite/thkJHKj'>Discord</ExternalLink>.
+            </p>
+          </div>
+      }
     </div>
   </div>
 )

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import path from 'path'
-import { Action } from 'redux'
 import { remote } from 'electron'
+import fs from 'fs'
 import changeCase from 'change-case'
 
 import Modal from './Modal'
@@ -11,13 +11,10 @@ import TextInput from '../form/TextInput'
 import Error from './Error'
 import Buttons from './Buttons'
 import ButtonInput from '../form/ButtonInput'
-import { validateDatasetName } from '../../utils/formValidation'
 
 interface CreateDatasetProps {
   onDismissed: () => void
-  onSubmit: (path: string, name: string, dir: string, mkdir: string) => Promise<ApiAction>
-  datasetDirPath: string
-  setDatasetDirPath: (path: string) => Action
+  onSubmit: (filePath: string, fileName: string, fileSize: number) => Promise<ApiAction>
   filePath: string
 }
 
@@ -25,8 +22,6 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
   const {
     onDismissed,
     onSubmit,
-    datasetDirPath: persistedDatasetDirPath,
-    setDatasetDirPath: saveDatasetDirPath,
     filePath: givenFilePath
   } = props
 
@@ -38,29 +33,16 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
     return coercedName.replace(/^[^a-z0-9_]+$/g, '')
   }
 
-  const [datasetDirPath, setDatasetDirPath] = React.useState(persistedDatasetDirPath)
   const [filePath, setFilePath] = React.useState(givenFilePath)
   const [datasetName, setDatasetName] = React.useState(validName(path.basename(filePath, path.extname(filePath))))
 
   const [dismissable, setDismissable] = React.useState(true)
   const [buttonDisabled, setButtonDisabled] = React.useState(true)
-  const [datasetNameError, setDatasetNameError] = React.useState('')
   const [alreadyDatasetError, setAlreadyDatasetError] = React.useState('')
 
   React.useEffect(() => {
-    // validate datasetName and assign error
-    const datasetNameValidationError = validateDatasetName(datasetName)
-    datasetNameValidationError ? setDatasetNameError(datasetNameValidationError) : setDatasetNameError('')
-
-    // only ready when all three fields are not invalid
-    const ready = datasetDirPath !== '' && filePath !== '' && datasetName !== '' && !datasetNameValidationError
-    setButtonDisabled(!ready)
-  }, [datasetName, datasetDirPath, filePath])
-
-  React.useEffect(() => {
-    // persist the datasetDirPath
-    saveDatasetDirPath(datasetDirPath)
-  }, [datasetDirPath])
+    setButtonDisabled(filePath === '')
+  }, [filePath])
 
   // should come from props
   const [error, setError] = React.useState('')
@@ -68,26 +50,6 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
 
   // should come from props/actions that has us check if the directory already contains a qri dataset
   const isQriDataset = (datasetDirPath: string) => !datasetDirPath
-
-  const showDirectoryPicker = () => {
-    const window = remote.getCurrentWindow()
-    const directory: string[] | undefined = remote.dialog.showOpenDialog(window, {
-      properties: ['createDirectory', 'openDirectory']
-    })
-
-    if (!directory) {
-      return
-    }
-
-    const selectedPath = directory[0]
-
-    setDatasetDirPath(selectedPath)
-    const isDataset = isQriDataset(selectedPath)
-    if (isDataset) {
-      setAlreadyDatasetError('A dataset already exists in this directory.')
-      setButtonDisabled(true)
-    }
-  }
 
   const showFilePicker = () => {
     const window = remote.getCurrentWindow()
@@ -124,41 +86,18 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
       .then(() => setDismissable(true))
   }
 
-  const handlePathPickerDialog = (showFunc: () => void) => {
-    new Promise(resolve => {
-      setDismissable(false)
-      resolve()
-    })
-      .then(() => showFunc())
-      .then(() => setDismissable(true))
-  }
-
-  const handleChanges = (name: string, value: any) => {
-    if (value[value.length - 1] === ' ') {
-      return
-    }
-
-    if (name === 'datasetName') {
-      setDatasetName(value)
-      setAlreadyDatasetError('')
-    }
-  }
-
   const handleSubmit = () => {
+    if (filePath === '') return
     setDismissable(false)
     setLoading(true)
+    const fileName = path.basename(filePath)
+    const stats = fs.statSync(filePath)
+
     error && setError('')
     if (!onSubmit) return
-    onSubmit(filePath, datasetName, datasetDirPath, datasetName)
-      .then(() => onDismissed())
-      .catch((action: any) => {
-        setLoading(false)
-        setDismissable(true)
-        setError(action.payload.err.message)
-      })
+    onSubmit(filePath, fileName, stats.size)
+    onDismissed()
   }
-
-  const fullPath = path.join(datasetDirPath, datasetName)
 
   return (
     <Modal
@@ -180,46 +119,17 @@ const CreateDataset: React.FunctionComponent<CreateDatasetProps> = (props) => {
               labelTooltip='Select a CSV or JSON file on your computer.<br/>Qri will import the data and leave the file in place.'
               type=''
               value={filePath}
-              onChange={handleChanges}
+              onChange={(name: string, value: any) => {
+                setButtonDisabled(value === '')
+              }}
               maxLength={600}
               errorText={alreadyDatasetError}
               tooltipFor='modal-tooltip'
             />
             <div className='margin-left'><ButtonInput id='chooseBodyFilePath' onClick={() => handleFilePickerDialog(showFilePicker)} >Choose...</ButtonInput></div>
           </div>
-          <TextInput
-            name='datasetName'
-            label='Dataset Name'
-            labelTooltip='Choose a descriptive name that is unique among your datasets'
-            type=''
-            value={datasetName}
-            onChange={handleChanges}
-            maxLength={600}
-            errorText={datasetNameError}
-            tooltipFor='modal-tooltip'
-          />
-          <div className='flex-space-between'>
-            <TextInput
-              name='savePath'
-              label='Directory path'
-              labelTooltip='Qri will create a new directory for<br/>this dataset&apos;s files at this location.'
-              type=''
-              value={datasetDirPath}
-              onChange={handleChanges}
-              maxLength={600}
-              errorText={alreadyDatasetError}
-              tooltipFor='modal-tooltip'
-            />
-            <div className='margin-left'><ButtonInput id='chooseSavePath' onClick={() => handlePathPickerDialog(showDirectoryPicker)} >Choose...</ButtonInput></div>
-          </div>
         </div>
       </div>
-
-      <p className='submit-message'>
-        {!buttonDisabled && (
-          <span>Qri will create the directory {fullPath} and import your data file</span>
-        )}
-      </p>
       <Error id={'create-modal-error'} text={error} />
       <Buttons
         cancelText='cancel'

--- a/app/components/modals/Header.tsx
+++ b/app/components/modals/Header.tsx
@@ -76,7 +76,7 @@ const DialogHeader: React.FunctionComponent<IDialogHeaderProps> = ({ onDismissed
   }
 
   const renderTitle = () => {
-    return <h1 id={titleId}>{title}</h1>
+    return <div className='title' id={titleId}>{title}</div>
   }
 
   const spinner = loading ? <Spinner /> : null

--- a/app/components/modals/LinkDataset.tsx
+++ b/app/components/modals/LinkDataset.tsx
@@ -101,7 +101,7 @@ const LinkDataset: React.FunctionComponent<LinkDatasetProps> = ({ peername, name
   return (
     <Modal
       id="LinkDataset"
-      title={`Link ${peername}/${name}`}
+      title={`Checkout ${peername}/${name}`}
       onDismissed={onDismissed}
       onSubmit={() => {}}
       dismissable={dismissable}

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -5,7 +5,6 @@ import Store from '../models/store'
 import {
   fetchMyDatasets,
   addDatasetAndFetch,
-  initDatasetAndFetch,
   linkDatasetAndFetch,
   pingApi,
   publishDataset,
@@ -68,7 +67,6 @@ const AppContainer = connect(
     signup,
     setQriCloudAuthenticated,
     addDataset: addDatasetAndFetch,
-    initDataset: initDatasetAndFetch,
     linkDataset: linkDatasetAndFetch,
     openToast,
     closeToast,

--- a/app/containers/DatasetContainer.tsx
+++ b/app/containers/DatasetContainer.tsx
@@ -16,7 +16,8 @@ import {
 
 import {
   setActiveTab,
-  setSelectedListItem
+  setSelectedListItem,
+  setRoute
 } from '../actions/selections'
 import { DetailsType } from '../models/details'
 
@@ -62,6 +63,7 @@ const DatasetContainer = connect(
     fetchBody,
     fetchWorkingDataset,
     publishDataset,
+    setRoute,
     unpublishDataset
   },
   mergeProps

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qri-desktop",
   "productName": "Qri Desktop",
-  "version": "0.3.0",
+  "version": "0.3.1-dev",
   "backendVersion": "0.9.3",
   "description": "Version your data with the Qri desktop app!",
   "main": "./main.js",

--- a/app/reducers/commitDetail.ts
+++ b/app/reducers/commitDetail.ts
@@ -30,6 +30,9 @@ const initialState: CommitDetails = {
     },
     readme: {
       value: {}
+    },
+    transform: {
+      value: {}
     }
   },
   stats: []

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -149,29 +149,6 @@ export default (state = initialState, action: AnyAction) => {
         activeTab: 'status'
       }
 
-      // when a new dataset is added from the network, make it the selected dataset
-    case ADD_SUCC:
-      localStore().setItem('peername', action.payload.data.peername)
-      localStore().setItem('name', action.payload.data.name)
-      localStore().setItem('activeTab', 'history')
-      return {
-        ...state,
-        peername: action.payload.data.peername,
-        name: action.payload.data.name,
-        activeTab: 'history'
-      }
-      // when a new dataset is created, make it the selected dataset
-    case INIT_SUCC:
-      localStore().setItem('peername', action.payload.data.peername)
-      localStore().setItem('name', action.payload.data.name)
-      localStore().setItem('activeTab', 'status')
-      return {
-        ...state,
-        peername: action.payload.data.peername,
-        name: action.payload.data.name,
-        activeTab: 'status'
-      }
-
     case RENAME_SUCC:
       localStore().setItem('name', action.payload.data.name)
       return {

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -103,7 +103,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
             value: dataset && dataset.structure ? dataset.structure : {}
           },
           transform: {
-            value: dataset && dataset.transform ? atob(dataset.transform.scriptBytes) : ''
+            value: dataset && dataset.transform ? dataset.transform : {}
           }
         }
       }

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -414,13 +414,15 @@ $header-font-size: .9rem;
 
 .unlinked-dataset {
   height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   .message-container {
     display: flex;
     flex-direction: row;
-    padding: 19px;
+    padding: $spacer * 2;
     max-width: 475px;
-    margin: 150px auto;
     border-radius: 5px;
   }
 }

--- a/app/scss/_dialog.scss
+++ b/app/scss/_dialog.scss
@@ -27,8 +27,11 @@ dialog {
     justify-content: space-between;
     align-items: center;
 
-    h1 {
+    .title {
       font-weight: $font-weight-medium;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       font-size: $font-size-lg;
       margin: 0;
       padding: 0;

--- a/app/utils/formValidation.ts
+++ b/app/utils/formValidation.ts
@@ -37,15 +37,19 @@ export const validatePassword = (password: string) => {
   return null
 }
 
+export const ERR_INVALID_DATASETNAME_START: ValidationError = 'Dataset names must start with a letter'
 export const ERR_INVALID_DATASETNAME_CHARACTERS: ValidationError = 'Dataset names may only include lowercase letters, numbers, and underscores'
-export const ERR_INVALID_DATASETNAME_LENGTH: ValidationError = 'Username must be 100 characters or fewer'
+export const ERR_INVALID_DATASETNAME_LENGTH: ValidationError = 'Username must be 144 characters or fewer'
 
 export const validateDatasetName = (name: string): ValidationError => {
   if (name) {
-    const invalidCharacters = !(/^[a-z0-9_]+$/.test(name))
+    const invalidStart = !(/[a-z]/).test(name[0])
+    if (invalidStart) return ERR_INVALID_DATASETNAME_START
+
+    const invalidCharacters = !(/^(?![0-9])[a-z0-9_]+$/.test(name))
     if (invalidCharacters) return ERR_INVALID_DATASETNAME_CHARACTERS
 
-    const tooLong = name.length > 100
+    const tooLong = name.length > 144
     if (tooLong) return ERR_INVALID_DATASETNAME_LENGTH
   }
   return null

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qri-desktop",
   "productName": "Qri Desktop",
-  "version": "0.3.0",
+  "version": "0.3.1-dev",
   "description": "Version your data with the Qri desktop app!",
   "main": "main.js",
   "scripts": {

--- a/test/app/reducers/selections.test.ts
+++ b/test/app/reducers/selections.test.ts
@@ -205,40 +205,6 @@ describe('Body Reducer', () => {
   })
 
   //
-  // ADD_SUCC
-  //
-  it('ADD_SUCC', () => {
-    const expected = {
-      peername: 'foo',
-      name: 'bar'
-    }
-    const action = {
-      type: ADD_SUCC,
-      payload: {
-        data: expected
-      }
-    }
-    Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({ ...expected, activeTab: 'history' })
-  })
-
-  //
-  // INIT_SUCC
-  //
-  it('INIT_SUCC', () => {
-    const expected = {
-      peername: 'foo',
-      name: 'bar'
-    }
-    const action = {
-      type: INIT_SUCC,
-      payload: {
-        data: expected
-      }
-    }
-    Reducer(SelectionsReducer).withState(initialState).expect(action).toChangeInState({ ...expected, activeTab: 'status' })
-  })
-
-  //
   // COMMIT_SUCC
   // DATASET_SUCC
   //

--- a/test/app/utils/formValidation.test.ts
+++ b/test/app/utils/formValidation.test.ts
@@ -9,7 +9,8 @@ import {
   ERR_INVALID_EMAIL,
   ERR_INVALID_PASSWORD_LENGTH,
   ERR_INVALID_DATASETNAME_CHARACTERS,
-  ERR_INVALID_DATASETNAME_LENGTH
+  ERR_INVALID_DATASETNAME_LENGTH,
+  ERR_INVALID_DATASETNAME_START
 } from '../../../app/utils/formValidation'
 
 import { DatasetStatus } from '../../../app/models/store'
@@ -108,7 +109,7 @@ describe('formValidation', () => {
   const datasetNameGoodCases = [
     'a',
     'hello_world',
-    'pmfqbx5bhe7w4nbonqj6zu2abb15txq7vc5yfgysawjbdiqaxghvt4iy3rdyhvxg2v52mcsqeh1yymxe6ciz1lsxwmfsqyzdkh'
+    'pmfqbx5bhe7w4nbonqj6zu2abb15txq7vc5yfgysawjbdiqaxghvt4iy3rdyhvxg2v52mcsqeh1yymxe6ciz1lsxwmfsqyzdkhfjdksajfiejfijeilsdjafijdsilafjdkmciejntiesail'
   ]
 
   datasetNameGoodCases.forEach((string) => {
@@ -124,12 +125,16 @@ describe('formValidation', () => {
       err: ERR_INVALID_DATASETNAME_CHARACTERS
     },
     {
-      string: '👋🏻',
+      string: 'hi👋🏻',
       err: ERR_INVALID_DATASETNAME_CHARACTERS
     },
     {
-      string: 'pmfqbx5bhe7w4nbonqj6zu2abb15txq7vc5yfgysawjbdiqaxghvt4iy3rdyhvxg2v52mcsqeh1yymxe6ciz1lsxwmfsqyzdkhsdf3182',
+      string: 'pmfqbx5bhe7w4nbonqj6zu2abb15txq7vc5yfgysawjbdiqaxghvt4iy3rdyhvxg2v52mcsqeh1yymxe6ciz1lsxwmfsqyzdkhfjdksajfiejfijeilsdjafijdsilafjdkmciejntiesailj',
       err: ERR_INVALID_DATASETNAME_LENGTH
+    },
+    {
+      string: '911calls',
+      err: ERR_INVALID_DATASETNAME_START
     }
   ]
 

--- a/version.js
+++ b/version.js
@@ -1,2 +1,2 @@
-exports.desktopVersion = '0.3.0'
+exports.desktopVersion = '0.3.1-dev'
 exports.backendVersion = '0.9.3'


### PR DESCRIPTION
The `ipcRenderer.on()` functions that we use to hook into the electron menu are event listeners. We haven't been handling the removal of these listeners in the `App` and `Dataset` components. For each listener we add in `componentDidMount` we need to remove it in `componentDidUnmount`.

This commit also fixes some styling on the Dataset component when a dataset is not `checkedout`, it clears the selection once you've successfully removed a dataset, and also adjusts the no dataset selected state to include navigation that will send you back to the collections page.

closes #368 - remove auto checkout from Create and Add modals/flow, also remove ability to checkout a dataset that is not in your namespace, until we come up with an explicit plan (remove ability for Desktop users to foot gun themselves)
closes #369 - after a commit, drop user into history to view the commit
closes #371 - adjust checkout modal _note: could not replicate the bug in the issue_
closes #372 - bring desktop naming rules inline with backend
closes #373 - fix event listeners leak
closes #374 - clear selection once a dataset has been removed