### PR TITLE
chore(version): version bump to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## [0.4.1](https://github.com/qri-io/desktop/compare/v0.4.0...v0.4.1) (2020-04-07)
+
+This release is all about minor bug fixes, clean up, stabilization, and updating the desktop app to work with the latest qri release!
+
+Be sure to check out the latest [qri backend release](https://github.com/qri-io/qri/releases/tag/v0.9.7) to see the lovely fixes we inherit.
+
+## Export
+In a combined effort from the backend and desktop, we've fixed the export bug! Right-clicking the version you want to export, and clicking 'export this version', opens the save dialog, prefilled with a default zipname.
+
+## API changes
+This desktop update adjusts our requests to meet the expectations of the latest qri backend's API
+
+## Reloading
+Because of those wonderful backend api changes, we were able to fix a long-standing bug where re-loading on the `workbench` page broke the app. Now you can reload to your heart's content
+
+## Websockets
+Combining websockets and the backend status request changes, we are able to more intelligently re-fetch fsi linked datasets as you make changes to them using a text editor and the qri desktop app.
+
+## Editing
+Cleaned up a whole lotta bugs surrounding ui flickering in meta and structure editing. Also, all meta and structure fields are now tested in our visual end to end tests.
+
+### Bug Fixes
+
+* **export:** send correct path for export ([726e0eb](https://github.com/qri-io/desktop/commit/726e0eb))
+* **fetchWorkingDatasetDetails:** don't fetch status unless dataset is linked ([04625de](https://github.com/qri-io/desktop/commit/04625de))
+* **mappingFunc:** account for different expected history response behavior ([32f757a](https://github.com/qri-io/desktop/commit/32f757a))
+* **MultiStructuredInput:** fix bug that caused component flickering ([5e52a7f](https://github.com/qri-io/desktop/commit/5e52a7f))
+* **selectStatusFromMutations:** corrently pull or create a status ([028f40b](https://github.com/qri-io/desktop/commit/028f40b))
+* **websockets:** use websocket responses more intelligently ([2e6aad2](https://github.com/qri-io/desktop/commit/2e6aad2))
+* **workbench:** when fsi true, don't prompt the user about unsaved changes ([ba958b2](https://github.com/qri-io/desktop/commit/ba958b2))
+
+
+### Features
+
+* **selections:** adding workbench selections and actions ([d32d201](https://github.com/qri-io/desktop/commit/d32d201))
+
+
+
 # [0.4.0](https://github.com/qri-io/desktop/compare/v0.3.5...v0.4.0) (2020-03-05)
 
 Release notes 0.4.0

--- a/app/package.json
+++ b/app/package.json
@@ -1,8 +1,8 @@
 {
   "name": "qri-desktop",
   "productName": "Qri Desktop",
-  "version": "0.4.0",
-  "backendVersion": "0.9.6",
+  "version": "0.4.1",
+  "backendVersion": "0.9.7",
   "description": "Version your data with the Qri desktop app!",
   "main": "./main.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qri-desktop",
   "productName": "Qri Desktop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Version your data with the Qri desktop app!",
   "main": "main.js",
   "scripts": {
@@ -169,7 +169,7 @@
     "electron-builder-http": "19.27.5",
     "electron-chromedriver": "7.0.0",
     "electron-devtools-installer": "2.2.4",
-    "electron-notarize": "0.2.0",
+    "electron-notarize": "0.3.0",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.1",
     "eslint": "6.6.0",

--- a/version.js
+++ b/version.js
@@ -1,4 +1,4 @@
 module.exports = {
-  desktopVersion: '0.4.0',
-  backendVersion: '0.9.6'
+  desktopVersion: '0.4.1',
+  backendVersion: '0.9.7'
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6002,10 +6002,10 @@ electron-log@4.0.5:
   resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.0.5.tgz#4179f0ecf28917e74f0408cfa1e93857b8f20f97"
   integrity sha512-YadfIactRvhnkclBwxJ9jYGCrkbjhpPXjQXglz71rzrhUq1mXq3DyISrq1t4XiL0C8HKJbSpAq5DXbDppPxzaQ==
 
-electron-notarize@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-0.2.0.tgz#676c71688ee84149bab27b22426d0a9452e7e262"
-  integrity sha512-u3KdEMOEcGMF9yCML8ej4ZF+O29VmGYIjrs/DoOi23neTWOMiIc5YCeFs4vxq3JG496omcw7Y5pimPm0sH9A7g==
+electron-notarize@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-0.3.0.tgz#b93c606306eac558b250c78ff95273ddb9fedf0a"
+  integrity sha512-tuDw8H0gcDOalNLv6RM2CwGvUXU60MPGZRDEmd0ppX+yP5XqL8Ec2DuXyz9J7WQSA3aRCfzIgH8C5CAivDYWMw==
   dependencies:
     debug "^4.1.1"
     fs-extra "^8.1.0"


### PR DESCRIPTION
This release is all about minor bug fixes, clean up, stabilization, and updating the desktop app to work with the latest qri release!

Be sure to check out the latest [qri backend release](https://github.com/qri-io/qri/releases/tag/v0.9.7) to see the lovely fixes we inherit.

## Export
In a combined effort from the backend and desktop, we've fixed the export bug! Right-clicking the version you want to export, and clicking 'export this version', opens the save dialog, prefilled with a default zipname.

## API changes
This desktop update adjusts our requests to meet the expectations of the latest qri backend's API

## Reloading
Because of those wonderful backend api changes, we were able to fix a long-standing bug where re-loading on the `workbench` page broke the app. Now you can reload to your heart's content

## Websockets
Combining websockets and the backend status request changes, we are able to more intelligently re-fetch fsi linked datasets as you make changes to them using a text editor and the qri desktop app.

## Editing
Cleaned up a whole lotta bugs surrounding ui flickering in meta and structure editing. Also, all meta and structure fields are now tested in our visual end to end tests.