### PR TITLE
Network pane fixes

### DIFF
--- a/app/components/network/NetworkHome.tsx
+++ b/app/components/network/NetworkHome.tsx
@@ -44,7 +44,7 @@ const NetworkHome: React.FC<RouteComponentProps> = ({ history }) => {
     <div className='network_home'>
       <h2>Home</h2>
       {featured && featured.length && <div>
-        <label>Featured Datasets</label>
+        <h4>Featured Datasets</h4>
         {featured.map((vi: VersionInfo, i) => <div key={i} className='featured-datasets-item'>
           <DatasetItem onClick={(username: string, name: string) => {
             history.push(`/network/${username}/${name}`)
@@ -52,7 +52,7 @@ const NetworkHome: React.FC<RouteComponentProps> = ({ history }) => {
         </div>)}
       </div>}
       {recent && recent.length && <div>
-        <label>Recent Datasets</label>
+        <h4>Recent Datasets</h4>
         {recent.map((vi: VersionInfo, i) => <div key={i} className='recent-datasets-item'>
           <DatasetItem onClick={(username: string, name: string) => {
             history.push(`/network/${username}/${name}`)

--- a/app/scss/0.4.0/item.scss
+++ b/app/scss/0.4.0/item.scss
@@ -97,12 +97,13 @@
   &.category {
     color: #F8AB31;
     background: #F2F2F2;
-    border-radius: 2px; 
+    border-radius: 2px;
   }
 }
 
 
 .dataset-item {
+  margin: 15px 0;
   padding: 20px;
   background: white;
   border-radius: 5px;

--- a/app/scss/_navbar.scss
+++ b/app/scss/_navbar.scss
@@ -8,7 +8,7 @@ $navbar-item-margin: 6px;
 }
 
 .navbar, {
-  width: 60px;
+  width: 68px;
   height: 100%;
   padding: 48px 0 8px 0;
   color: $icon-gray;


### PR DESCRIPTION
- Adds some margin around list items in Network pane
- Treats `themeList` as a string (quick fix, it supposed to be an array, opened #462 about this)
- Increases the navbar width to 68px so the macOS window buttons appear centered
