### PR TITLE
feat(logging): Log to a file, menu item to export it

### DIFF
--- a/app/backend.js
+++ b/app/backend.js
@@ -10,42 +10,56 @@ class BackendProcess {
   constructor () {
     this.qriBinPath = null
     this.process = null
+    this.debugLogPath = null;
 
-    if (process.env.NODE_ENV === 'development') {
-      // if we're in dev mode write to this process
-      this.out = process.stdout
-      this.err = process.stderr
-    } else {
-      try {
-        const dirPath = path.join(os.tmpdir(), 'io.qri.desktop')
-        const logPath = path.join(dirPath, 'qri.log')
-        
-        if (!fs.existsSync(dirPath)) {
-          fs.mkdirSync(dirPath)
-        }
-        this.out = fs.openSync(logPath, 'a')
-        this.err = fs.openSync(logPath, 'a')
-      } catch (err) {
-        dialog.showMessageBox({
-          type: 'error',
-          title: 'error setting up backend logging',
-          message: 'We couldn\'t configure the backend to log to a temporary directory. \nThis might not be a big deal, but it also may be a sign of problems with qri interacting with your filesystem',
-          detail: err
-        })
-        // fall back to writing to stdout & stderr
-        this.out = process.stdout
-        this.err = process.stderr
+    // Default to writing to stdout & stderr
+    this.out = process.stdout
+    this.err = process.stderr
+    try {
+      // Create a log whose filename contains the current day.
+      const nowTime = new Date();
+      const nowString = nowTime.toISOString();
+      const filename = 'qri_' + nowString.substring(0, nowString.indexOf('T')) + '.log';
+
+      // Log to this file in a temporary directory named after our app
+      const dirPath = path.join(os.tmpdir(), 'io.qri.desktop')
+      const logPath = path.join(dirPath, filename)
+      if (!fs.existsSync(dirPath)) {
+        fs.mkdirSync(dirPath)
       }
+      console.log('Logging to ' + logPath);
+      this.debugLogPath = logPath;
+
+      this.out = fs.openSync(logPath, 'a')
+      this.err = fs.openSync(logPath, 'a')
+    } catch (err) {
+      dialog.showMessageBox({
+        type: 'error',
+        title: 'error setting up backend logging',
+        message: 'We couldn\'t configure the backend to log to a temporary directory. \nThis might not be a big deal, but it also may be a sign of problems with qri interacting with your filesystem',
+        detail: err
+      })
     }
   }
 
   maybeStartup () {
-    // Locate the binary for the qri backend command-line
-    this.qriBinPath = this.findQriBin([process.resourcesPath, path.join(__dirname, '../')])
+    // In development node, use installed qri binary
+    if (process.env.NODE_ENV === 'development') {
+      let processResult = childProcess.execSync('which qri');
+      let whichBin = processResult.toString().trim();
+      if (fs.existsSync(whichBin)) {
+        this.qriBinPath = whichBin;
+      }
+    }
+    // Locate the binary for the qri backend command-line in common paths
+    if (!this.qriBinPath) {
+      this.qriBinPath = this.findQriBin([process.resourcesPath, path.join(__dirname, '../')])
+    }
     if (!this.qriBinPath) {
       return
     }
     // Run the binary if it is found
+    console.log('Found qri binary at path ' + this.qriBinPath);
     this.launchProcess()
   }
 
@@ -58,12 +72,14 @@ class BackendProcess {
 
   launchProcess () {
     try {
+      let processResult = childProcess.execSync(this.qriBinPath + ' version')
+      let qriBinVersion = processResult.toString().trim();
       this.process = childProcess.spawn(this.qriBinPath, ['connect', '--setup'], { stdio: ['ignore', this.out, this.err] })
       this.process.on('error', (err) => { this.handleEvent('error', err) })
       this.process.on('exit', (err) => { this.handleEvent('exit', err) })
       this.process.on('close', (err) => { this.handleEvent('close', err) })
       this.process.on('disconnect', (err) => { this.handleEvent('disconnect', err) })
-      console.log('launched backend')
+      console.log('starting up qri backend version ' + qriBinVersion)
     } catch (err) {
       console.log('ERROR, Starting background process: ' + err)
     }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -2,7 +2,8 @@ import * as React from 'react'
 import { Action } from 'redux'
 import { CSSTransition } from 'react-transition-group'
 import { ConnectedRouter } from 'connected-react-router'
-import { ipcRenderer } from 'electron'
+import { ipcRenderer, remote } from 'electron'
+import fs from 'fs'
 import path from 'path'
 import ReactTooltip from 'react-tooltip'
 import { history } from '../store/configureStore.development'
@@ -95,7 +96,8 @@ class App extends React.Component<AppProps, AppState> {
       currentModal: noModalObject,
       sessionID: this.props.session.sessionID,
       peername: this.props.session.peername,
-      showDragDrop: false
+      showDragDrop: false,
+      debugLogPath: ''
     }
 
     this.renderModal = this.renderModal.bind(this)
@@ -104,6 +106,8 @@ class App extends React.Component<AppProps, AppState> {
     this.handleCreateDataset = this.handleCreateDataset.bind(this)
     this.handleAddDataset = this.handleAddDataset.bind(this)
     this.handleSelectRoute = this.handleSelectRoute.bind(this)
+    this.handleSetDebugLogPath = this.handleSetDebugLogPath.bind(this)
+    this.handleExportDebugLog = this.handleExportDebugLog.bind(this)
   }
 
   private handleCreateDataset () {
@@ -118,6 +122,27 @@ class App extends React.Component<AppProps, AppState> {
     this.props.setRoute(route)
   }
 
+  private handleSetDebugLogPath (_e: any, path: string) {
+    this.setState({ debugLogPath: path })
+  }
+
+  private handleExportDebugLog () {
+    const window = remote.getCurrentWindow()
+    const exportFilename: string | undefined = remote.dialog.showSaveDialog(window, {
+      defaultPath: 'qri-debug.log'
+    })
+    if (!exportFilename) {
+      // Dialog cancelled, do nothing
+      return
+    }
+    if (!this.state.debugLogPath) {
+      // Don't have a log file, log and do nothing
+      console.log('debugLogPath not set, cannot export!')
+      return
+    }
+    fs.copyFileSync(this.state.debugLogPath, exportFilename)
+  }
+
   componentDidMount () {
     // handle ipc events from electron menus
     ipcRenderer.on('create-dataset', this.handleCreateDataset)
@@ -125,6 +150,10 @@ class App extends React.Component<AppProps, AppState> {
     ipcRenderer.on('add-dataset', this.handleAddDataset)
 
     ipcRenderer.on('select-route', this.handleSelectRoute)
+
+    ipcRenderer.on('set-debug-log-path', this.handleSetDebugLogPath)
+
+    ipcRenderer.on('export-debug-log', this.handleExportDebugLog)
 
     setInterval(() => {
       if (this.props.apiConnection !== 1 || this.props.selections.peername === '' || this.props.selections.name === '') {

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -82,6 +82,7 @@ interface AppState {
   sessionID: string
   peername: string
   showDragDrop: boolean
+  debugLogPath: string
 }
 
 const noModalObject: HideModal = {
@@ -128,7 +129,7 @@ class App extends React.Component<AppProps, AppState> {
 
   private handleExportDebugLog () {
     const window = remote.getCurrentWindow()
-    const exportFilename: string | undefined = remote.dialog.showSaveDialog(window, {
+    const exportFilename: string | undefined = remote.dialog.showSaveDialogSync(window, {
       defaultPath: 'qri-debug.log'
     })
     if (!exportFilename) {
@@ -137,7 +138,7 @@ class App extends React.Component<AppProps, AppState> {
     }
     if (!this.state.debugLogPath) {
       // Don't have a log file, log and do nothing
-      console.log('debugLogPath not set, cannot export!')
+      console.log('debugLogsPath not set, cannot export!')
       return
     }
     fs.copyFileSync(this.state.debugLogPath, exportFilename)

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -121,6 +121,7 @@ app.on('ready', () =>
       mainWindow.webContents.on('did-finish-load', () => {
         mainWindow.show()
         mainWindow.focus()
+        mainWindow.webContents.send('set-debug-log-path', backendProcess.debugLogPath)
       })
 
       mainWindow.on('closed', () => {
@@ -459,6 +460,12 @@ app.on('ready', () =>
           { type: 'separator' },
           {
             label: `Qri backend ${backendVersion}`
+          },
+          {
+            label: 'Export debug log',
+            click () {
+              mainWindow.webContents.send('export-debug-log')
+            }
           }
         ]
       }


### PR DESCRIPTION
When launching the qri backend, always log its output to a temporary file. If a developer wants to see output in a terminal, they can either run `qri connect` themselves, or they can `tail -f` the log. The log filename uses the current day in the filename.

In development mode, try to locate an installed `qri` binary, which makes it easier to develop both desktop and the backend at the same time.

Add a menu item under 'Help' which lets the user copy the debug log to a path.

Output a few useful pieces of info: which version of the qri backend was launched, the path to the the backend, the path to the log file.