### PR TITLE
refactor(Search & Network): link the search results to routes

### DIFF
--- a/app/actions/mappingFuncs.ts
+++ b/app/actions/mappingFuncs.ts
@@ -43,6 +43,23 @@ export function versionInfoToDataset (vi: VersionInfo): Dataset {
   }
 }
 
+// datasetToVersionInfo converts a dataset to a versionInfo
+export function datasetToVersionInfo (d: Dataset): VersionInfo {
+  return {
+    username: d.peername,
+    name: d.name,
+    path: d.path,
+    metaTitle: d.meta && d.meta.title,
+    themeList: d.meta && d.meta.theme && d.meta.theme.join(','),
+    bodySize: d.structure && d.structure.length,
+    bodyRows: d.structure && d.structure.entries,
+    numErrors: d.structure && d.structure.errCount,
+    commitTime: d.commit && d.commit.timestamp,
+    bodyFormat: d.structure && d.structure.format,
+    fsiPath: d.fsiPath
+  }
+}
+
 export function mapStatus (data: Array<Record<string, string>>): ComponentStatus[] {
   return data.map((d) => {
     return {

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -265,7 +265,7 @@ class App extends React.Component<AppProps, AppState> {
 
       case ModalType.Search: {
         modalComponent = (
-          <SearchModal q={modal.q} onDismissed={() => { setModal(noModalObject) }}/>
+          <SearchModal q={modal.q} onDismissed={() => { setModal(noModalObject) }} setWorkingDataset={this.props.setWorkingDataset}/>
         )
         break
       }
@@ -394,8 +394,8 @@ class App extends React.Component<AppProps, AppState> {
         }}>
         {this.renderAppError()}
         {this.state.showDragDrop && this.renderDragDrop() }
-        {this.renderModal()}
         <ConnectedRouter history={history}>
+          {this.renderModal()}
           <Navbar
             userphoto={userphoto}
             username={username}

--- a/app/components/dataset/DatasetDetailsSubtext.tsx
+++ b/app/components/dataset/DatasetDetailsSubtext.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
 import moment from 'moment'
 import filesize from 'filesize'
+import classNames from 'classnames'
 // TODO (b5) - move these into icon component
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFile, faClock } from '@fortawesome/free-regular-svg-icons'
 
-import Dataset from '../../models/dataset'
-import classNames from 'classnames'
+import { VersionInfo } from '../../models/store'
 
 // component for rendering dataset format, timestamp, size, etc
 export interface DatasetDetailsSubtextProps {
-  data: Dataset
+  data: VersionInfo
 
   // if true, omit display of commit timestamp
   noTimestamp?: boolean
@@ -20,14 +20,14 @@ export interface DatasetDetailsSubtextProps {
 
 export const DatasetDetailsSubtext: React.FunctionComponent<DatasetDetailsSubtextProps> = ({ data, size = 'md', color = 'dark', noTimestamp }) => {
   if (!data) { return null }
-  const { structure, commit } = data
+  const { commitTime, bodyFormat, numCommits, bodySize } = data
 
   return (
     <div className={classNames('dataset-details', { 'small': size === 'sm', 'light': color === 'light', 'muted': color === 'muted' }) }>
-      {structure && <span className='dataset-details-item'> {structure.format}</span>}
-      {(!noTimestamp && commit && commit.timestamp) && <span className='dataset-details-item'><FontAwesomeIcon icon={faClock} size='sm'/> {moment(commit.timestamp).fromNow()}</span>}
-      {commit && commit.count && <span className='dataset-details-item'>{`${commit.count} ${commit.count === 1 ? 'commits' : 'commits'}`}</span>}
-      {structure && structure.length && <span className='dataset-details-item'><FontAwesomeIcon icon={faFile} size='sm'/> {filesize(structure.length)}</span>}
+      {bodyFormat && <span className='dataset-details-item'> {bodyFormat}</span>}
+      {(!noTimestamp && commitTime) && <span className='dataset-details-item'><FontAwesomeIcon icon={faClock} size='sm'/> {moment(commitTime).fromNow()}</span>}
+      {numCommits && <span className='dataset-details-item'>{`${numCommits} ${numCommits === 1 ? 'commits' : 'commits'}`}</span>}
+      {bodySize && <span className='dataset-details-item'><FontAwesomeIcon icon={faFile} size='sm'/> {filesize(bodySize)}</span>}
     </div>
   )
 }

--- a/app/components/item/DatasetItem.tsx
+++ b/app/components/item/DatasetItem.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 
-import Dataset from '../../models/dataset'
+import { VersionInfo } from '../../models/store'
 import DatasetDetailsSubtext from '../dataset/DatasetDetailsSubtext'
 import Tag from './Tag'
 import classNames from 'classnames'
 
 interface DatasetItemProps {
-  data: Dataset
+  data: VersionInfo
   onClick: (username: string, name: string) => void
   fullWidth: boolean
   path?: string
@@ -15,16 +15,15 @@ interface DatasetItemProps {
 
 const DatasetItem: React.FunctionComponent<DatasetItemProps> = ({ data, path, hideUsername, fullWidth = false, onClick }) => {
   if (!data) { return null }
-  const { meta, username, name } = data
-  const title = (meta && meta.title) ? meta.title : `No Title - ${name}`
+  const { metaTitle, themeList, username, name } = data
 
   return (
     <div className={classNames('dataset-item', { 'full': fullWidth })} key={path}>
       <div className='header'>
         <a onClick={() => onClick(username, name)}>{hideUsername ? `${name}` : `${username}/${name}`}</a>
-        {meta && meta.theme && meta.theme.length > 0 && <Tag type='category' tag={meta.theme[0]} />}
+        {themeList && themeList.length > 0 && <Tag type='category' tag={themeList[0]} />}
       </div>
-      <div className='title'>{ title }</div>
+      <div className='title'>{ metaTitle }</div>
       <div className='details'><DatasetDetailsSubtext data={data} color='muted' /></div>
     </div>
   )

--- a/app/components/item/DatasetItem.tsx
+++ b/app/components/item/DatasetItem.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames'
 
 interface DatasetItemProps {
   data: Dataset
-  onClick: (peername: string, name: string) => void
+  onClick: (username: string, name: string) => void
   fullWidth: boolean
   path?: string
   hideUsername?: boolean
@@ -15,13 +15,13 @@ interface DatasetItemProps {
 
 const DatasetItem: React.FunctionComponent<DatasetItemProps> = ({ data, path, hideUsername, fullWidth = false, onClick }) => {
   if (!data) { return null }
-  const { meta, peername, name } = data
+  const { meta, username, name } = data
   const title = (meta && meta.title) ? meta.title : `No Title - ${name}`
 
   return (
     <div className={classNames('dataset-item', { 'full': fullWidth })} key={path}>
       <div className='header'>
-        <a onClick={() => onClick(peername, name)}>{hideUsername ? `${name}` : `${peername}/${name}`}</a>
+        <a onClick={() => onClick(username, name)}>{hideUsername ? `${name}` : `${username}/${name}`}</a>
         {meta && meta.theme && meta.theme.length > 0 && <Tag type='category' tag={meta.theme[0]} />}
       </div>
       <div className='title'>{ title }</div>

--- a/app/components/item/VersionInfoItem.tsx
+++ b/app/components/item/VersionInfoItem.tsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFileAlt } from '@fortawesome/free-solid-svg-icons'
 
 import { VersionInfo } from '../../models/store'
-import { detailedDatasetRefToDataset } from '../../actions/mappingFuncs'
+import { versionInfoToDataset } from '../../actions/mappingFuncs'
 import DatasetDetailsSubtext from '../dataset/DatasetDetailsSubtext'
 
 interface VersionInfoItemProps {
@@ -30,7 +30,7 @@ const VersionInfoItem: React.FunctionComponent<VersionInfoItemProps> = ({ data, 
       </div>
       <div className='text-column'>
         <div className='text'>{username}/{name}</div>
-        <DatasetDetailsSubtext data={detailedDatasetRefToDataset(data)} />
+        <DatasetDetailsSubtext data={versionInfoToDataset(data)} />
       </div>
     </div>
   )

--- a/app/components/modals/SearchModal.tsx
+++ b/app/components/modals/SearchModal.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react'
 import _ from 'underscore'
+import { RouteComponentProps, withRouter } from 'react-router-dom'
 
 import { Dataset as IDataset } from '../../models/dataset'
+import { datasetToVersionInfo } from '../../actions/mappingFuncs'
 import { FetchOptions } from '../../store/api'
 import { BACKEND_URL } from '../../constants'
+import { VersionInfo } from '../../models/store'
 
 import SearchBox from '../chrome/SearchBox'
 import DatasetItem from '../item/DatasetItem'
 import Switch from '../chrome/Switch'
 import Modal from './Modal'
 import Close from '../chrome/Close'
-import { RouteComponentProps, withRouter } from 'react-router-dom'
 
 interface SearchModalProps extends RouteComponentProps {
   q: string
@@ -31,7 +33,7 @@ const debounceTime = 300
 const SearchModal: React.FunctionComponent<SearchModalProps> = (props) => {
   const { q, onDismissed, setWorkingDataset, history } = props
   const [local, setLocal] = React.useState(false)
-  const [results, setResults] = React.useState<SearchProps[]>([])
+  const [results, setResults] = React.useState<VersionInfo[]>([])
   const [term, setTerm] = React.useState(q)
 
   const search = async (): Promise<void> => {
@@ -48,14 +50,10 @@ const SearchModal: React.FunctionComponent<SearchModalProps> = (props) => {
       throw err // eslint-disable-line
     }
 
-    const data = local ? res.data.map((item: IDataset) => {
-      return {
-        Type: 'dataset',
-        ID: item.path,
-        URL: '',
-        Value: item
-      }
-    }) : res.data
+    const data = local ? res.data
+      : res.data.map((item: SearchProps) => {
+        return datasetToVersionInfo(item.Value)
+      })
     setResults(data)
   }
 
@@ -69,7 +67,6 @@ const SearchModal: React.FunctionComponent<SearchModalProps> = (props) => {
     if (local) {
       return (username: string, name: string) => {
         setWorkingDataset(username, name)
-        console.log(username, name)
         history.push(`/workbench/${username}/${name}`)
         onDismissed()
       }
@@ -107,7 +104,7 @@ const SearchModal: React.FunctionComponent<SearchModalProps> = (props) => {
           {term && <p className='response-description'>{results.length} {results.length === 1 ? 'result' : 'results'} for <i>{term}</i></p>}
         </header>
         <div className='results'>
-          {term && (results.length !== 0) && results.map((result: SearchProps, i) => <DatasetItem key={i} data={result.Value} fullWidth onClick={handleOnClick()} />)}
+          {term && (results.length !== 0) && results.map((result: VersionInfo, i) => <DatasetItem key={i} data={result} fullWidth onClick={handleOnClick()} />)}
           {term && !results.length && <h4 className='no-results'>No Results</h4>}
         </div>
       </div>

--- a/app/components/modals/SearchModal.tsx
+++ b/app/components/modals/SearchModal.tsx
@@ -6,14 +6,16 @@ import { FetchOptions } from '../../store/api'
 import { BACKEND_URL } from '../../constants'
 
 import SearchBox from '../chrome/SearchBox'
-import Dataset from '../item/Dataset'
+import DatasetItem from '../item/DatasetItem'
 import Switch from '../chrome/Switch'
 import Modal from './Modal'
 import Close from '../chrome/Close'
+import { RouteComponentProps, withRouter } from 'react-router-dom'
 
-interface SearchModalProps {
+interface SearchModalProps extends RouteComponentProps {
   q: string
   onDismissed: () => void
+  setWorkingDataset: (username: string, name: string) => void
 }
 
 interface SearchProps {
@@ -27,7 +29,7 @@ interface SearchProps {
 const debounceTime = 300
 
 const SearchModal: React.FunctionComponent<SearchModalProps> = (props) => {
-  const { q, onDismissed } = props
+  const { q, onDismissed, setWorkingDataset, history } = props
   const [local, setLocal] = React.useState(false)
   const [results, setResults] = React.useState<SearchProps[]>([])
   const [term, setTerm] = React.useState(q)
@@ -51,10 +53,7 @@ const SearchModal: React.FunctionComponent<SearchModalProps> = (props) => {
         Type: 'dataset',
         ID: item.path,
         URL: '',
-        Value: {
-          ...item.dataset,
-          name: item.name
-        }
+        Value: item
       }
     }) : res.data
     setResults(data)
@@ -68,14 +67,16 @@ const SearchModal: React.FunctionComponent<SearchModalProps> = (props) => {
 
   const handleOnClick = () => {
     if (local) {
-      return (peername: string, name: string) => {
-        alert(`navigate to /dataset/${peername}/${name}`)
+      return (username: string, name: string) => {
+        setWorkingDataset(username, name)
+        console.log(username, name)
+        history.push(`/workbench/${username}/${name}`)
         onDismissed()
       }
     }
 
-    return (peername: string, name: string) => {
-      alert(`navigate to /network/${peername}/${name}`)
+    return (username: string, name: string) => {
+      history.push(`/network/${username}/${name}`)
       onDismissed()
     }
   }
@@ -106,7 +107,7 @@ const SearchModal: React.FunctionComponent<SearchModalProps> = (props) => {
           {term && <p className='response-description'>{results.length} {results.length === 1 ? 'result' : 'results'} for <i>{term}</i></p>}
         </header>
         <div className='results'>
-          {term && (results.length !== 0) && results.map((result: SearchProps, i) => <Dataset key={i} data={result.Value} fullWidth onClick={handleOnClick()} />)}
+          {term && (results.length !== 0) && results.map((result: SearchProps, i) => <DatasetItem key={i} data={result.Value} fullWidth onClick={handleOnClick()} />)}
           {term && !results.length && <h4 className='no-results'>No Results</h4>}
         </div>
       </div>
@@ -114,4 +115,4 @@ const SearchModal: React.FunctionComponent<SearchModalProps> = (props) => {
   )
 }
 
-export default SearchModal
+export default withRouter(SearchModal)

--- a/app/components/network/Network.tsx
+++ b/app/components/network/Network.tsx
@@ -35,7 +35,7 @@ const Network: React.FunctionComponent<NetworkProps> = (props) => {
    */
     if (!qriRef.username) return <NetworkHome history={history}/>
 
-    if (!qriRef.dataset) {
+    if (!qriRef.name) {
       return (
         <div
           style={{

--- a/app/components/network/NetworkHome.tsx
+++ b/app/components/network/NetworkHome.tsx
@@ -3,10 +3,12 @@ import { withRouter, RouteComponentProps } from 'react-router-dom'
 
 import { BACKEND_URL } from '../../constants'
 import { NetworkHomeData } from '../../models/network'
+import { VersionInfo } from '../../models/store'
+import Dataset from '../../models/dataset'
 
 import Spinner from '../chrome/Spinner'
 import DatasetItem from '../item/DatasetItem'
-import Dataset from '../../models/dataset'
+import { datasetToVersionInfo } from '../../actions/mappingFuncs'
 
 const initialDataState: NetworkHomeData = {
   featured: [],
@@ -30,18 +32,12 @@ const NetworkHome: React.FC<RouteComponentProps> = ({ history }) => {
         let data = { ...f }
         if (data.featured) {
           data.featured = f.featured.map((d: Dataset) => {
-            return {
-              ...d,
-              username: d.peername
-            }
+            return datasetToVersionInfo(d)
           })
         }
         if (data.recent) {
           data.recent = f.recent.map((d: Dataset) => {
-            return {
-              ...d,
-              username: d.peername
-            }
+            return datasetToVersionInfo(d)
           })
         }
         setData(data)
@@ -67,17 +63,15 @@ const NetworkHome: React.FC<RouteComponentProps> = ({ history }) => {
       <h2>Home</h2>
       {featured && featured.length && <div>
         <label>Featured Datasets</label>
-        {featured.map((ds, i) => <DatasetItem onClick={(username: string, name: string) => {
-          console.log(username, name)
+        {featured.map((vi: VersionInfo, i) => <DatasetItem onClick={(username: string, name: string) => {
           history.push(`/network/${username}/${name}`)
-        }} data={ds} key={i} />)}
+        }} data={vi} key={i} />)}
       </div>}
       {recent && recent.length && <div>
         <label>Recent Datasets</label>
-        {recent.map((ds, i) => <DatasetItem onClick={(username: string, name: string) => {
-          console.log(username, name)
+        {recent.map((vi: VersionInfo, i) => <DatasetItem onClick={(username: string, name: string) => {
           history.push(`/network/${username}/${name}`)
-        }} data={ds} key={i} />)}
+        }} data={vi} key={i} />)}
       </div>}
     </div>
   )

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -98,35 +98,35 @@ export interface VersionInfo {
   // human-readble name of the owner of this dataset
   username: string
   // user identifier
-  profileId: string
+  profileId?: string
   // dataset name
   name: string
   // commit hash, eg: /ipfs/QmY9WcXXUnHJbYRA28LRctiL4qu4y...
-  path: string
+  path?: string
 
   // repo locality
   // path to a local filesystem-linked directory (if exists)
-  fsiPath: string
+  fsiPath?: string
   // is block data for this commit stored locally?
-  foreign: boolean
+  foreign?: boolean
 
   // dataset version details
   // dataset meta.Title field
-  metaTitle: string
+  metaTitle?: string
   // meta.Themes array as a "comma,separated,string"
-  themeList: string
+  themeList?: string
   // length of body data in bytes
-  bodySize: number
+  bodySize?: number
   // number of rows in the body
-  bodyRows: number
+  bodyRows?: number
   // number of validation errors in the body
-  numErrors: number
+  numErrors?: number
   // commit.Timestamp field, time of version creation
-  commitTime: Date
+  commitTime?: Date
 
   // TODO (b5) - these are not yet supplied by the backend.
-  // bodyFormat: string  // data format of the body
-  // numCommits: number  // number of commits in history
+  bodyFormat?: string // data format of the body
+  numCommits?: number // number of commits in history
 
   // TODO (b5) - need to figure out publication representation. there's tension
   // about what "publication" as a boolean means.

--- a/stories/8-Item.stories.tsx
+++ b/stories/8-Item.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import DatasetItem from '../app/components/item/Dataset'
+import DatasetItem from '../app/components/item/DatasetItem'
+import { datasetToVersionInfo } from '../app/actions/mappingFuncs'
 import LabeledStats, { Stat } from '../app/components/item/LabeledStats'
 import Tag from '../app/components/item/Tag'
 
@@ -17,7 +18,7 @@ const worldBank = {
     timestamp: new Date(),
     count: 3
   },
-  structure: { length: 239940, format: 'csv' },
+  structure: { length: 239940, format: 'csv', errCount: 0, entries: 220 },
   meta: {
     title: 'World Bank Population - Geographic Regions Only',
     theme: ['population', 'world bank statistics']
@@ -28,7 +29,7 @@ export const dataset = () => {
   return (
     <div style={{ margin: 0, padding: 30, height: '100%', background: '#F5F7FA' }}>
       <div style={{ width: 800, margin: '2em auto' }}>
-        <DatasetItem path='foo/bar' data={worldBank} />
+        <DatasetItem path='foo/bar' data={datasetToVersionInfo(worldBank)} />
       </div>
     </div>
   )


### PR DESCRIPTION
clicking on search results will take you to the network page, if the dataset is on the network, or the workbench if the dataset is local.

This also alters `DatasetItem` to take `VersionInfos` and adds the `datasetToVersionInfo` function which we won't need once the backend list (search, feed, list) responses are refactored to return arrays of VersionInfos.