### PR TITLE
feat(selections): adding workbench selections and actions

### DIFF
--- a/app/components/workbench/Workbench.tsx
+++ b/app/components/workbench/Workbench.tsx
@@ -226,7 +226,7 @@ class Workbench extends React.Component<WorkbenchProps, Status> {
     setMutationsDataset(dataset)
   }
 
-  // TODO (refactor into selection)
+  // TODO (refactor into selection) - marked for removal after container refactor
   datasetFromCommitDetails (commitDetails: ICommitDetails): Dataset {
     const { components } = commitDetails
     let d: Dataset = {}
@@ -240,10 +240,9 @@ class Workbench extends React.Component<WorkbenchProps, Status> {
     return d
   }
 
-  // TODO (ramfox): refactor into selection - should this logic should happen at the container level, and the
-  // component should just display whatever dataset it is given? We need to
-  // know what the head dataset looks like, however, in order to determine if
-  // anything has changed in 'handleSetDataset'
+  // TODO (ramfox): once all dataset components are refactored in containers
+  // will remove this function
+  // replaced by `selectDatasetFromMutations`
   datasetFromMutations (): Dataset {
     const { data } = this.props
     const { workingDataset, mutationsDataset } = data

--- a/app/selections.ts
+++ b/app/selections.ts
@@ -1,0 +1,49 @@
+import Dataset from "./models/dataset"
+import cloneDeep from 'clone-deep'
+
+import Store, { CommitDetails, Status } from "./models/store"
+
+export function selectDatasetFromMutations (state: Store): Dataset {
+  const { mutations } = state
+  const mutationsDataset = mutations.dataset.value
+
+  const dataset = selectWorkingDataset(state)
+  const d = { ...dataset, ...mutationsDataset }
+  return d
+}
+
+export function selectWorkingDataset (state: Store): Dataset {
+  return datasetFromCommitDetails(state.workingDataset)
+}
+
+export function selectHistoryDataset (state: Store): Dataset {
+  return datasetFromCommitDetails(state.commitDetails)
+}
+
+function datasetFromCommitDetails (commitDetails: CommitDetails): Dataset {
+  const { components } = commitDetails
+  let d: Dataset = {}
+
+  Object.keys(components).forEach((componentName: string) => {
+    if (componentName === 'bodyPath') return
+    if (components[componentName].value) {
+      d[componentName] = cloneDeep(components[componentName].value)
+    }
+  })
+  return d
+}
+
+export function selectStatusFromMutations (state: Store): Status {
+  const { workingDataset, mutations } = state
+  const mutationsStatus = mutations.status.value
+
+  return { ...workingDataset.status, ...mutationsStatus }
+}
+
+export function selectWorkingStatus (state: Store): Status {
+  return state.workingDataset.status
+}
+
+export function selectHistoryStatus (state: Store): Status {
+  return state.commitDetails.status
+}

--- a/app/selections/workbench.ts
+++ b/app/selections/workbench.ts
@@ -1,0 +1,49 @@
+import Dataset from "../models/dataset"
+import cloneDeep from 'clone-deep'
+
+import Store, { CommitDetails, Status } from "../models/store"
+
+export function selectDatasetFromMutations (state: Store): Dataset {
+  const { mutations } = state
+  const mutationsDataset = mutations.dataset.value
+
+  const dataset = selectWorkingDataset(state)
+  const d = { ...dataset, ...mutationsDataset }
+  return d
+}
+
+export function selectWorkingDataset (state: Store): Dataset {
+  return datasetFromCommitDetails(state.workingDataset)
+}
+
+export function selectHistoryDataset (state: Store): Dataset {
+  return datasetFromCommitDetails(state.commitDetails)
+}
+
+function datasetFromCommitDetails (commitDetails: CommitDetails): Dataset {
+  const { components } = commitDetails
+  let d: Dataset = {}
+
+  Object.keys(components).forEach((componentName: string) => {
+    if (componentName === 'bodyPath') return
+    if (components[componentName].value) {
+      d[componentName] = cloneDeep(components[componentName].value)
+    }
+  })
+  return d
+}
+
+export function selectStatusFromMutations (state: Store): Status {
+  const { workingDataset, mutations } = state
+  const mutationsStatus = mutations.status.value
+
+  return { ...workingDataset.status, ...mutationsStatus }
+}
+
+export function selectWorkingStatus (state: Store): Status {
+  return state.workingDataset.status
+}
+
+export function selectHistoryStatus (state: Store): Status {
+  return state.commitDetails.status
+}


### PR DESCRIPTION
added array of selections that we will need for the coming container refactor

added `writeDataset` function that combines `fsiWrite`, `setMutationsDataset`, and `setMutationsStatus`, adapted from the `handleSetDataset` function in `Workbench`

This pr just adds the functions, it doesn't remove any current functionality from the `Workbench` component