### PR TITLE
fix(commit, MetadataEditor): fix meta editing and the flow after you commit

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -24,3 +24,4 @@ This will only work if you are internal to Qri and have the correct keys
   - take the updated file into from size, sha512 and blockMapSize
   - update the `/release/latest-mac.yml` with that info
   - replace `FILENAME.zip` to the release page
+12) **remember to change website link give details of where here** 

--- a/app/actions/mutations.ts
+++ b/app/actions/mutations.ts
@@ -1,6 +1,7 @@
 import {
   SET_COMMIT_TITLE,
-  SET_COMMIT_MESSAGE
+  SET_COMMIT_MESSAGE,
+  SAVE_COMPLETE
 } from '../reducers/mutations'
 
 export function setCommitTitle (title: string) {
@@ -14,5 +15,12 @@ export function setCommitMessage (message: string) {
   return {
     type: SET_COMMIT_MESSAGE,
     message
+  }
+}
+
+export function setSaveComplete (error?: string) {
+  return {
+    type: SAVE_COMPLETE,
+    error
   }
 }

--- a/app/actions/selections.ts
+++ b/app/actions/selections.ts
@@ -15,9 +15,6 @@ export const setActiveTab = (activeTab: string) => {
 }
 
 export const setSelectedListItem = (type: string, selectedListItem: string) => {
-  if (type === 'commit') {
-    console.log('setting to', selectedListItem)
-  }
   return {
     type: SELECTIONS_SET_SELECTED_LISTITEM,
     payload: {

--- a/app/actions/selections.ts
+++ b/app/actions/selections.ts
@@ -15,6 +15,9 @@ export const setActiveTab = (activeTab: string) => {
 }
 
 export const setSelectedListItem = (type: string, selectedListItem: string) => {
+  if (type === 'commit') {
+    console.log('setting to', selectedListItem)
+  }
   return {
     type: SELECTIONS_SET_SELECTED_LISTITEM,
     payload: {

--- a/app/components/Commit.tsx
+++ b/app/components/Commit.tsx
@@ -91,7 +91,7 @@ const Commit: React.FunctionComponent<CommitProps> = (props: CommitProps) => {
         <div className='submit'>
           {
             isLoading
-              ? <button className='sync-spinner btn btn-primary'><FontAwesomeIcon icon={faSync} /> Saving...</button>
+              ? <button className='sync-spinner btn btn-large btn-primary'><FontAwesomeIcon icon={faSync} /> Saving...</button>
               : <button id='submit' className={classNames('btn btn-primary btn-large', { 'disabled': !isValid })} type='submit'>Commit</button>
           }
         </div>

--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -193,7 +193,7 @@ class DatasetList extends React.Component<DatasetListProps> {
 
         return (<ContextMenuArea menuItems={menuItems} key={`${peername}/${name}`}>
           <div
-            id={`${peername}/${name}`}
+            id={`${peername}-${name}`}
             key={`${peername}/${name}`}
             className={classNames('sidebar-list-item', 'sidebar-list-item-text', {
               'selected': (peername === workingDataset.peername) && (name === workingDataset.name)

--- a/app/components/MetadataEditor.tsx
+++ b/app/components/MetadataEditor.tsx
@@ -82,12 +82,6 @@ const MetadataEditor: React.FunctionComponent<MetadataEditorProps> = (props: Met
   const [stateMeta, setStateMeta] = React.useState(meta)
   const [previousMeta, setPreviousMeta] = React.useState(meta)
 
-  // when new meta comes from above, reset local state
-  React.useEffect(() => {
-    setStateMeta(meta)
-    setPreviousMeta(meta)
-  }, [meta])
-
   if (!meta) {
     return <SpinnerWithIcon loading={true} />
   }

--- a/app/components/modals/LinkDataset.tsx
+++ b/app/components/modals/LinkDataset.tsx
@@ -100,7 +100,7 @@ const LinkDataset: React.FunctionComponent<LinkDatasetProps> = ({ peername, name
 
   return (
     <Modal
-      id="remove-dataset"
+      id="checkout-dataset"
       title={`Checkout ${peername}/${name}`}
       onDismissed={onDismissed}
       onSubmit={() => {}}

--- a/app/containers/BodyContainer.tsx
+++ b/app/containers/BodyContainer.tsx
@@ -17,7 +17,7 @@ const mapStateToProps = (state: Store) => {
 
   var format = ''
   if (history) {
-    format = workingDataset.components.structure.value.format
+    format = dataset.components.structure.value.format
   } else {
     format = state.workingDataset.status && state.workingDataset.status.body && state.workingDataset.status.body.filepath
       ? path.extname(state.workingDataset.status.body.filepath).slice(1)
@@ -36,7 +36,6 @@ const mapStateToProps = (state: Store) => {
     format,
     history,
     details,
-    workingDataset,
     stats
   }
 }

--- a/app/containers/CommitContainer.tsx
+++ b/app/containers/CommitContainer.tsx
@@ -13,7 +13,7 @@ const mapStateToProps = (state: Store) => {
 
   // get data for the currently selected component
   return {
-    isLoading: false,
+    isLoading: mutations.save.isLoading,
     datasetRef: `${peername}/${name}`,
     title,
     message,

--- a/app/containers/CommitDetailsContainer.tsx
+++ b/app/containers/CommitDetailsContainer.tsx
@@ -6,7 +6,7 @@ import { setSelectedListItem } from '../actions/selections'
 import { fetchCommitDetail } from '../actions/api'
 
 const mapStateToProps = (state: Store) => {
-  const { workingDataset, selections, commitDetails } = state
+  const { selections, commitDetails } = state
 
   const {
     peername,
@@ -15,18 +15,15 @@ const mapStateToProps = (state: Store) => {
     commitComponent: selectedComponent
   } = selections
 
-  // find the currently selected commit
-  const selectedCommit = workingDataset.history.value
-    .find(d => d.path === selectedCommitPath)
-
   return {
     peername,
     name,
     selectedCommitPath: selectedCommitPath,
-    commit: selectedCommit,
+    commit: commitDetails.components.commit.value,
     selectedComponent,
     commitDetails,
-    structure: commitDetails.components.structure.value
+    structure: commitDetails.components.structure.value,
+    isLoading: commitDetails.isLoading
   }
 }
 

--- a/app/reducers/mutations.ts
+++ b/app/reducers/mutations.ts
@@ -13,7 +13,8 @@ const initialState: Mutations = {
   }
 }
 
-export const [SAVE_REQ, SAVE_SUCC, SAVE_FAIL] = apiActionTypes('save')
+export const [SAVE_REQ] = apiActionTypes('save')
+export const SAVE_COMPLETE = 'SAVE_COMPLETE'
 export const SET_COMMIT_TITLE = 'SET_COMMIT_TITLE'
 export const SET_COMMIT_MESSAGE = 'SET_COMMIT_MESSAGE'
 
@@ -50,22 +51,15 @@ const mutationsReducer: Reducer = (state = initialState, action: AnyAction): Mut
           error: null
         }
       }
-    case SAVE_SUCC:
-      return {
-        ...state,
-        save: {
-          value: initialState.save.value,
-          isLoading: false,
-          error: null
-        }
-      }
-    case SAVE_FAIL:
+
+    case SAVE_COMPLETE:
       return {
         ...state,
         save: {
           ...state.save,
           isLoading: false,
-          error: action.payload.err
+          error: action.err,
+          value: initialState.save.value
         }
       }
 

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -93,6 +93,8 @@ export default (state = initialState, action: AnyAction) => {
     case SELECTIONS_SET_WORKING_DATASET:
       const { peername, name } = action.payload
 
+      if (peername === state.peername && name === state.name) return state
+
       localStore().setItem('peername', peername)
       localStore().setItem('name', name)
       localStore().setItem('commit', '')

--- a/app/reducers/ui.ts
+++ b/app/reducers/ui.ts
@@ -3,7 +3,6 @@ import { ipcRenderer } from 'electron'
 
 import store from '../utils/localStore'
 import { apiActionTypes } from '../utils/actionType'
-import { SAVE_SUCC, SAVE_FAIL } from '../reducers/mutations'
 import { ModalType } from '../models/modals'
 import { DetailsType } from '../models/details'
 import {
@@ -144,27 +143,6 @@ export default (state = initialState, action: AnyAction) => {
       return {
         ...state,
         detailsBar: { type: DetailsType.NoDetails }
-      }
-
-    // listen for SAVE_SUCC and SAVE_FAIL to set the toast
-    case SAVE_SUCC:
-      return {
-        ...state,
-        toast: {
-          type: 'success',
-          message: 'Commit Successful!',
-          visible: true
-        }
-      }
-
-    case SAVE_FAIL:
-      return {
-        ...state,
-        toast: {
-          type: 'error',
-          message: 'Oops, something went wrong with this commit',
-          visible: true
-        }
       }
 
     case UI_SIGNOUT:

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -7,8 +7,7 @@ import { ipcRenderer } from 'electron'
 import bodyValue from '../utils/bodyValue'
 
 import {
-  REMOVE_SUCC,
-  SELECTIONS_SET_WORKING_DATASET
+  REMOVE_SUCC
 } from './selections'
 
 const initialState: WorkingDataset = {
@@ -18,7 +17,6 @@ const initialState: WorkingDataset = {
   name: '',
   status: {},
   isLoading: false,
-  isCommiting: false,
   fsiPath: '',
   published: true,
   hasHistory: true,
@@ -270,9 +268,6 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
         ...state,
         stats: []
       }
-
-    case SELECTIONS_SET_WORKING_DATASET:
-      return initialState
 
     case RENAME_SUCC:
       return {

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -18,6 +18,7 @@ const initialState: WorkingDataset = {
   name: '',
   status: {},
   isLoading: false,
+  isCommiting: false,
   fsiPath: '',
   published: true,
   hasHistory: true,

--- a/test/e2e/e2e.spec.ts
+++ b/test/e2e/e2e.spec.ts
@@ -23,7 +23,7 @@ describe('Qri End to End tests', function spec () {
   const password = '1234567890!!'
 
   beforeAll(async () => {
-    jest.setTimeout(30000)
+    jest.setTimeout(60000)
 
     // spin up a new mock backend with a mock registry server attached
     backend = new TestBackendProcess()
@@ -206,6 +206,31 @@ describe('Qri End to End tests', function spec () {
     await checkStatus('structure', 'added')
   })
 
+  it ('navigate to collection and back to dataset', async () => {
+    const {
+      atLocation,
+      click,
+      expectTextToBe,
+      onHistoryTab
+    } = utils
+
+    await click('#history-tab')
+    await onHistoryTab()
+
+    await click('#collection')
+    // ensure we have redirected to the collection page
+    await atLocation('#/collection')
+    // click the dataset
+    const ref = `#${username}-${datasetName}`
+    await click(ref)
+    // ensure we have redirected to the dataset page
+    await atLocation('#/dataset')
+    // ensure we are still at the history tab
+    await onHistoryTab()
+    // ensure we have a commit title
+    await expectTextToBe('#commit-title', 'created dataset')
+  })
+
   // checkout
   it('checkout a dataset', async () => {
     const {
@@ -219,6 +244,9 @@ describe('Qri End to End tests', function spec () {
 
     // at dataset
     await click('#dataset')
+    // at status
+    await click('#status-tab')
+    await onStatusTab()
     // body is disabled
     await exists(['#body-status.disabled'])
     // click #checkout to open checkout modal

--- a/test/e2e/e2e.spec.ts
+++ b/test/e2e/e2e.spec.ts
@@ -23,7 +23,7 @@ describe('Qri End to End tests', function spec () {
   const password = '1234567890!!'
 
   beforeAll(async () => {
-    jest.setTimeout(20000);
+    jest.setTimeout(30000)
 
     // spin up a new mock backend with a mock registry server attached
     backend = new TestBackendProcess()
@@ -38,10 +38,10 @@ describe('Qri End to End tests', function spec () {
     // in the `init` fuction, and the app opens multiple times in a retry loop). The path ending
     // in ".exe" will work under Windows. Perhaps other platforms, such as OSX, should also be
     // using the binary in the "dist" folder.
-    let electronAppPath = path.join(__dirname, '..', '..', 'node_modules', '.bin', 'electron');
-    if (process.platform == 'win32') {
+    let electronAppPath = path.join(__dirname, '..', '..', 'node_modules', '.bin', 'electron')
+    if (process.platform === 'win32') {
       electronAppPath = path.join(__dirname, '..', '..', 'node_modules', 'electron',
-                                  'dist', 'electron.exe');
+        'dist', 'electron.exe')
     }
 
     app = new Application({
@@ -58,12 +58,12 @@ describe('Qri End to End tests', function spec () {
       // Logging will make it easier to debug problems.
       env: {
         ELECTRON_ENABLE_LOGGING: true,
-        ELECTRON_ENABLE_STACK_DUMPING: true,
+        ELECTRON_ENABLE_STACK_DUMPING: true
       },
       chromeDriverLogPath: path.join(__dirname, '../log/chromedriverlog.txt'),
       webdriverLogPath: path.join(__dirname, '../log/webdriverlog.txt'),
       waitTimeout: 10e3,
-      connectionRetryCount: 1,
+      connectionRetryCount: 1
     })
     fakeDialog.apply(app)
     utils = newE2ETestUtils(app)
@@ -213,7 +213,8 @@ describe('Qri End to End tests', function spec () {
       click,
       onStatusTab,
       exists,
-      doesNotExist
+      doesNotExist,
+      waitForNotExist
     } = utils
 
     // at dataset
@@ -222,16 +223,14 @@ describe('Qri End to End tests', function spec () {
     await exists(['#body-status.disabled'])
     // click #checkout to open checkout modal
     await click('#checkout')
-    // create filepath
-    const savePath = path.join(backend.dir, datasetName)
     // mock the dialog
-    await fakeDialog.mock([ { method: 'showOpenDialogSync', value: [savePath] } ])
+    await fakeDialog.mock([ { method: 'showOpenDialogSync', value: [backend.dir] } ])
     // click #chooseSavePath to open dialog
     await click('#chooseSavePath')
     // click #submit
     await click('#submit')
     // expect modal to be gone
-    await doesNotExist('#remove-dataset')
+    await waitForNotExist('#checkout-dataset')
     // atLocation
     await atLocation('#/dataset')
     // check we are at status tab
@@ -307,7 +306,6 @@ describe('Qri End to End tests', function spec () {
     const metaDescription = 'new dataset description'
     await setValue('#title', metaTitle)
     await setValue('#description', metaDescription)
-    // meta status should be 'added'
     await checkStatus('meta', 'added')
     // commit should be enabled
     await exists(['.clear-to-commit #commit-status'])
@@ -357,6 +355,8 @@ describe('Qri End to End tests', function spec () {
     await setValue('#dataset-name-input', 'test_dataset')
     // get correct class
     await doesNotExist('#dataset-name-input.invalid')
+    // submit by clicking away
+    await click('#dataset-reference')
   })
 
   // remove a dataset is commented out until we have a keyboard command in


### PR DESCRIPTION
Adjust the `saveWorkingDatasetAndFetch` and `Commit` components, along with the `mutations` reducer and actions to fix the flow after you commit.

We need to wait for both the commit to be successful and for the history list to update, inorder to show the user a clean commit experience. To do that, we've added a `saveComplete`/`SAVE_COMPLETE` action to the `mutations` reducer that gets called when save & history fetching is complete

Also adjusts the MetadataEditor to fix a content jumping problem


Also, also fixes a bug when navigating to a dataset using the dataset list.


After this pr, e2e tests are passing locally, but not on ci