### PR TITLE
test(e2e): round out e2e with more flows, regardless of if they pass

### DIFF
--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -119,7 +119,7 @@ class DatasetList extends React.Component<DatasetListProps> {
       return <div className='sidebar-list-item-text'>Oops, no matches found for <strong>&apos;{myDatasets.filter}&apos;</strong></div>
     }
     return (
-      <div className='sidebar-list-item-text'>Your datasets will be listed here</div>)
+      <div id='no-datasets' className='sidebar-list-item-text'>Your datasets will be listed here</div>)
   }
 
   render () {

--- a/app/components/DatasetReference.tsx
+++ b/app/components/DatasetReference.tsx
@@ -91,9 +91,9 @@ const DatasetReference: React.FunctionComponent<DatasetReferenceProps> = (props)
   return (
     <div id='dataset-reference' className='dataset-reference'>
       <div className='dataset-peername'>{peername}/</div>
-      <div className='dataset-name' ref={nameRef}>
+      <div className='dataset-name' id='dataset-name' ref={nameRef}>
         { nameEditing && <input
-          id='dataset-name'
+          id='dataset-name-input'
           className={classNames({ invalid: inValid })}
           type='text'
           value={newName}

--- a/app/components/Metadata.tsx
+++ b/app/components/Metadata.tsx
@@ -92,7 +92,7 @@ const renderTable = (keys: string[], data: Meta) => {
             return (
               <tr key={key} className='keyvalue-table-row'>
                 <td className='keyvalue-table-key'>{key}</td>
-                <td>{cellContent}</td>
+                <td id={`meta-${key}`}>{cellContent}</td>
               </tr>
             )
           })}

--- a/app/components/modals/LinkDataset.tsx
+++ b/app/components/modals/LinkDataset.tsx
@@ -100,7 +100,7 @@ const LinkDataset: React.FunctionComponent<LinkDatasetProps> = ({ peername, name
 
   return (
     <Modal
-      id="LinkDataset"
+      id="remove-dataset"
       title={`Checkout ${peername}/${name}`}
       onDismissed={onDismissed}
       onSubmit={() => {}}


### PR DESCRIPTION
We now have flows for:

- open window
- accept terms of service by clicking accept and get taken to signup
- create a new account, taken to datasets page
- signout and sign in
- create new CSV dataset from a data source
- checkout a dataset
- write the body to the filesystem & commit
- create a meta & commit
- rename a dataset

Checkout fails, and each subsequent test relies on having a checked-out dataset, so each subsequent  test fails
