### PR TITLE
feat(main process logging): add logging for main process

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,3 +1,4 @@
+const log = require('electron-log')
 const { app, BrowserWindow, Menu, shell, ipcMain } = require('electron')
 const { autoUpdater } = require('electron-updater')
 const { BackendProcess } = require('./backend')
@@ -45,6 +46,7 @@ app.on('window-all-closed', () => {
 })
 
 app.on('will-quit', () => {
+  log.info('quitting app')
   if (backendProcess) {
     backendProcess.close()
     backendProcess = null
@@ -96,6 +98,7 @@ let quitting = false
 app.on('ready', () =>
   installExtensions()
     .then(() => {
+      log.info('main process ready')
       autoUpdater.checkForUpdatesAndNotify()
       backendProcess = new BackendProcess()
       backendProcess.maybeStartup()
@@ -548,4 +551,6 @@ app.on('ready', () =>
       app.on('before-quit', () => {
         quitting = true
       })
+
+      log.info('app launched')
     }))

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "deep-equal": "1.1.0",
     "electron-debug": "3.0.1",
     "electron-dl": "1.14.0",
+    "electron-log": "4.0.3",
     "electron-updater": "4.2.0",
     "eslint-utils": "1.4.3",
     "filesize": "6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5857,6 +5857,11 @@ electron-localshortcut@^3.1.0:
     keyboardevent-from-electron-accelerator "^2.0.0"
     keyboardevents-areequal "^0.2.1"
 
+electron-log@4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.0.3.tgz#c998ebf6d4d0c0b017795639d0bc00eb51b39b30"
+  integrity sha512-FcPwem0P/NI0/AkfJWEbcNPQ2rHOWFCVO+AnSRHQhKYugUmYuy721JklE2b9VgK2raUCBmPuHqZR0MBFhl1iqQ==
+
 electron-notarize@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-0.2.0.tgz#676c71688ee84149bab27b22426d0a9452e7e262"
@@ -15038,7 +15043,7 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-cli@3.3.10:
+webpack-cli@^3.3.10:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.10.tgz#17b279267e9b4fb549023fae170da8e6e766da13"
   integrity sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==


### PR DESCRIPTION
using the electron-log package, which is lovely. From the [package documentation](https://www.npmjs.com/package/electron-log), this'll create a log file called `main.js` in a platform-dependent location:

* on Linux: `~/.config/{app name}/logs/{process type}.log`
* on macOS: `~/Library/Logs/{app name}/{process type}.log`
* on Windows: `%USERPROFILE%\AppData\Roaming\{app name}\logs\{process type}.log`