### PR TITLE
Migration components

### DIFF
--- a/app/components/CrashReportSender.tsx
+++ b/app/components/CrashReportSender.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react'
+import Button from './chrome/Button'
+import ExternalLink from './ExternalLink'
+import WelcomeTemplate from './onboard/WelcomeTemplate'
+import { FetchOptions } from '../store/api'
+import versions from '../../version'
+import { CRASH_REPORTER_URL } from '../constants'
+
+interface CrashReportSenderProps extends ErrorProps {
+  title: string
+}
+
+interface ErrorProps {
+  error?: Error
+  errorInfo?: React.ErrorInfo
+}
+
+const CrashReportSender: React.FC<CrashReportSenderProps> = ({ title, error, errorInfo }) => {
+  const [sendingReport, setSendingReport] = useState(false)
+  const [sentReport, setSentReport] = useState(false)
+
+  const handleSendCrashReport = async () => {
+    setSendingReport(true)
+    try {
+      console.log('sending report')
+      await postCrashReport(error, errorInfo)
+      setSendingReport(true)
+      setSentReport(true)
+    } catch (e) {
+      console.log(e)
+      setSendingReport(false)
+    }
+  }
+
+  const handleReload = () => {
+    window.location.hash = '/'
+    window.location.reload()
+  }
+
+  return (
+    <WelcomeTemplate title={title}>
+      <div className="reporting actions">
+        <p>Apologies, Qri desktop encountered an error. Send us a crash report!</p>
+        {sentReport
+          ? <p>Thanks!</p>
+          : <Button
+            id="send-crash-report"
+            text="Send Crash Report"
+            color="primary"
+            loading={sendingReport}
+            onClick={handleSendCrashReport}
+          />}
+      </div>
+      <br />
+      <div className="reload">
+        <p>If you have additional info or questions, feel free to <ExternalLink id="file-issue" href="https://github.com/qri-io/desktop/issues/new">file an issue</ExternalLink> describing where things went wrong. The more detail, the better. Reload to get back to Qri.</p>
+        <Button
+          id="error-reload"
+          text="Reload Qri Desktop"
+          color="dark"
+          onClick={handleReload}
+        />
+      </div>
+    </WelcomeTemplate>
+  )
+}
+
+// TODO (b5) - bring this back in the near future for fetching home feed
+const postCrashReport = async (error: ErrorProps['error'], errorInfo: ErrorProps['errorInfo']): Promise<any> => {
+  const options: FetchOptions = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      app: 'desktop',
+      version: versions.desktopVersion,
+      platform: navigator.platform,
+      error: error?.toString(),
+      info: errorInfo?.componentStack
+    })
+  }
+
+  console.log(CRASH_REPORTER_URL)
+  const r = await fetch(CRASH_REPORTER_URL, options)
+  const res = await r.json()
+  return res
+}
+
+export default CrashReportSender

--- a/app/components/CrashReportSender.tsx
+++ b/app/components/CrashReportSender.tsx
@@ -10,7 +10,7 @@ interface CrashReportSenderProps extends ErrorProps {
   title: string
 }
 
-interface ErrorProps {
+export interface ErrorProps {
   error?: Error
   errorInfo?: React.ErrorInfo
 }

--- a/app/components/ErrorHandler.tsx
+++ b/app/components/ErrorHandler.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import CrashReportSender, { ErrorProps } from './CrashReportSender'
+import ReportCrashAndReload, { ErrorProps } from './ReportCrashAndReload'
 import localStore from '../utils/localStore'
 
 export default class ErrorHandler extends React.Component {
@@ -27,7 +27,7 @@ export default class ErrorHandler extends React.Component {
     }
 
     return (
-      <CrashReportSender
+      <ReportCrashAndReload
         title='Dang. It broke.'
         error={this.state.error}
         errorInfo={this.state.errorInfo}/>

--- a/app/components/ErrorHandler.tsx
+++ b/app/components/ErrorHandler.tsx
@@ -1,28 +1,16 @@
 import React from 'react'
-import versions from '../../version'
-import { CRASH_REPORTER_URL } from '../constants'
 
+import CrashReportSender, { ErrorProps } from './CrashReportSender'
 import localStore from '../utils/localStore'
-import ExternalLink from './ExternalLink'
-import Button from './chrome/Button'
 
 export default class ErrorHandler extends React.Component {
   state = {
     error: undefined,
-    errorInfo: undefined,
-    sendingReport: false,
-    sentReport: false
+    errorInfo: undefined
   }
 
-  constructor (props) {
-    super(props)
-
-    this.handleSendCrashReport = this.handleSendCrashReport.bind(this)
-    this.handleReload = this.handleReload.bind(this)
-  }
-
-  componentDidCatch (error, errorInfo) {
-    this.setState({ error, errorInfo, sendingReport: false })
+  componentDidCatch (error: ErrorProps['error'], errorInfo: ErrorProps['errorInfo']) {
+    this.setState({ error, errorInfo })
 
     // clear local storage, which may cause re-crashing if in an error put us
     // into an un-recoverable state
@@ -33,87 +21,16 @@ export default class ErrorHandler extends React.Component {
     localStore().setItem('commitComponent', '')
   }
 
-  handleSendCrashReport (e: React.MouseEvent) {
-    const { error, errorInfo } = this.state
-    this.setState({ error, errorInfo, sendingReport: true })
-
-    console.log('sending report')
-    postCrashReport(error, errorInfo)
-      .then(() => {
-        this.setState({
-          sentReport: true,
-          sendingReport: false
-        })
-      })
-      .catch((e) => {
-        console.log(e)
-        this.setState({
-          sendingReport: false
-        })
-      })
-  }
-
-  handleReload (e: React.MouseEvent) {
-    window.location.hash = '/'
-    window.location.reload()
-  }
-
   render () {
     if (!this.state.error) {
       return this.props.children
     }
 
-    const { sendingReport, sentReport } = this.state
-
     return (
-      <div className="error-container">
-        <div className="dialog">
-          <h1>Dang. It broke.</h1>
-          <p>Apologies, Qri desktop encountered an error. Send us a crash report!</p>
-          <div className="reporting actions">
-            {sentReport
-              ? <p>Thanks!</p>
-              : <Button
-                id="send-crash-report"
-                text="Send Crash Report"
-                color="primary"
-                loading={sendingReport}
-                onClick={this.handleSendCrashReport}
-              />}
-          </div>
-          <div className="reload">
-            <p>If you have additional info or questions, feel free to <ExternalLink id="file-issue" href="https://github.com/qri-io/desktop/issues/new">file an issue</ExternalLink> describing where things went wrong. The more detail, the better. Reload to get back to Qri.</p>
-            <Button
-              id="error-reload"
-              text="Reload Qri Desktop"
-              color="dark"
-              onClick={this.handleReload}
-            />
-          </div>
-        </div>
-      </div>
+      <CrashReportSender
+        title='Dang. It broke.'
+        error={this.state.error}
+        errorInfo={this.state.errorInfo}/>
     )
   }
-}
-
-// TODO (b5) - bring this back in the near future for fetching home feed
-async function postCrashReport (err, errInfo): Promise<any> {
-  const options: FetchOptions = {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      app: 'desktop',
-      version: versions.desktopVersion,
-      platform: navigator.platform,
-      error: err.toString(),
-      info: errInfo.componentStack
-    })
-  }
-
-  console.log(CRASH_REPORTER_URL)
-  const r = await fetch(CRASH_REPORTER_URL, options)
-  const res = await r.json()
-  return res
 }

--- a/app/components/IncompatibleBackend.tsx
+++ b/app/components/IncompatibleBackend.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import WelcomeTemplate from './onboard/WelcomeTemplate'
+import ExternalLink from './ExternalLink'
+import { backendVersion } from '../../version.js'
+
+interface IncompatibleBackendProps {
+  incompatibleVersion: string
+}
+
+const IncompatibleBackend: React.FC<IncompatibleBackendProps> = ({ incompatibleVersion }) => (
+  <WelcomeTemplate title='Incompatible Backend Version'>
+    <p>{`Incorrect backend version supplied. Expected qri v${backendVersion}, but have ${incompatibleVersion}. Please file an issue `}
+      <ExternalLink id="file-issue" href="https://github.com/qri-io/desktop/issues/new">here</ExternalLink>.
+    </p>
+  </WelcomeTemplate>
+)
+
+export default IncompatibleBackend

--- a/app/components/IncompatibleBackend.tsx
+++ b/app/components/IncompatibleBackend.tsx
@@ -1,17 +1,19 @@
 import React from 'react'
 import WelcomeTemplate from './onboard/WelcomeTemplate'
 import ExternalLink from './ExternalLink'
-import { backendVersion } from '../../version.js'
 
 interface IncompatibleBackendProps {
   incompatibleVersion: string
 }
 
+// TODO: this variable needs to be replaced when the
+// lowestCompatibleBackend variable exists in backend.js
+const lowestCompatibleBackend = '0.9.8'
+
 const IncompatibleBackend: React.FC<IncompatibleBackendProps> = ({ incompatibleVersion }) => (
   <WelcomeTemplate title='Incompatible Backend Version'>
-    <p>{`Incorrect backend version supplied. Expected qri v${backendVersion}, but have v${incompatibleVersion}. Please file an issue `}
-      <ExternalLink id="file-issue" href="https://github.com/qri-io/desktop/issues/new">here</ExternalLink>.
-    </p>
+    <p>{`The lowest supported backend version is v${lowestCompatibleBackend}, but you are running on v${incompatibleVersion}.`}</p>
+    <p>Please file an issue <ExternalLink id="file-issue" href="https://github.com/qri-io/desktop/issues/new">here</ExternalLink>.</p>
   </WelcomeTemplate>
 )
 

--- a/app/components/IncompatibleBackend.tsx
+++ b/app/components/IncompatibleBackend.tsx
@@ -9,7 +9,7 @@ interface IncompatibleBackendProps {
 
 const IncompatibleBackend: React.FC<IncompatibleBackendProps> = ({ incompatibleVersion }) => (
   <WelcomeTemplate title='Incompatible Backend Version'>
-    <p>{`Incorrect backend version supplied. Expected qri v${backendVersion}, but have ${incompatibleVersion}. Please file an issue `}
+    <p>{`Incorrect backend version supplied. Expected qri v${backendVersion}, but have v${incompatibleVersion}. Please file an issue `}
       <ExternalLink id="file-issue" href="https://github.com/qri-io/desktop/issues/new">here</ExternalLink>.
     </p>
   </WelcomeTemplate>

--- a/app/components/MigratingBackend.tsx
+++ b/app/components/MigratingBackend.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import WelcomeTemplate from './onboard/WelcomeTemplate'
+
+const MigratingBackend: React.FC<{}> = () => (
+  <WelcomeTemplate title='Migrating the Qri backend' subtitle='This might take a minute...' loading/>
+)
+
+export default MigratingBackend

--- a/app/components/MigrationFailed.tsx
+++ b/app/components/MigrationFailed.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import CrashReportSender from './CrashReportSender'
+import ReportCrashAndReload from './ReportCrashAndReload'
 
-const MigrationFailed: React.FC<{}> = () => <CrashReportSender title='The Qri backend migration failed!'/>
+const MigrationFailed: React.FC<{}> = () => <ReportCrashAndReload title='The Qri backend migration failed!'/>
 
 export default MigrationFailed

--- a/app/components/MigrationFailed.tsx
+++ b/app/components/MigrationFailed.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import CrashReportSender from './CrashReportSender'
+
+const MigrationFailed: React.FC<{}> = () => <CrashReportSender title='The Qri backend migration failed!'/>
+
+export default MigrationFailed

--- a/app/components/ReportCrashAndReload.tsx
+++ b/app/components/ReportCrashAndReload.tsx
@@ -6,7 +6,7 @@ import { FetchOptions } from '../store/api'
 import versions from '../../version'
 import { CRASH_REPORTER_URL } from '../constants'
 
-interface CrashReportSenderProps extends ErrorProps {
+interface ReportCrashAndReloadProps extends ErrorProps {
   title: string
 }
 
@@ -15,7 +15,7 @@ export interface ErrorProps {
   errorInfo?: React.ErrorInfo
 }
 
-const CrashReportSender: React.FC<CrashReportSenderProps> = ({ title, error, errorInfo }) => {
+const ReportCrashAndReload: React.FC<ReportCrashAndReloadProps> = ({ title, error, errorInfo }) => {
   const [sendingReport, setSendingReport] = useState(false)
   const [sentReport, setSentReport] = useState(false)
 
@@ -87,4 +87,4 @@ const postCrashReport = async (error: ErrorProps['error'], errorInfo: ErrorProps
   return res
 }
 
-export default CrashReportSender
+export default ReportCrashAndReload

--- a/stories/AppLaunch.stories.tsx
+++ b/stories/AppLaunch.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+import IncompatibleBackend from '../app/components/IncompatibleBackend'
+import MigratingBackend from '../app/components/MigratingBackend'
+import MigrationFailed from '../app/components/MigrationFailed'
+
+export default {
+  title: 'App Launch',
+  parameters: {
+    notes: 'List of migration components rendered on app launch'
+  }
+}
+
+export const incompatibleBackend = () => (<IncompatibleBackend incompatibleVersion='0.0.1'/>)
+
+incompatibleBackend.story = {
+  name: 'Incompatible Backend',
+  parameters: { note: 'Screen when user is running an incompatible backend qri version' }
+}
+
+export const migratingBackend = () => <MigratingBackend />
+
+migratingBackend.story = {
+  name: 'Migrating Backend',
+  parameters: { note: 'Screen when backend is in the process of migrating' }
+}
+
+export const migrationFailed = () => <MigrationFailed />
+
+migratingBackend.story = {
+  name: 'Migration Failed',
+  parameters: { note: 'Screen when backend migration has failed' }
+}

--- a/stories/AppLaunch.stories.tsx
+++ b/stories/AppLaunch.stories.tsx
@@ -27,7 +27,7 @@ migratingBackend.story = {
 
 export const migrationFailed = () => <MigrationFailed />
 
-migratingBackend.story = {
+migrationFailed.story = {
   name: 'Migration Failed',
   parameters: { note: 'Screen when backend migration has failed' }
 }

--- a/stories/AppLaunch.stories.tsx
+++ b/stories/AppLaunch.stories.tsx
@@ -7,7 +7,7 @@ import MigrationFailed from '../app/components/MigrationFailed'
 export default {
   title: 'App Launch',
   parameters: {
-    notes: 'List of migration components rendered on app launch'
+    notes: 'List of migration components conditionally rendered on app launch'
   }
 }
 

--- a/stories/Error.stories.tsx
+++ b/stories/Error.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import CrashReportSender from '../app/components/CrashReportSender'
+import ReportCrashAndReload from '../app/components/ReportCrashAndReload'
 
 export default {
   title: 'Error',
@@ -9,7 +9,7 @@ export default {
   }
 }
 
-const crashReportSenderProps = {
+const reportCrashAndReloadProps = {
   title: 'Storybook test has crashed',
   error: new Error('Test error for Storybook!'),
   errorInfo: { 
@@ -19,9 +19,9 @@ const crashReportSenderProps = {
     in App` }
 }
   
-export const crashReportSender = () => (<CrashReportSender {...crashReportSenderProps}/>)
+export const reportCrashAndReload = () => (<ReportCrashAndReload {...reportCrashAndReloadProps}/>)
   
-crashReportSender.story = {
-  name: 'Crash Report Sender',
+reportCrashAndReload.story = {
+  name: 'Report Crash and Reload',
   parameters: { note: 'Screen when app throws an error and is caught. Prompts error report, issue and reload CTAs' }
 }

--- a/stories/Error.stories.tsx
+++ b/stories/Error.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import CrashReportSender from '../app/components/CrashReportSender'
+
+export default {
+  title: 'Error',
+  parameters: {
+      notes: 'Application error handling'
+  }
+}
+
+const crashReportSenderProps = {
+  title: 'Storybook test has crashed',
+  error: new Error('Test error for Storybook!'),
+  errorInfo: { 
+    componentStack: `in ComponentThatThrows (created by App)
+    in ErrorBoundary (created by App)
+    in div (created by App)
+    in App` }
+}
+  
+export const crashReportSender = () => (<CrashReportSender {...crashReportSenderProps}/>)
+  
+crashReportSender.story = {
+  name: 'Crash Report Sender',
+  parameters: { note: 'Screen when app throws an error and is caught. Prompts error report, issue and reload CTAs' }
+}


### PR DESCRIPTION
closes #567 

Builds the following new components for use in Desktop's handling of the backend qri migration:
1. `IncompatibleBackend`
2. `MigratingBackend`
3. `MigrationFailed`

Also builds new `ReportCrashAndReload` component to modulate functionality which can be shared by existing `ErrorHandler` component and new `MigrationFailed` one