### PR TITLE
feat(Collection): explore datasets you have locally in the Collection pane

### DIFF
--- a/app/components/DatasetList.tsx
+++ b/app/components/DatasetList.tsx
@@ -124,7 +124,7 @@ class DatasetList extends React.Component<DatasetListProps> {
             onClick={(data: VersionInfo) => {
               setWorkingDataset(data.username, data.name)
                 .then(() => {
-                  this.props.history.push(`/workbench/${data.username}/${name}`)
+                  this.props.history.push(`/collection/${data.username}/${name}`)
                 })
             }}
           />

--- a/app/components/ReadmeHistory.tsx
+++ b/app/components/ReadmeHistory.tsx
@@ -15,6 +15,7 @@ const ReadmeHistory: React.FunctionComponent<ReadmeHistoryProps> = (props) => {
       if (el !== null) {
         fetch(`http://localhost:2503/render/${peername}/${name}/at/${path}`)
           .then(async (res) => {
+            if (res.status !== 200) { setHasReadme(false) }
             return res.text()
           })
           .then((render) => {
@@ -59,7 +60,6 @@ const ReadmeHistory: React.FunctionComponent<ReadmeHistoryProps> = (props) => {
   // }
 
   if (!hasReadme) {
-    console.log('no readme')
     return null
   }
   return (

--- a/app/components/collection/Collection.tsx
+++ b/app/components/collection/Collection.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react'
 import { Action, AnyAction } from 'redux'
 
-import HeaderColumnButton from './chrome/HeaderColumnButton'
-import WelcomeTemplate from './onboard/WelcomeTemplate'
-import DatasetList from './DatasetList'
-import Layout from './Layout'
-import { MyDatasets, WorkingDataset } from '../models/store'
-import { Modal, ModalType } from '../models/modals'
+import WelcomeTemplate from '../onboard/WelcomeTemplate'
+import DatasetList from '../DatasetList'
+import LocalPreview from '../dataset/LocalPreview'
+import Layout from '../Layout'
+import { MyDatasets, WorkingDataset } from '../../models/store'
+import { Modal } from '../../models/modals'
+import { RouteComponentProps } from 'react-router'
 
-import { faPlus, faDownload } from '@fortawesome/free-solid-svg-icons'
-
-interface CollectionProps {
+interface CollectionProps extends RouteComponentProps {
   myDatasets: MyDatasets
   workingDataset: WorkingDataset
   toggleCollection: () => Action
@@ -27,6 +26,7 @@ interface CollectionProps {
 class Collection extends React.Component<CollectionProps> {
   render () {
     const {
+      match,
       myDatasets,
       workingDataset,
       sidebarWidth,
@@ -38,33 +38,25 @@ class Collection extends React.Component<CollectionProps> {
       importFileSize
     } = this.props
 
-    const mainContent = (
-      <>
-        <div className='main-content-header'>
-          <HeaderColumnButton
-            id='create-dataset'
-            icon={faPlus}
-            label='Create new Dataset'
-            onClick={() => { setModal({ type: ModalType.CreateDataset }) }}
-          />
-          <HeaderColumnButton
-            icon={faDownload}
-            id='add-dataset'
-            label='Add existing Dataset'
-            onClick={() => { setModal({ type: ModalType.AddDataset }) }}
-          />
-        </div>
-        <div className='main-content-flex'>
-          <WelcomeTemplate
-            title='Welcome to Qri!'
-            subtitle={`drop a file to create a new dataset`}
-            id='drop-file'
-            loading={false}
-            fullscreen={false}
-          />
-        </div>
-      </>
-    )
+    const { params } = match
+
+    const renderMainContent = () => {
+      if (params && (!params.username || !params.dataset)) {
+        return (
+          <div className='main-content-header'>
+            <WelcomeTemplate
+              title='Welcome to Qri!'
+              subtitle={`drop a file to create a new dataset`}
+              id='drop-file'
+              loading={false}
+              fullscreen={false}
+            />
+          </div>
+        )
+      }
+
+      return <LocalPreview peername={params.username} name={params.dataset} path={params.path} />
+    }
 
     return (
       <Layout
@@ -80,7 +72,7 @@ class Collection extends React.Component<CollectionProps> {
         />}
         sidebarWidth={sidebarWidth}
         onSidebarResize={(width) => { setSidebarWidth('collection', width) }}
-        mainContent={mainContent}
+        mainContent={renderMainContent()}
       />
     )
   }

--- a/app/components/dataset/Dataset.tsx
+++ b/app/components/dataset/Dataset.tsx
@@ -4,7 +4,7 @@ import { Dataset as IDataset, DatasetAction } from '../../models/dataset'
 
 import BodySegment from './BodySegment'
 import Overview from './Overview'
-// import ReadmeSegment from './ReadmeSegment'
+import ReadmeSegment from './ReadmeSegment'
 import StructureSegment from './StructureSegment'
 import CommitPreview from './CommitPreview'
 
@@ -17,14 +17,14 @@ const Dataset: React.FunctionComponent<DatasetProps> = (props) => {
   const { data, actions = [] } = props
   if (!data) { return null }
 
-  // const { commit = {}, peername, name, path, structure } = data
-  const { commit = {}, structure } = data
+  const { commit = {}, peername, name, path, structure } = data
+  // const { commit = {}, structure } = data
 
   return (
     <div className='dataset'>
       <Overview data={data} actions={actions} />
       <CommitPreview data={commit} />
-      {/* <ReadmeSegment peername={peername} name={name} path={path} collapsable /> */}
+      <ReadmeSegment peername={peername} name={name} path={path} collapsable />
       <StructureSegment data={structure} collapsable />
       <BodySegment data={data} collapsable />
     </div>

--- a/app/components/dataset/LocalPreview.tsx
+++ b/app/components/dataset/LocalPreview.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+
+import { Dataset as IDataset, DatasetAction } from '../../models/dataset'
+import { FetchOptions } from '../../store/api'
+import { BACKEND_URL } from '../../constants'
+
+import Dataset from './Dataset'
+import SpinnerWithIcon from '../chrome/SpinnerWithIcon'
+
+interface LocalPreviewProps {
+  peername: string
+  name: string
+  path?: string
+
+  actions?: DatasetAction[]
+}
+
+/**
+ * LocalPreview is a self-sufficiant component whose content is ephemeral, if you
+ * give it a peername, name, and optional path, it will fetch the dataset
+ * preview for you
+ */
+const LocalPreview: React.FunctionComponent<LocalPreviewProps> = (props) => {
+  const { peername, name, path = '', actions } = props
+
+  const [data, setData] = React.useState<IDataset>()
+  const [error, setError] = React.useState('')
+
+  const fetchDataset = async (): Promise<void> => {
+    const options: FetchOptions = {
+      method: 'GET'
+    }
+
+    const url = path === '' ? `${BACKEND_URL}/${peername}/${name}` : `${BACKEND_URL}/${peername}/${name}/at/${path}`
+    const bodyUrl = path === '' ? `${BACKEND_URL}/body/${peername}/${name}` : `${BACKEND_URL}/${peername}/${name}/at/${path}`
+
+    const r = await fetch(url, options)
+    const res = await r.json()
+    if (res.meta.code !== 200) {
+      setError(res.meta.error)
+      return
+    }
+    const br = await fetch(bodyUrl, options)
+    const bodyRes = await br.json()
+    if (bodyRes.meta.code !== 200) {
+      setError(res.meta.error)
+      return
+    }
+    let dataset: IDataset = {
+      ...res.data.dataset,
+      body: bodyRes.data.data
+    }
+    setData(dataset)
+  }
+
+  React.useEffect(() => {
+    if (error !== '') setError('')
+    fetchDataset()
+  }, [peername, name, path])
+
+  // TODO (ramfox): what does an error screen look like here? or do we just nav
+  // back to the network/home & pop up a toast?
+  if (error !== '') {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          fontSize: 16,
+          height: '100%',
+          width: '100%'
+        }}>
+        <div style={{ width: 300 }}>
+          There was an error loading dataset {peername}/{name}: {error}
+        </div>
+      </div>
+    )
+  }
+
+  // TODO (ramfox): would love a better less jarring way to show loading
+  // perhaps a DatasetLoading component that has all the sections rendered
+  // with ala slack or linkedin or fb
+  // basically, each segment has a `mock` version that we display when we are
+  // `loading`, if `loading === false && !data`, however, we return null
+  if (!data) return <SpinnerWithIcon loading/>
+
+  return <Dataset data={data} actions={actions} />
+}
+
+export default LocalPreview

--- a/app/components/dataset/NetworkPreview.tsx
+++ b/app/components/dataset/NetworkPreview.tsx
@@ -7,7 +7,7 @@ import { BACKEND_URL } from '../../constants'
 import Dataset from './Dataset'
 import SpinnerWithIcon from '../chrome/SpinnerWithIcon'
 
-interface PreviewProps {
+interface NetworkPreviewProps {
   peername: string
   name: string
   path?: string
@@ -16,14 +16,11 @@ interface PreviewProps {
 }
 
 /**
- * Preview is a self-sufficiant component whose content is ephemeral, if you
+ * NetworkPreview is a self-sufficiant component whose content is ephemeral, if you
  * give it a peername, name, and optional path, it will fetch the dataset
  * preview for you
- * TODO (ramfox): we can refactor the fetching and state into the Dataset
- * component itself, just wanted to iterate outside of the component first
- * This should probably have a different name, such as DatasetFetchAndPreview?
  */
-const Preview: React.FunctionComponent<PreviewProps> = (props) => {
+const NetworkPreview: React.FunctionComponent<NetworkPreviewProps> = (props) => {
   const { peername, name, path = '', actions } = props
 
   const [data, setData] = React.useState<IDataset>()
@@ -80,4 +77,4 @@ const Preview: React.FunctionComponent<PreviewProps> = (props) => {
   return <Dataset data={data} actions={actions} />
 }
 
-export default Preview
+export default NetworkPreview

--- a/app/components/item/DatasetItem.tsx
+++ b/app/components/item/DatasetItem.tsx
@@ -1,30 +1,30 @@
 import * as React from 'react'
 
-import { VersionInfo } from '../../models/store'
+import Dataset from '../../models/dataset'
 import DatasetDetailsSubtext from '../dataset/DatasetDetailsSubtext'
 import Tag from './Tag'
 import classNames from 'classnames'
 
 interface DatasetItemProps {
-  id?: string
-  data: VersionInfo
+  data: Dataset
   onClick: (username: string, name: string) => void
   fullWidth: boolean
   path?: string
   hideUsername?: boolean
 }
 
-const DatasetItem: React.FunctionComponent<DatasetItemProps> = ({ id, data, path, hideUsername, fullWidth = false, onClick }) => {
+const DatasetItem: React.FunctionComponent<DatasetItemProps> = ({ data, path, hideUsername, fullWidth = false, onClick }) => {
   if (!data) { return null }
-  const { metaTitle, themeList, username, name } = data
+  const { meta, username, name } = data
+  const title = (meta && meta.title) ? meta.title : `No Title - ${name}`
 
   return (
-    <div id={id} className={classNames('dataset-item', { 'full': fullWidth })} key={path} data-ref={`${username}/${name}`}>
+    <div className={classNames('dataset-item', { 'full': fullWidth })} key={path}>
       <div className='header'>
         <a onClick={() => onClick(username, name)}>{hideUsername ? `${name}` : `${username}/${name}`}</a>
-        {themeList && themeList.length > 0 && <Tag type='category' tag={themeList[0]} />}
+        {meta && meta.theme && meta.theme.length > 0 && <Tag type='category' tag={meta.theme[0]} />}
       </div>
-      <div className='title'>{ metaTitle }</div>
+      <div className='title'>{ title }</div>
       <div className='details'><DatasetDetailsSubtext data={data} color='muted' /></div>
     </div>
   )

--- a/app/components/network/Network.tsx
+++ b/app/components/network/Network.tsx
@@ -7,10 +7,11 @@ import { ApiActionThunk } from '../../store/api'
 import Layout from '../Layout'
 import NetworkHome from './NetworkHome'
 import NetworkSidebar from './NetworkSidebar'
-import Preview from '../dataset/Preview'
 import LogList from './LogList'
 import SidebarActionButton from '../chrome/SidebarActionButton'
-import { RouteComponentProps } from 'react-router'
+
+import NetworkPreview from '../dataset/NetworkPreview'
+import { RouteComponentProps } from 'react-router-dom'
 
 export interface NetworkProps extends RouteComponentProps{
   qriRef: QriRef
@@ -29,7 +30,6 @@ export interface NetworkProps extends RouteComponentProps{
 const Network: React.FunctionComponent<NetworkProps> = (props) => {
   const {
     qriRef,
-
     inCollection,
     addDatasetAndFetch,
     sidebarWidth,
@@ -37,8 +37,7 @@ const Network: React.FunctionComponent<NetworkProps> = (props) => {
   } = props
 
   const renderMainContent = () => {
-    /** TODO (ramfox): username, name, and path must be passed down from container
-   * based on route or selections
+    /**
    * if empty, peername is empty, we know to show 'home'
    * if name is empty, we know to show 'profile'
    */
@@ -62,7 +61,7 @@ const Network: React.FunctionComponent<NetworkProps> = (props) => {
       )
     }
 
-    return <Preview peername={qriRef.username} name={qriRef.name} path={qriRef.path} />
+    return <NetworkPreview peername={qriRef.username} name={qriRef.name} path={qriRef.path} />
   }
 
   const mainContent = (

--- a/app/components/network/NetworkHome.tsx
+++ b/app/components/network/NetworkHome.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
 
 import { BACKEND_URL } from '../../constants'
+import { FetchOptions } from '../../store/api'
 import { NetworkHomeData } from '../../models/network'
 import { VersionInfo } from '../../models/store'
 

--- a/app/components/network/NetworkSidebar.tsx
+++ b/app/components/network/NetworkSidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const NetworkSidebar: React.FC<void> = (props) => {
+const NetworkSidebar: React.FC<any> = (props) => {
   const { children } = props
   return (
     <div id='network-sidebar'>

--- a/app/containers/CollectionContainer.tsx
+++ b/app/containers/CollectionContainer.tsx
@@ -1,17 +1,13 @@
 import { connect } from 'react-redux'
 import { setFilter } from '../actions/myDatasets'
-import Collection from '../components/Collection'
+import Collection from '../components/collection/Collection'
 import { fetchMyDatasets } from '../actions/api'
 import { setWorkingDataset } from '../actions/selections'
-import { setSidebarWidth } from '../actions/ui'
+import { setSidebarWidth, setModal } from '../actions/ui'
 
-import { Modal } from '../models/modals'
+import { RouteComponentProps } from 'react-router'
 
-interface CollectionContainerProps {
-  setModal: (modal: Modal) => void
-}
-
-const mapStateToProps = (state: any, ownProps: CollectionContainerProps) => {
+const mapStateToProps = (state: any, ownProps: RouteComponentProps) => {
   const { myDatasets, workingDataset, ui } = state
   const {
     collectionSidebarWidth: sidebarWidth,
@@ -19,8 +15,10 @@ const mapStateToProps = (state: any, ownProps: CollectionContainerProps) => {
     importFileSize
   } = ui
 
-  const { setModal } = ownProps
+  const { match } = ownProps
+  console.log(ownProps)
   return {
+    match,
     myDatasets,
     workingDataset,
     setModal,

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -16,8 +16,7 @@ export default function Routes (props: any) {
     setQriCloudAuthenticated,
     acceptTOS,
     signup,
-    signin,
-    setModal
+    signin
   } = props
 
   const requireSignin = (dest: React.ReactElement): React.ReactElement => {
@@ -69,14 +68,12 @@ export default function Routes (props: any) {
             return sectionElement('network', <NetworkContainer {...props} />)
           }} />
         }
-        <Route exact path='/collection' render={() => {
-          return sectionElement('collection', <CollectionContainer setModal={setModal} />)
+        { __BUILD__.ENABLE_NETWORK_SECTION && <Route path='/collection/:username/:dataset' render={(props) => {
+          return sectionElement('collection', <CollectionContainer { ...props }/>)
         }} />
-        <Route path='/collection/:username' render={(props) => {
-          return sectionElement('collection', <Placeholder
-            title='Collection User Datasets'
-            pathname={props.location.pathname}
-          />)
+        }
+        <Route exact path='/collection' render={(props) => {
+          return sectionElement('collection', <CollectionContainer {...props} />)
         }} />
 
         <Route exact path='/workbench' render={() => {
@@ -95,14 +92,14 @@ export default function Routes (props: any) {
   )
 }
 
-interface PlaceholderProps {
-  title: string
-  pathname: string
-}
+// interface PlaceholderProps {
+//   title: string
+//   pathname: string
+// }
 
-const Placeholder: React.FunctionComponent<PlaceholderProps> = ({ title, pathname }) => {
-  return <div className='container dataset'>
-    <h1>{title}</h1>
-    <i>a placeholder for: {pathname}</i>
-  </div>
-}
+// const Placeholder: React.FunctionComponent<PlaceholderProps> = ({ title, pathname }) => {
+//   return <div className='container dataset'>
+//     <h1>{title}</h1>
+//     <i>a placeholder for: {pathname}</i>
+//   </div>
+// }

--- a/app/scss/_sidebar-layout.scss
+++ b/app/scss/_sidebar-layout.scss
@@ -36,10 +36,12 @@
       overflow: hidden;
 
       .main-content-header {
-        flex: 0;
         display: flex;
+        justify-content: center;
         align-items: center;
         padding: 5px 0;
+        height: 100%;
+        width: 100%;
 
         .header-column {
           display: inline-flex;
@@ -67,7 +69,7 @@
       }
 
       .main-content-flex {
-        flex: 1;
+        // flex: 1;
       }
     }
   }


### PR DESCRIPTION
closes #448 

- add `LocalPreview`s to` Collection`
- add `HistoryList` sidebar to `Collection`, that is available when we navigate to a preview (the normal `DatasetList` should slide out revealing the `HistoryList` and a "Edit Dataset" `SidebarActionButton` in the same location that the `Clone Dataset` button lives on the `Network` tab
- add `Export version` to the `dataset/Dataset` `Titlebar`
- Add ability to expand `BodySegment` in `LocalPreview`
- Segment -> option to be full height (all segments except for body)
