### PR TITLE
chore(release): version bump to 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## [0.3.4](https://github.com/qri-io/desktop/compare/v0.3.3...v0.3.4) (2020-02-03)
+
+This patch release fixes two visual bugs (packaged fonts and adjustments to the menus), restores the 'unpublish' option to the dataset page, and adds a number of reusable components that we will begin to surface as we release new features.
+
+### Bug Fixes
+
+* **Dataset:** add `Hamburger` to dataset actions ([c4d0c6a](https://github.com/qri-io/desktop/commit/c4d0c6a))
+* **fonts:** add Rubik font to font-face in scss ([e628d57](https://github.com/qri-io/desktop/commit/e628d57))
+
+
+### Features
+
+* **Dataset Item Compoent:** add basic item component for datasets ([6fb5240](https://github.com/qri-io/desktop/commit/6fb5240))
+* **Hamburger, Action Button, Titlebar:** add to stories ([ae58313](https://github.com/qri-io/desktop/commit/ae58313))
+* **modal/Search:** work on search modal component ([7917f7c](https://github.com/qri-io/desktop/commit/7917f7c))
+* **navbar:** initial 0.4.0 page navabar and supporting components ([5bcfdb3](https://github.com/qri-io/desktop/commit/5bcfdb3))
+* **Network:** add network section behind __BUILD__ flag ([16dace1](https://github.com/qri-io/desktop/commit/16dace1))
+* **NetworkHome:** added initial NetworkHome component ([1996e3f](https://github.com/qri-io/desktop/commit/1996e3f))
+* **Overview:** component that gives basic meta and structure info at top of preview page ([26fde61](https://github.com/qri-io/desktop/commit/26fde61))
+* **switch:** add light/dark, small/large versions of Switch ([36e7140](https://github.com/qri-io/desktop/commit/36e7140))
+* **Tag:** tag component, `category`/`keyword` options ([d61efab](https://github.com/qri-io/desktop/commit/d61efab))
+* **TitleBar:** ActionButton, ActionButtonBar, used to make responsive title bar ([4ac5f51](https://github.com/qri-io/desktop/commit/4ac5f51))
+
+
+
 ## [0.3.3](https://github.com/qri-io/desktop/compare/v0.3.2...v0.3.3) (2020-01-24)
 
 Quick patch release to address some bugs when viewing the body!

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qri-desktop",
   "productName": "Qri Desktop",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "backendVersion": "0.9.4",
   "description": "Version your data with the Qri desktop app!",
   "main": "./main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qri-desktop",
   "productName": "Qri Desktop",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Version your data with the Qri desktop app!",
   "main": "main.js",
   "scripts": {

--- a/version.js
+++ b/version.js
@@ -1,2 +1,2 @@
-exports.desktopVersion = '0.3.3'
+exports.desktopVersion = '0.3.4'
 exports.backendVersion = '0.9.4'

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -84,7 +84,7 @@ module.exports = merge(baseConfig, {
         use: {
           loader: 'url-loader',
           options: {
-            limit: 10000,
+            limit: 30000,
             mimetype: 'application/font-woff'
           }
         }
@@ -95,7 +95,7 @@ module.exports = merge(baseConfig, {
         use: {
           loader: 'url-loader',
           options: {
-            limit: 10000,
+            limit: 30000,
             mimetype: 'application/font-woff'
           }
         }

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -79,7 +79,7 @@ module.exports = merge(baseConfig, {
         use: {
           loader: 'url-loader',
           options: {
-            limit: 10000,
+            limit: 30000,
             mimetype: 'application/font-woff'
           }
         }
@@ -126,7 +126,7 @@ module.exports = merge(baseConfig, {
 
     new webpack.DefinePlugin({
       /**
-       * compile-time flags are stored under a global __BUILD__ constant. 
+       * compile-time flags are stored under a global __BUILD__ constant.
        * Useful for allowing different behaviour between development builds and
        * release builds. These should be synted with
        *

--- a/yarn.lock
+++ b/yarn.lock
@@ -5835,7 +5835,7 @@ electron-builder@22.1.0:
     update-notifier "^3.0.1"
     yargs "^14.0.0"
 
-electron-chromedriver@^7.0.0:
+electron-chromedriver@7.0.0, electron-chromedriver@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/electron-chromedriver/-/electron-chromedriver-7.0.0.tgz#204e1bfcdf2dfd56e5a3b8e6f37d19b1433a7937"
   integrity sha512-7qymT0fn3VTit0peym1iz4Y+fTwq9EPsv1V9Qh+vQdoVqP/4SM9lOHrsBeuFN1JJADZLu7R119ZvMkP6EnLYhw==
@@ -5905,7 +5905,7 @@ electron-localshortcut@^3.1.0:
     keyboardevent-from-electron-accelerator "^2.0.0"
     keyboardevents-areequal "^0.2.1"
 
-electron-log@^4.0.5:
+electron-log@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.0.5.tgz#4179f0ecf28917e74f0408cfa1e93857b8f20f97"
   integrity sha512-YadfIactRvhnkclBwxJ9jYGCrkbjhpPXjQXglz71rzrhUq1mXq3DyISrq1t4XiL0C8HKJbSpAq5DXbDppPxzaQ==
@@ -12244,7 +12244,7 @@ react-simplemde-editor@4.1.0:
     "@types/codemirror" "^0.0.76"
     easymde "^2.7.1-202.0"
 
-react-sizeme@^2.6.12:
+react-sizeme@2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.12.tgz#ed207be5476f4a85bf364e92042520499455453e"
   integrity sha512-tL4sCgfmvapYRZ1FO2VmBmjPVzzqgHA7kI8lSJ6JS6L78jXFNRdOZFpXyK6P1NBZvKPPCZxReNgzZNUajAerZw==
@@ -12949,7 +12949,7 @@ resolve-pathname@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
   integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
-resolve-url-loader@^3.1.1:
+resolve-url-loader@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-3.1.1.tgz#28931895fa1eab9be0647d3b2958c100ae3c0bf0"
   integrity sha512-K1N5xUjj7v0l2j/3Sgs5b8CjrrgtC70SmdCuZiJ8tSyb5J+uk3FoeZ4b7yTnH6j7ngI+Bc5bldHJIa8hYdu2gQ==


### PR DESCRIPTION
This patch release fixes two visual bugs (packaged fonts and adjustments to the menus), restores the 'unpublish' option to the dataset page, and adds a number of reusable components that we will begin to surface as we release new features.