### PR TITLE
feat(migration): adjust `BackendProcess`, `main.dev.js` & `App.ts` so we can coordinate migrations!

### DIFF
--- a/app/actions/ui.ts
+++ b/app/actions/ui.ts
@@ -9,10 +9,11 @@ import {
   UI_SET_DATASET_DIR_PATH,
   UI_SET_EXPORT_PATH,
   UI_SET_DETAILS_BAR,
-  UI_SET_IMPORT_FILE_DETAILS
+  UI_SET_IMPORT_FILE_DETAILS,
+  UI_SET_BOOTUP_COMPONENT
 } from '../reducers/ui'
 
-import { ToastType } from '../models/store'
+import { ToastType, BootupComponentType } from '../models/store'
 import { Modal, ModalType } from '../models/modals'
 import { Details } from '../models/details'
 
@@ -98,5 +99,12 @@ export const setImportFileDetails = (fileName: string, fileSize: number) => {
     type: UI_SET_IMPORT_FILE_DETAILS,
     fileName,
     fileSize
+  }
+}
+
+export const setBootupComponent = (component: BootupComponentType) => {
+  return {
+    type: UI_SET_BOOTUP_COMPONENT,
+    component
   }
 }

--- a/app/backend.js
+++ b/app/backend.js
@@ -148,7 +148,7 @@ class BackendProcess {
 
   async checkBackendCompatibility () {
     log.info(`checking to see if given backend version ${this.backendVer} is compatible with expected version ${lowestCompatibleBackend.join(".")}`)
-    var compatible = false
+    let compatible = false
     try {
       let ver = this.backendVer
       if (this.backendVer.indexOf("-dev") !== -1) {
@@ -157,12 +157,15 @@ class BackendProcess {
       ver = ver.split(".").map((i) => parseInt(i))
       compatible = lowestCompatibleBackend.every((val, i) => {
         if (val <= ver[i]) {
-          return
+          return true
         }
-        throw new Error("incompatible-backend")
+        return false
       })
     } catch (e) {
       throw e
+    }
+    if (!compatible) {
+      throw new Error("incompatible-backend")
     }
   }
 

--- a/app/backend.js
+++ b/app/backend.js
@@ -7,8 +7,7 @@ const os = require('os')
 const http = require('http')
 const { dialog } = require('electron')
 
-var lowestCompatibleBackend = [0, 9, 9]
-var lowestCompatibleConfigRevision = 2
+const lowestCompatibleBackend = [0, 9, 9]
 
 // BackendProcess runs the qri backend binary in connected'ed mode, to handle api requests.
 class BackendProcess {
@@ -154,7 +153,7 @@ class BackendProcess {
 
   launchProcess () {
     try {
-      this.process = childProcess.spawn(this.qriBinPath, ['connect', '--migrate', '--log-all'], { stdio: ['ignore', this.out, this.err] })
+      this.process = childProcess.spawn(this.qriBinPath, ['connect', '--migrate', '--log-all', '--setup', '--no-prompt'], { stdio: ['ignore', this.out, this.err] })
       this.process.on('error', (err) => { this.handleEvent('error', err) })
       this.process.on('exit', (err) => { this.handleEvent('exit', err) })
       this.process.on('close', (err) => { this.handleEvent('close', err) })
@@ -177,7 +176,7 @@ class BackendProcess {
   checkNeedsMigration() {
     log.info("checking for backend migrations")
     try {
-      childProcess.execSync(`"${this.qriBinPath}" list`)
+      childProcess.execSync(`"${this.qriBinPath}" config get`)
     } catch (err) {
       // status code 2 means we need to run a migration
       if (err.status == 2) {

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -13,19 +13,19 @@ import { DEFAULT_POLL_INTERVAL } from '../constants'
 import { history } from '../store/configureStore.development'
 import { ApiAction } from '../store/api'
 import { Modal, ModalType } from '../models/modals'
-import { Selections, ApiConnection } from '../models/store'
+import { Selections, ApiConnection, BootupComponentType } from '../models/store'
 import { Session } from '../models/session'
 
 // import util funcs
 import { connectComponentToProps } from '../utils/connectComponentToProps'
 
 // import actions
-import { setModal } from '../actions/ui'
+import { setModal, setBootupComponent } from '../actions/ui'
 import { pingApi } from '../actions/api'
 import { bootstrap } from '../actions/session'
 
 // import selections
-import { selectSelections, selectModal, selectApiConnection, selectSession } from '../selections'
+import { selectSelections, selectModal, selectApiConnection, selectSession, selectBootupComponent } from '../selections'
 
 // import components
 import Toast from './Toast'
@@ -34,10 +34,14 @@ import AppError from './AppError'
 import AppLoading from './AppLoading'
 import Modals from './modals/Modals'
 import Routes from '../routes'
+import MigratingBackend from './MigratingBackend'
+import MigrationFailed from './MigrationFailed'
+import IncompatibleBackend from './IncompatibleBackend'
 
 // declare interface for props
 export interface AppProps {
   loading: boolean
+  bootupComponent: BootupComponentType
   session: Session
   selections: Selections
   apiConnection?: ApiConnection
@@ -46,6 +50,7 @@ export interface AppProps {
 
   push: (path: string) => void
   setModal: (modal: Modal) => Action
+  setBootupComponent: (component: BootupComponentType) => Action
 
   bootstrap: () => Promise<ApiAction>
   pingApi: () => Promise<ApiAction>
@@ -73,6 +78,14 @@ class AppComponent extends React.Component<AppProps, AppState> {
     this.handleReload = this.handleReload.bind(this)
     this.handleSetDebugLogPath = this.handleSetDebugLogPath.bind(this)
     this.handleExportDebugLog = this.handleExportDebugLog.bind(this)
+    this.handleIncompatibleBackend = this.handleIncompatibleBackend.bind(this)
+    this.handleMigratingBackend = this.handleMigratingBackend.bind(this)
+    this.handleMigrationFailure = this.handleMigrationFailure.bind(this)
+    this.handleStartingBackend = this.handleStartingBackend.bind(this)
+  }
+
+  private handleStartingBackend () {
+    console.log("started backend message received")
   }
 
   private handleCreateDataset () {
@@ -112,6 +125,21 @@ class AppComponent extends React.Component<AppProps, AppState> {
     fs.copyFileSync(this.state.debugLogPath, exportFilename)
   }
 
+  private handleIncompatibleBackend (_: Electron.IpcRendererEvent, ver: string) {
+    console.log('incompatible event triggered')
+    this.props.setBootupComponent(ver)
+  }
+
+  private handleMigratingBackend () {
+    console.log('migration triggered')
+    this.props.setBootupComponent('migrating')
+  }
+
+  private handleMigrationFailure () {
+    console.log("migration failure triggered")
+    this.props.setBootupComponent('migrationFailure')
+  }
+
   componentDidMount () {
     // handle ipc events from electron menus
     ipcRenderer.on('create-dataset', this.handleCreateDataset)
@@ -120,6 +148,12 @@ class AppComponent extends React.Component<AppProps, AppState> {
     ipcRenderer.on('set-debug-log-path', this.handleSetDebugLogPath)
     ipcRenderer.on('export-debug-log', this.handleExportDebugLog)
     ipcRenderer.on('reload', this.handleReload)
+    ipcRenderer.on('incompatible-backend', this.handleIncompatibleBackend)
+    ipcRenderer.on('migrating-backend', this.handleMigratingBackend)
+    ipcRenderer.on('migration-failed', this.handleMigrationFailure)
+    ipcRenderer.on("starting-backend", this.handleStartingBackend)
+
+    ipcRenderer.send("app-fully-loaded")
 
     setInterval(() => {
       if (this.props.apiConnection !== 1) {
@@ -138,6 +172,10 @@ class AppComponent extends React.Component<AppProps, AppState> {
     ipcRenderer.removeListener('history-push', this.handlePush)
     ipcRenderer.removeListener('set-debug-log-path', this.handleSetDebugLogPath)
     ipcRenderer.removeListener('reload', this.handleReload)
+    ipcRenderer.removeListener('incompatible-backend', this.handleIncompatibleBackend)
+    ipcRenderer.removeListener('migrating-backend', this.handleMigratingBackend)
+    ipcRenderer.removeListener('migration-failed', this.handleMigrationFailure)
+    ipcRenderer.removeListener("starting-backend", this.handleStartingBackend)
   }
 
   componentDidUpdate (prevProps: AppProps) {
@@ -151,20 +189,52 @@ class AppComponent extends React.Component<AppProps, AppState> {
   }
 
   render () {
-    const { apiConnection, modal, loading } = this.props
+    const { apiConnection, modal, loading, bootupComponent } = this.props
 
     if (loading) {
       return (
-        <CSSTransition
-          in={loading}
-          classNames="fade"
-          component="div"
-          timeout={1000}
-          mountOnEnter
-          unmountOnExit
-        >
-          <AppLoading />
-        </CSSTransition>
+        <>
+          <CSSTransition
+            in={bootupComponent === 'loading'}
+            classNames="fade"
+            component="div"
+            timeout={1000}
+            mountOnEnter
+            unmountOnExit
+          >
+            <AppLoading />
+          </CSSTransition>
+          <CSSTransition
+            in={bootupComponent === 'migrating'}
+            classNames="fade"
+            component="div"
+            timeout={1000}
+            mountOnEnter
+            unmountOnExit
+          >
+            <MigratingBackend />
+          </CSSTransition>
+          <CSSTransition
+            in={bootupComponent === 'migrationFailure'}
+            classNames="fade"
+            component="div"
+            timeout={1000}
+            mountOnEnter
+            unmountOnExit
+          >
+            <MigrationFailed />
+          </CSSTransition>
+          <CSSTransition
+            in={bootupComponent !== 'loading' && bootupComponent !== 'migrating' && bootupComponent !== 'migrationFailure'}
+            classNames="fade"
+            component="div"
+            timeout={1000}
+            mountOnEnter
+            unmountOnExit
+          >
+            <IncompatibleBackend incompatibleVersion={bootupComponent} />
+          </CSSTransition>
+        </>
       )
     }
 
@@ -228,6 +298,7 @@ export default connectComponentToProps(
       selections: selectSelections(state),
       apiConnection,
       modal: selectModal(state),
+      bootupComponent: selectBootupComponent(state),
       ...ownProps
     }
   },
@@ -236,6 +307,7 @@ export default connectComponentToProps(
     push,
     setModal,
     bootstrap,
+    setBootupComponent,
     pingApi
   }
 )

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -126,17 +126,14 @@ class AppComponent extends React.Component<AppProps, AppState> {
   }
 
   private handleIncompatibleBackend (_: Electron.IpcRendererEvent, ver: string) {
-    console.log('incompatible event triggered')
     this.props.setBootupComponent(ver)
   }
 
   private handleMigratingBackend () {
-    console.log('migration triggered')
     this.props.setBootupComponent('migrating')
   }
 
   private handleMigrationFailure () {
-    console.log("migration failure triggered")
     this.props.setBootupComponent('migrationFailure')
   }
 

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -127,43 +127,6 @@ app.on('ready', () =>
         mainWindow.webContents.send('set-debug-log-path', backendProcess.debugLogPath)
       })
 
-      backendProcess = new BackendProcess()
-      backendProcess.checkNoActiveBackendProcess()
-      .then(backendProcess.checkBackendCompatibility)
-      .then(backendProcess.checkNeedsMigration)
-      .then((needsMigration) => {
-        if (needsMigration) {
-          log.info("migrating backend")
-          // this doesn't trigger migrations, which happens automatically
-          // when we run `launchProcess`, but instead alerts the user
-          // that we are running a migration and it might take a moment
-          mainWindow.webContents.send("migrating-backend")
-        }
-      })
-      .then(backendProcess.launchProcess)
-      .catch(err => {
-        switch (err.message) {
-          case "backend-already-running":
-            log.info("a qri backend is already running at port 2503")
-            mainWindow.webContents.send("backend-already-running")
-            return
-          case "incompatible-backend":
-            log.info("qri backend is incompatible")
-            mainWindow.webContents.send("incompatible-backend", backendProcess.backendVer)
-            return
-          case "migration-failed":
-            log.debug("migration-failed")
-            mainWindow.webContents.send("migration-failed")
-            return
-          case "error-launching-backend":
-            log.debug("error-launching-backend")
-            mainWindow.webContents.send("error-launching-backend")
-            return
-          default:
-            log.error(err.message)
-        }
-      })
-
       mainWindow.on('closed', () => {
         mainWindow = null
       })
@@ -588,5 +551,49 @@ app.on('ready', () =>
         quitting = true
       })
 
+      ipcMain.on('app-fully-loaded', () => {
+        log.info("starting backend process")
+        backendProcess = new BackendProcess()
+        backendProcess.checkNoActiveBackendProcess()
+        .then(backendProcess.checkBackendCompatibility)
+        .then(backendProcess.checkNeedsMigration)
+        .then((needsMigration) => {
+          if (needsMigration) {
+            log.info("migrating backend")
+            // this doesn't trigger migrations, which happens automatically
+            // when we run `launchProcess`, but instead alerts the user
+            // that we are running a migration and it might take a moment
+            mainWindow.webContents.send("migrating-backend")
+          }
+        })
+        .then(backendProcess.launchProcess)
+        .catch(err => {
+          switch (err.message) {
+            case "backend-already-running":
+              log.info("a qri backend is already running at port 2503")
+              mainWindow.webContents.send("backend-already-running")
+              break
+            case "incompatible-backend":
+              log.info("qri backend is incompatible")
+              mainWindow.webContents.send("incompatible-backend", backendProcess.backendVer)
+              break
+            case "migration-failed":
+              log.debug("migration-failed")
+              mainWindow.webContents.send("migration-failed")
+              break
+            case "error-launching-backend":
+              log.debug("error-launching-backend")
+              mainWindow.webContents.send("error-launching-backend")
+              break
+            default:
+              log.error(err.message)
+          }
+          // if we error here, we should close the process
+          log.info("closing backend process")
+          backendProcess.close()
+        })
+      })
+
       log.info('app launched')
-    }))
+    })
+  )

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -75,7 +75,10 @@ export interface UI {
   detailsBar: Details
   importFileName: string
   importFileSize: number
+  bootupComponent: BootupComponentType
 }
+
+export type BootupComponentType = 'loading' | 'migrating' | 'migrationFailure' | string
 
 export type SelectedComponent = 'commit' | 'readme' | 'meta' | 'body' | 'structure' | 'transform' | ''
 

--- a/app/reducers/ui.ts
+++ b/app/reducers/ui.ts
@@ -24,6 +24,7 @@ export const UI_SET_DATASET_DIR_PATH = 'UI_SET_DATASET_DIR_PATH'
 export const UI_SET_EXPORT_PATH = 'UI_SET_EXPORT_PATH'
 export const UI_SET_DETAILS_BAR = 'UI_SET_DETAILS_BAR'
 export const UI_SET_IMPORT_FILE_DETAILS = 'UI_SET_IMPORT_FILE_DETAILS'
+export const UI_SET_BOOTUP_COMPONENT = 'UI_SET_BOOTUP_COMPONENT'
 
 export const UNAUTHORIZED = 'UNAUTHORIZED'
 
@@ -62,7 +63,8 @@ const initialState = {
   modal: { type: ModalType.NoModal },
   detailsBar: { type: DetailsType.NoDetails },
   importFileName: '',
-  importFileSize: 0
+  importFileSize: 0,
+  bootupComponent: 'loading'
 }
 
 // send an event to electron to block menus on first load
@@ -206,6 +208,12 @@ export default (state = initialState, action: AnyAction) => {
         importFileName: fileName
       }
 
+    case UI_SET_BOOTUP_COMPONENT:
+      const { component } = action
+      return {
+        ...state,
+        bootupComponent: component
+      }
     default:
       return state
   }

--- a/app/selections.ts
+++ b/app/selections.ts
@@ -10,7 +10,8 @@ import Store, {
   Selections,
   Toast,
   ApiConnection,
-  StatusInfo
+  StatusInfo,
+  BootupComponentType
 } from './models/store'
 import { Details, DetailsType } from "./models/details"
 import { datasetToVersionInfo } from "./actions/mappingFuncs"
@@ -309,6 +310,9 @@ export function selectToast (state: Store): Toast {
   return state.ui.toast
 }
 
+export function selectBootupComponent (state: Store): BootupComponentType {
+  return state.ui.bootupComponent
+}
 /**
  *
  * WORKINGDATASET STATE TREE


### PR DESCRIPTION
closes #566 

My journey through this process has been decently well chronicled in the above issue!

My last comment would be, very open to re-structuring `BackendProcess` to take a `window` so that the main function is less unwieldy and is less responsible for coordinating the behavior. However, it might be nice to keep all the emitted events in the `main.development.js` file, so that behavior isn't hidden down in another class. Anyone have strong opinions?

Edit:
Backend is getting a refactor! Now commands won't "auto-trigger" a migration, unless you have the `--migrations` flag. And a command will fail w/ an exit error (`2`) if the config needs a migration. We can use these to remove the desktop's reliance on knowing about the QRI_PATH and keeping track of config revisions!
