### PR TITLE
chore(release): version 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.4.2](https://github.com/qri-io/desktop/compare/v0.4.1...v0.4.2) (2020-04-20)
+
+The Qri Desktop 0.4.2 patch fixes a major export bug! It also fixes two minor bugs surrounding fetching datasets for display in the Workbench.
+
+Be sure to check out the latest [qri backend release](https://github.com/qri-io/qri/releases/tag/v0.9.8) to see the other fixes we inherit.
+
+### Bug Fixes
+
+* **workbench:** adjust action to fall through and load history dataset if path is provided ([a16367b](https://github.com/qri-io/desktop/commit/a16367b))
+* **workbench:** if we are given a path, fall through and allow the commit to be fetched ([73277ec](https://github.com/qri-io/desktop/commit/73277ec))
+
+
+
 ## [0.4.1](https://github.com/qri-io/desktop/compare/v0.4.0...v0.4.1) (2020-04-07)
 
 This release is all about minor bug fixes, clean up, stabilization, and updating the desktop app to work with the latest qri release!

--- a/app/package.json
+++ b/app/package.json
@@ -1,8 +1,8 @@
 {
   "name": "qri-desktop",
   "productName": "Qri Desktop",
-  "version": "0.4.2-dev",
-  "backendVersion": "0.9.8-dev",
+  "version": "0.4.2",
+  "backendVersion": "0.9.8",
   "description": "Version your data with the Qri desktop app!",
   "main": "./main.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qri-desktop",
   "productName": "Qri Desktop",
-  "version": "0.4.2-dev",
+  "version": "0.4.2",
   "description": "Version your data with the Qri desktop app!",
   "main": "main.js",
   "scripts": {

--- a/version.js
+++ b/version.js
@@ -1,4 +1,4 @@
 module.exports = {
-  desktopVersion: '0.4.2-dev',
-  backendVersion: '0.9.8-dev'
+  desktopVersion: '0.4.2',
+  backendVersion: '0.9.8'
 }


### PR DESCRIPTION
Changelog/release message:


The Qri Desktop 0.4.2 patch fixes an export bug! It also fixes two minor bugs surrounding fetching datasets for display in the Workbench.

Be sure to check out the latest [qri backend release](https://github.com/qri-io/qri/releases/tag/v0.9.8) to see the other fixes we inherit.
