### PR TITLE
refactor(*): changes to get desktop to work with qri v0.9.9/v0.9.10 changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.14.1-node-browsers
+      - image: circleci/golang:1.14.6-node-browsers
         environment:
           GO111MODULE: "on"
     working_directory: ~/desktop

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -486,7 +486,7 @@ export function publishDataset (username: string, name: string): ApiActionThunk 
     try {
       let response: Action
       response = await dispatch(action)
-      await whenOk(fetchWorkingDataset(username, name))(response)
+      await whenOk(fetchLog(username, name))(response)
     } catch (action) {
       throw action
     }
@@ -513,7 +513,7 @@ export function unpublishDataset (username: string, name: string): ApiActionThun
     try {
       let response: Action
       response = await dispatch(action)
-      await whenOk(fetchWorkingDataset(username, name))(response)
+      await whenOk(fetchLog(username, name))(response)
     } catch (action) {
       throw action
     }

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -711,7 +711,7 @@ export function renameDataset (username: string, name: string, newName: string):
         method: 'POST',
         body: {
           current: `${username}/${name}`,
-          new: `${username}/${newName}`
+          next: `${username}/${newName}`
         }
       }
     }

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -508,7 +508,8 @@ export function unpublishDataset (username: string, name: string): ApiActionThun
           name
         },
         query: {
-          remote: 'registry'
+          remote: 'registry',
+          all: true
         }
       }
     }

--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -432,12 +432,12 @@ export function saveWorkingDatasetAndFetch (username: string, name: string): Api
   }
 }
 
-export function addDataset (username: string, name: string): ApiActionThunk {
+export function pullDataset (username: string, name: string): ApiActionThunk {
   return async (dispatch) => {
     const action = {
-      type: 'add',
+      type: 'pull',
       [CALL_API]: {
-        endpoint: 'add',
+        endpoint: 'pull',
         method: 'POST',
         segments: {
           username,
@@ -450,13 +450,13 @@ export function addDataset (username: string, name: string): ApiActionThunk {
   }
 }
 
-export function addDatasetAndFetch (username: string, name: string): ApiActionThunk {
+export function pullDatasetAndFetch (username: string, name: string): ApiActionThunk {
   return async (dispatch, getState) => {
     const whenOk = chainSuccess(dispatch, getState)
     let response: Action
 
     try {
-      response = await addDataset(username, name)(dispatch, getState)
+      response = await pullDataset(username, name)(dispatch, getState)
       // reset pagination
       response = await whenOk(fetchMyDatasets(-1))(response)
       dispatch(push(pathToDataset(username, name, '')))
@@ -474,7 +474,7 @@ export function publishDataset (username: string, name: string): ApiActionThunk 
     const action = {
       type: 'publish',
       [CALL_API]: {
-        endpoint: 'publish',
+        endpoint: 'push',
         method: 'POST',
         segments: {
           username,
@@ -501,11 +501,14 @@ export function unpublishDataset (username: string, name: string): ApiActionThun
     const action = {
       type: 'unpublish',
       [CALL_API]: {
-        endpoint: 'publish',
+        endpoint: 'remove',
         method: 'DELETE',
         segments: {
           username,
           name
+        },
+        query: {
+          remote: 'registry'
         }
       }
     }

--- a/app/backend.js
+++ b/app/backend.js
@@ -1,7 +1,6 @@
 const log = require('electron-log')
 const childProcess = require('child_process')
 const fs = require('fs')
-const yaml = require('js-yaml')
 const path = require('path')
 const os = require('os')
 const http = require('http')

--- a/app/backend.js
+++ b/app/backend.js
@@ -110,6 +110,7 @@ class BackendProcess {
   }
 
   async checkNoActiveBackendProcess() {
+    log.info("checking for active backend process")
     const healthCheck = async () => {
       return new Promise((res, rej) => {
         http.get('http://localhost:2503/health', (data) => {

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -73,7 +73,7 @@ class AppComponent extends React.Component<AppProps, AppState> {
     }
 
     this.handleCreateDataset = this.handleCreateDataset.bind(this)
-    this.handleAddDataset = this.handleAddDataset.bind(this)
+    this.handlePullDataset = this.handlePullDataset.bind(this)
     this.handlePush = this.handlePush.bind(this)
     this.handleReload = this.handleReload.bind(this)
     this.handleSetDebugLogPath = this.handleSetDebugLogPath.bind(this)
@@ -92,8 +92,8 @@ class AppComponent extends React.Component<AppProps, AppState> {
     this.props.setModal({ type: ModalType.CreateDataset })
   }
 
-  private handleAddDataset () {
-    this.props.setModal({ type: ModalType.AddDataset })
+  private handlePullDataset () {
+    this.props.setModal({ type: ModalType.PullDataset })
   }
 
   private handlePush (e: any, route: string) {
@@ -140,7 +140,7 @@ class AppComponent extends React.Component<AppProps, AppState> {
   componentDidMount () {
     // handle ipc events from electron menus
     ipcRenderer.on('create-dataset', this.handleCreateDataset)
-    ipcRenderer.on('add-dataset', this.handleAddDataset)
+    ipcRenderer.on('pull-dataset', this.handlePullDataset)
     ipcRenderer.on('history-push', this.handlePush)
     ipcRenderer.on('set-debug-log-path', this.handleSetDebugLogPath)
     ipcRenderer.on('export-debug-log', this.handleExportDebugLog)
@@ -165,7 +165,7 @@ class AppComponent extends React.Component<AppProps, AppState> {
 
   componentWillUnmount () {
     ipcRenderer.removeListener('create-dataset', this.handleCreateDataset)
-    ipcRenderer.removeListener('add-dataset', this.handleAddDataset)
+    ipcRenderer.removeListener('pull-dataset', this.handlePullDataset)
     ipcRenderer.removeListener('history-push', this.handlePush)
     ipcRenderer.removeListener('set-debug-log-path', this.handleSetDebugLogPath)
     ipcRenderer.removeListener('reload', this.handleReload)

--- a/app/components/collection/CollectionHome.tsx
+++ b/app/components/collection/CollectionHome.tsx
@@ -74,9 +74,9 @@ export const CollectionHomeComponent: React.FunctionComponent<CollectionHomeProp
         />
         <HeaderColumnButton
           icon={faDownload}
-          id='add-dataset'
+          id='pull-dataset'
           label='Add existing Dataset'
-          onClick={() => { setModal({ type: ModalType.AddDataset }) }}
+          onClick={() => { setModal({ type: ModalType.PullDataset }) }}
         />
       </div>
       <div className='main-content-flex'>

--- a/app/components/modals/Modals.tsx
+++ b/app/components/modals/Modals.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { ModalType } from '../../models/modals'
 
-import AddDataset from './AddDataset'
+import PullDataset from './PullDataset'
 import LinkDataset from './LinkDataset'
 import RemoveDataset from './RemoveDataset'
 import CreateDataset from './CreateDataset'
@@ -16,8 +16,8 @@ export interface ModalsProps {
 
 const Modals: React.FunctionComponent<ModalsProps> = ({ type }) => {
   switch (type) {
-    case ModalType.AddDataset:
-      return <AddDataset />
+    case ModalType.PullDataset:
+      return <PullDataset />
     case ModalType.CreateDataset:
       return <CreateDataset />
     case ModalType.LinkDataset:

--- a/app/components/modals/PullDataset.tsx
+++ b/app/components/modals/PullDataset.tsx
@@ -6,7 +6,7 @@ import { ApiAction } from '../../store/api'
 import { validateDatasetReference } from '../../utils/formValidation'
 import { connectComponentToProps } from '../../utils/connectComponentToProps'
 
-import { addDatasetAndFetch } from '../../actions/api'
+import { pullDatasetAndFetch } from '../../actions/api'
 import { dismissModal } from '../../actions/ui'
 
 import Modal from './Modal'
@@ -15,17 +15,17 @@ import DebouncedTextInput from '../form/DebouncedTextInput'
 import Error from './Error'
 import Buttons from './Buttons'
 
-interface AddDatasetProps {
+interface PullDatasetProps {
   // func to call when we cancel or click away from the modal
   onDismissed: () => void
   // func to call when we hit submit, this adds the dataset from the network
-  addDatasetAndFetch: (peername: string, name: string) => Promise<ApiAction>
+  pullDatasetAndFetch: (peername: string, name: string) => Promise<ApiAction>
 }
 
-const AddDatasetComponent: React.FunctionComponent<AddDatasetProps> = (props) => {
+const PullDatasetComponent: React.FunctionComponent<PullDatasetProps> = (props) => {
   const {
     onDismissed,
-    addDatasetAndFetch
+    pullDatasetAndFetch
   } = props
 
   const [datasetReference, setDatasetReference] = React.useState('')
@@ -57,10 +57,10 @@ const AddDatasetComponent: React.FunctionComponent<AddDatasetProps> = (props) =>
     setLoading(true)
     error && setError('')
 
-    if (!addDatasetAndFetch) return
+    if (!pullDatasetAndFetch) return
     const [peername, datasetName] = datasetReference.split('/')
 
-    addDatasetAndFetch(peername, datasetName)
+    pullDatasetAndFetch(peername, datasetName)
       .then(() => { onDismissed() })
       .catch((action) => {
         setDismissable(true)
@@ -118,12 +118,12 @@ const AddDatasetComponent: React.FunctionComponent<AddDatasetProps> = (props) =>
 }
 
 export default connectComponentToProps(
-  AddDatasetComponent,
-  (state: any, ownProps: AddDatasetProps) => {
+  PullDatasetComponent,
+  (state: any, ownProps: PullDatasetProps) => {
     return ownProps
   },
   {
-    addDatasetAndFetch,
+    pullDatasetAndFetch,
     onDismissed: dismissModal
   }
 )

--- a/app/components/network/LogList.tsx
+++ b/app/components/network/LogList.tsx
@@ -33,7 +33,6 @@ const LogList: React.FunctionComponent<LogListProps> = ({ qriRef, history }) => 
 
   React.useEffect(() => {
     if (error !== '') setError('')
-    console.log('fetching!!!')
     fetchLogs()
   }, [qriRef.username, qriRef.name])
 

--- a/app/components/network/Network.tsx
+++ b/app/components/network/Network.tsx
@@ -9,7 +9,7 @@ import Store, { RouteProps, VersionInfo } from '../../models/store'
 import { connectComponentToProps } from '../../utils/connectComponentToProps'
 
 import { setSidebarWidth, openToast, SidebarTypes } from '../../actions/ui'
-import { addDatasetAndFetch } from '../../actions/api'
+import { pullDatasetAndFetch } from '../../actions/api'
 import {
   setActiveTab,
   setSelectedListItem
@@ -31,7 +31,7 @@ export interface NetworkProps extends RouteProps {
   importFileName: string
   importFileSize: number
 
-  addDatasetAndFetch: (username: string, name: string) => ApiActionThunk
+  pullDatasetAndFetch: (username: string, name: string) => ApiActionThunk
   toggleNetwork: () => Action
   setSidebarWidth: (type: SidebarTypes, sidebarWidth: number) => Action
 }
@@ -41,7 +41,7 @@ const NetworkComponent: React.FunctionComponent<NetworkProps> = (props) => {
     qriRef,
 
     inCollection,
-    addDatasetAndFetch,
+    pullDatasetAndFetch,
     sidebarWidth,
     setSidebarWidth
   } = props
@@ -98,7 +98,7 @@ const NetworkComponent: React.FunctionComponent<NetworkProps> = (props) => {
             qriRef.username && qriRef.name && !inCollection &&
               <SidebarActionButton
                 text='Clone Dataset'
-                onClick={() => addDatasetAndFetch(qriRef.username, qriRef.name)}
+                onClick={() => pullDatasetAndFetch(qriRef.username, qriRef.name)}
               />
           }
         </NetworkSidebar>
@@ -134,7 +134,7 @@ export default connectComponentToProps(
   },
   {
     openToast,
-    addDatasetAndFetch,
+    pullDatasetAndFetch,
     setActiveTab,
     setSidebarWidth,
     setSelectedListItem

--- a/app/components/workbench/NoDatasetsMainContent.tsx
+++ b/app/components/workbench/NoDatasetsMainContent.tsx
@@ -31,7 +31,7 @@ const NoDatasetsMainContentComponent: React.FunctionComponent<NoDatasetsProps> =
       <h5><FontAwesomeIcon icon={faDownload} />&nbsp;&nbsp;Create a Dataset</h5>
       <p>Choose a data file on your computer to create a new Qri dataset.</p>
     </div>
-    <div id='add_dataset' className='no-datasets-options' onClick={() => setModal && setModal({ type: ModalType.AddDataset })}>
+    <div id='add_dataset' className='no-datasets-options' onClick={() => setModal && setModal({ type: ModalType.PullDataset })}>
       <h5><FontAwesomeIcon icon={faPlus} />&nbsp;&nbsp;Add a Dataset</h5>
       <p>Copy an existing Qri dataset to your computer</p>
     </div>

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -205,11 +205,11 @@ app.on('ready', () =>
             }
           },
           {
-            id: 'add-dataset',
+            id: 'pull-dataset',
             label: 'Add a Dataset...',
             accelerator: 'CmdOrCtrl+D',
             click () {
-              mainWindow.webContents.send('add-dataset')
+              mainWindow.webContents.send('pull-dataset')
             }
           }
         ]
@@ -227,11 +227,11 @@ app.on('ready', () =>
             }
           },
           {
-            id: 'add-dataset',
+            id: 'pull-dataset',
             label: 'Add a Dataset...',
             accelerator: 'CmdOrCtrl+D',
             click () {
-              mainWindow.webContents.send('add-dataset')
+              mainWindow.webContents.send('pull-dataset')
             }
           },
           {
@@ -519,7 +519,7 @@ app.on('ready', () =>
         const blockableMenus = [
           'show-all',
           'new-dataset',
-          'add-dataset',
+          'pull-dataset',
           'show-status',
           'show-history',
           'publish-unpublish-dataset',

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -127,43 +127,6 @@ app.on('ready', () =>
         mainWindow.webContents.send('set-debug-log-path', backendProcess.debugLogPath)
       })
 
-      backendProcess = new BackendProcess()
-      backendProcess.checkNoActiveBackendProcess()
-      .then(backendProcess.checkBackendCompatibility)
-      .then(backendProcess.checkNeedsMigration)
-      .then((needsMigration) => {
-        if (needsMigration) {
-          log.info("migrating backend")
-          // this doesn't trigger migrations, which happens automatically
-          // when we run `launchProcess`, but instead alerts the user
-          // that we are running a migration and it might take a moment
-          mainWindow.webContents.send("migrating-backend")
-        }
-      })
-      .then(backendProcess.launchProcess)
-      .catch(err => {
-        switch (err.message) {
-          case "backend-already-running":
-            log.info("a qri backend is already running at port 2503")
-            mainWindow.webContents.send("backend-already-running")
-            return
-          case "incompatible-backend":
-            log.info("qri backend is incompatible")
-            mainWindow.webContents.send("incompatible-backend", backendProcess.backendVer)
-            return
-          case "migration-failed":
-            log.debug("migration-failed")
-            mainWindow.webContents.send("migration-failed")
-            return
-          case "error-launching-backend":
-            log.debug("error-launching-backend")
-            mainWindow.webContents.send("error-launching-backend")
-            return
-          default:
-            log.error(err.message)
-        }
-      })
-
       mainWindow.on('closed', () => {
         mainWindow = null
       })

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -127,6 +127,43 @@ app.on('ready', () =>
         mainWindow.webContents.send('set-debug-log-path', backendProcess.debugLogPath)
       })
 
+      backendProcess = new BackendProcess()
+      backendProcess.checkNoActiveBackendProcess()
+      .then(backendProcess.checkBackendCompatibility)
+      .then(backendProcess.checkNeedsMigration)
+      .then((needsMigration) => {
+        if (needsMigration) {
+          log.info("migrating backend")
+          // this doesn't trigger migrations, which happens automatically
+          // when we run `launchProcess`, but instead alerts the user
+          // that we are running a migration and it might take a moment
+          mainWindow.webContents.send("migrating-backend")
+        }
+      })
+      .then(backendProcess.launchProcess)
+      .catch(err => {
+        switch (err.message) {
+          case "backend-already-running":
+            log.info("a qri backend is already running at port 2503")
+            mainWindow.webContents.send("backend-already-running")
+            return
+          case "incompatible-backend":
+            log.info("qri backend is incompatible")
+            mainWindow.webContents.send("incompatible-backend", backendProcess.backendVer)
+            return
+          case "migration-failed":
+            log.debug("migration-failed")
+            mainWindow.webContents.send("migration-failed")
+            return
+          case "error-launching-backend":
+            log.debug("error-launching-backend")
+            mainWindow.webContents.send("error-launching-backend")
+            return
+          default:
+            log.error(err.message)
+        }
+      })
+
       mainWindow.on('closed', () => {
         mainWindow = null
       })

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -555,6 +555,15 @@ app.on('ready', () =>
         log.info("starting backend process")
         backendProcess = new BackendProcess()
         backendProcess.checkNoActiveBackendProcess()
+        .then(() => {
+          // at this point, we know that the backendProcess
+          // we have just created is the one we are going to
+          // be relying one
+          // we need to hold onto a reference to this process
+          // so we can close on app exit
+          log.info("backend process not detected")
+          this.backendProcess = backendProcess
+        })
         .then(backendProcess.checkBackendCompatibility)
         .then(backendProcess.checkNeedsMigration)
         .then((needsMigration) => {
@@ -593,7 +602,6 @@ app.on('ready', () =>
           backendProcess.close()
         })
       })
-
       log.info('app launched')
     })
   )

--- a/app/models/modals.ts
+++ b/app/models/modals.ts
@@ -1,7 +1,7 @@
 export enum ModalType {
   NoModal,
   CreateDataset,
-  AddDataset,
+  PullDataset,
   LinkDataset,
   RemoveDataset,
   PublishDataset,
@@ -9,8 +9,8 @@ export enum ModalType {
   Search
 }
 
-export interface AddDatasetModal {
-  type: ModalType.AddDataset
+export interface PullDatasetModal {
+  type: ModalType.PullDataset
 }
 
 export interface CreateDatasetModal {
@@ -52,7 +52,7 @@ export interface UnpublishDatasetModal {
   name: string
 }
 
-export type Modal = AddDatasetModal
+export type Modal = PullDatasetModal
 | CreateDatasetModal
 | LinkDatasetModal
 | HideModal

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -13,7 +13,7 @@ export enum ApiConnection {
 
 enum ModalType {
   CreateDataset,
-  AddDataset,
+  PullDataset,
 }
 
 export type ComponentType = 'component' | 'commit' | 'commitComponent'
@@ -25,7 +25,7 @@ type Modal =
   bodyPath?: string
 }
 | {
-  type: ModalType.AddDataset
+  type: ModalType.PullDataset
   initialURL?: string | null
 }
 

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -121,6 +121,8 @@ export interface VersionInfo {
   fsiPath: string
   // is block data for this commit stored locally?
   foreign: boolean
+  // published tells whether or not a dataset is published
+  published: boolean
 
   // dataset version details
   // dataset meta.Title field

--- a/app/selections.ts
+++ b/app/selections.ts
@@ -327,8 +327,12 @@ export function selectIsLinked (state: Store): boolean {
   return !!state.workingDataset.fsiPath && state.workingDataset.fsiPath !== ''
 }
 
+/** TODO (ramfox): right now, we only show the published status of the head
+ * dataset. The dataset is considered published if HEAD is published, and
+ * unpublished if HEAD is not published
+*/
 export function selectIsPublished (state: Store): boolean {
-  return state.workingDataset.published
+  return !!state.log.value && state.log.value.length > 0 && state.log.value[0].published
 }
 
 export function selectVersionInfoFromWorkingDataset (state: Store): VersionInfo {
@@ -356,8 +360,12 @@ export function selectWorkingDatasetIsLoading (state: Store): boolean {
   return state.workingDataset.isLoading
 }
 
+/** TODO (ramfox): right now, we only show the published status of the head
+ * dataset. The dataset is considered published if HEAD is published, and
+ * unpublished if HEAD is not published
+*/
 export function selectWorkingDatasetIsPublished (state: Store): boolean {
-  return state.workingDataset.published
+  return !!state.log.value && state.log.value.length > 0 && state.log.value[0].published
 }
 
 export function selectWorkingDatasetName (state: Store): string {

--- a/app/store/wsMiddleware.ts
+++ b/app/store/wsMiddleware.ts
@@ -15,15 +15,15 @@ export const wsDisconnect = () => ({ type: 'WS_DISCONNECT' })
 export const wsDisconnected = () => ({ type: 'WS_DISCONNECTED' })
 
 // ETCreatedNewFile is the event for creating a new file
-var ETCreatedNewFile = "watchfs:CreatedNewFile"
+const ETCreatedNewFile = "watchfs:CreatedNewFile"
 // ETModifiedFile is the event for modifying a file
-var ETModifiedFile = "watchfs:ModifiedFile"
+const ETModifiedFile = "watchfs:ModifiedFile"
 // ETDeletedFile is the event for deleting a file
-var ETDeletedFile = "watchfs:DeletedFile"
+const ETDeletedFile = "watchfs:DeletedFile"
 // ETRenamedFolder is the event for renaming a folder
-// var ETRenamedFolder = "watchfs:RenamedFolder"
+// const ETRenamedFolder = "watchfs:RenamedFolder"
 // ETRemovedFolder is the event for removing a folder
-// var ETRemovedFolder = "watchfs:RemovedFolder"
+// const ETRemovedFolder = "watchfs:RemovedFolder"
 
 const socketMiddleware = () => {
   let socket: WebSocket = null
@@ -38,33 +38,37 @@ const socketMiddleware = () => {
   }
 
   const onMessage = (store: Store<IStore>) => (e: MessageEvent) => {
-    const event = JSON.parse(e.data)
-    switch (event.type) {
-      case ETCreatedNewFile:
-      case ETModifiedFile:
-      case ETDeletedFile:
-        const { workingDataset } = store.getState()
-        const { peername, name, status } = workingDataset
-        // if the websocket message Username and Dsname match the peername and
-        // dataset name of the dataset that is currently being viewed, fetch
-        // status
-        if (peername && name && peername === event.data.Username && name === event.data.Dsname && !workingDataset.isWriting && !workingDataset.isSaving) {
-          const components = Object.keys(status)
-          components.forEach((component: string) => {
-            if (event.data.Source === status[component].filepath) {
-              const wsMtime = new Date(Date.parse(event.data.Time))
-              // if there is and mtime or if the ws mtime is older then the status mtime, don't refetch
-              if (status[component].mtime && !(status[component].mtime < wsMtime)) return
-              // if there is no mtime, or if the ws mtime is newer then the status mtime, fetch!
-              fetchWorkingDatasetDetails(peername, name)(store.dispatch, store.getState)
-              store.dispatch(resetMutationsDataset())
-              store.dispatch(resetMutationsStatus())
-            }
-          })
-        }
-        break
-      default:
-        console.log(event.type)
+    try {
+      const event = JSON.parse(e.data)
+      switch (event.type) {
+        case ETCreatedNewFile:
+        case ETModifiedFile:
+        case ETDeletedFile:
+          const { workingDataset } = store.getState()
+          const { peername, name, status } = workingDataset
+          // if the websocket message Username and Dsname match the peername and
+          // dataset name of the dataset that is currently being viewed, fetch
+          // status
+          if (peername && name && peername === event.data.Username && name === event.data.Dsname && !workingDataset.isWriting && !workingDataset.isSaving) {
+            const components = Object.keys(status)
+            components.forEach((component: string) => {
+              if (event.data.Source === status[component].filepath) {
+                const wsMtime = new Date(Date.parse(event.data.Time))
+                // if there is and mtime or if the ws mtime is older then the status mtime, don't refetch
+                if (status[component].mtime && !(status[component].mtime < wsMtime)) return
+                // if there is no mtime, or if the ws mtime is newer then the status mtime, fetch!
+                fetchWorkingDatasetDetails(peername, name)(store.dispatch, store.getState)
+                store.dispatch(resetMutationsDataset())
+                store.dispatch(resetMutationsStatus())
+              }
+            })
+          }
+          break
+        default:
+          console.log(`received websocket event: ${event.type}`)
+      }
+    } catch (e) {
+      console.log(`error parsing websocket message: ${e}`)
     }
   }
 

--- a/app/store/wsMiddleware.ts
+++ b/app/store/wsMiddleware.ts
@@ -48,11 +48,11 @@ const socketMiddleware = () => {
         // if the websocket message Username and Dsname match the peername and
         // dataset name of the dataset that is currently being viewed, fetch
         // status
-        if (peername && name && peername === event.data.Username && name === event.Dsname && !workingDataset.isWriting && !workingDataset.isSaving) {
+        if (peername && name && peername === event.data.Username && name === event.data.Dsname && !workingDataset.isWriting && !workingDataset.isSaving) {
           const components = Object.keys(status)
           components.forEach((component: string) => {
-            if (event.Source === status[component].filepath) {
-              const wsMtime = new Date(Date.parse(event.Time))
+            if (event.data.Source === status[component].filepath) {
+              const wsMtime = new Date(Date.parse(event.data.Time))
               // if there is and mtime or if the ws mtime is older then the status mtime, don't refetch
               if (status[component].mtime && !(status[component].mtime < wsMtime)) return
               // if there is no mtime, or if the ws mtime is newer then the status mtime, fetch!
@@ -64,7 +64,7 @@ const socketMiddleware = () => {
         }
         break
       default:
-        console.log('default')
+        console.log(event.type)
     }
   }
 

--- a/test/e2e/e2e.spec.ts
+++ b/test/e2e/e2e.spec.ts
@@ -7,7 +7,6 @@ import fakeDialog from 'spectron-fake-dialog'
 import { E2ETestUtils, newE2ETestUtils } from '../utils/e2eTestUtils'
 import http from 'http'
 import Dataset, { Commit, Meta, Structure } from '../../app/models/dataset'
-import { createConfigItem } from '@babel/core'
 
 const { Application } = require('spectron')
 
@@ -129,7 +128,7 @@ describe('Qri End to End tests', function spec () {
     var isQriRunning = await healthCheck()
 
     if (isQriRunning) {
-      throw ("An instance of Qri is already running. Aborting e2e tests.")
+      throw new Error("An instance of Qri is already running. Aborting e2e tests.")
     }
 
     registry = new TestTempRegistry()

--- a/test/utils/testQriBackend.ts
+++ b/test/utils/testQriBackend.ts
@@ -44,7 +44,7 @@ export default class TestBackendProcess {
 
   launchProcess () {
     try {
-      const [ base, qriPath, ipfsPath ] = this.setupRepo()
+      const [ base, qriPath ] = this.setupRepo()
 
       this.stdout = fs.createWriteStream(path.join(base, 'stdout.log'))
       this.stderr = fs.createWriteStream(path.join(base, 'stderr.log'))
@@ -52,8 +52,7 @@ export default class TestBackendProcess {
         // stdio: ['pipe', this.stdout, this.stderr],
         env: Object.assign(process.env, {
           'QRI_SETUP_CONFIG_DATA': qriConfig,
-          'QRI_PATH': qriPath,
-          'IPFS_PATH': ipfsPath
+          'QRI_PATH': qriPath
         })
       })
 
@@ -103,10 +102,7 @@ export default class TestBackendProcess {
     const qriPath = path.join(this.dir, '.qri')
     fs.mkdirSync(qriPath)
 
-    const ipfsPath = path.join(this.dir, '.ipfs')
-    fs.mkdirSync(ipfsPath)
-
-    return [this.dir, qriPath, ipfsPath]
+    return [this.dir, qriPath]
   }
 
   teardownRepo () {
@@ -122,7 +118,7 @@ export default class TestBackendProcess {
 }
 
 const qriConfig = `{
-  "Revision": 1,
+  "Revision": 2,
   "Profile": {
     "id": "QmboGUXqS1hvxKD92RaSCh2G29bDwJqxVmHUVop5ePxqtz",
     "privkey": "CAASqQkwggSlAgEAAoIBAQDGAumEqEOdSX/PIwfoEYq58Idgnx6Y671OnqHNcBkuK3XTw+vSyZduY10O9Ej9m1+5Yc5/twZ1uHPW3B0sY+uSScnD3L4TLMH/gBFU0GWh3AHiTBcvNZA1zlEq9pKAfXMm5EzSI+4mlo6wlKO8NnJ0Qyb9LaAsA/1aBO19VmxWeVndV4ckjrJ7yN8NvgkUxqpnFnqAP3f6sMSe7bcRUA6+3VXl4UPdpraYeI1W1YCdUBjKZ8F4+f0mEIpd++eQB6TtZ46Ve+SsXJEHB/K2eZcOL4KOkeTcAI9Dl9AkSsZsBeHGjWItOB2VH3MRAQH60hy71ZjbhhpxQD1F6m9bG1mPAgMBAAECggEBAIXzBmGVKlhGlk1bl0eoRj5OtmXoflxYbPG4YiCFiqMvB0BAM1GeyfAFC7jIDHBzIShZP8Yp3BbatpJMyPd0iLGndPQoafSyvHHJAvBrIbWDDUs2yiBHjcy4SzRTJPwC4VkX69fkMoCsLM7LXpA+DOMVYlS2/rmH4WV6G+ZEBnnf37UfW7VRX8L9MHwhZOEpJFYlcR0UChpFpA5zzTt+ePqdYZRFklT2Jwol+xlx/EXFbq2wIuHhxFgubiJ3IHKVyh4mSCDyt1wzfQTe9l33TEhQzJcbWidN8blBlXi2jXqSOTJgkCOHe2EC7VuY9T6EKfdJ9vtxv1QRHvjZmFF4HwECgYEAzQUuRAzjOn6z05vNcy0pKoJtsrwJF6SpTOQrH1/ejHO0snKVyISw9uXBuf6KpNmUAqre0GMnv1shyC7PVXFKX2qaqWne16Nx7EjhA2Tm8kGJ0s9HFxLLgLk3aOUYRfAGGm+k1Y0uOR+GYubWnIcHIeBz+N/MXHCi77n9aeIDFU8CgYEA9z+S2Ncs9UFXUG3r6f/JWldICom8FJAwnSKeTvC+VvfYJ4vgGToHnVm8sleO/1YDIaRuwe6KVn7kPGA5xvf1Gv0t+8aOt5qTTiMThp/UKHfliLaSwarnJLIP2NCnKm20HOlwjiwRnP5Ae4S0oR2te1PtU/Ytj0QRXICX46ES58ECgYEAtsJYhNcMNBfAS/FGStbGLJvKGBtg64+gT+fRvQ0kAQYf3Tch6HbInb8gW6HZi6xdMaeKKi9Jvl4Jlj6MGnl8N+R67Gxw9r8/jcdFtlXbPbdImgCmOZ5KhHwXNc2LPsUBW82MHcXVn5xHmqB2TWBc7kj8eK1fqkPKK3MbwKh14ScCgYB2OjYT7kCXPhlsYkOO7zrvMhFGyLng81nrqaQdh0zc9UKtFlugdHkzqrdqaCf+vLhem+xCW7hWx/KHVFQMaoEP2MTmQfn4nbeWg3tQwpiGiV5+0x618Oz6RRMC0DM/PJoFwTKLKVN6yLE43yooaLKN6IHxxiPe/+N1YiA/PsR1gQKBgQDDSk9hHxfffxVT3fuP1tVHHBL6ubP+U3w97jaa3pplnOSN/gxSamxcaVxPeCmCkIxUifPj1WWCHRkUuUOWT2JkqCvR1/kwCOmYBgpvSD7/R97lCPtVvNXueYZQODZPboeTaJwv2Q9y2YcR2PXO62ZyVyUOybtF1UfhZLXksEuvCQ==",
@@ -141,15 +137,13 @@ const qriConfig = `{
     "twitter": ""
   },
   "Repo": {
-    "middleware": [],
     "type": "fs"
   },
-  "Store": {
-    "type": "ipfs",
-    "options": {
-      "api": true
-    }
-  },
+  "Filesystems": [
+     { "type": "ipfs" },
+     { "type": "local" },
+     { "type": "http" }
+  ],
   "P2P": {
     "enabled": true,
     "peerid": "QmboGUXqS1hvxKD92RaSCh2G29bDwJqxVmHUVop5ePxqtz",
@@ -171,11 +165,6 @@ const qriConfig = `{
     "bootstrapaddrs": null,
     "autoNAT": false
   },
-  "Update": {
-    "type": "fs",
-    "daemonize": true,
-    "address": "127.0.0.1:2506"
-  },
   "Registry": {
     "location": "http://localhost:2500"
   },
@@ -186,7 +175,7 @@ const qriConfig = `{
   },
   "API": {
     "enabled": true,
-    "port": 2503,
+    "address": "/ip4/127.0.0.1/tcp/2503",
     "readonly": false,
     "remotemode": false,
     "remoteacceptsizemax": 0,
@@ -202,16 +191,9 @@ const qriConfig = `{
     ],
     "serveremotetraffic": true
   },
-  "Webapp": {
-    "enabled": true,
-    "port": 2505,
-    "analyticstoken": "",
-    "entrypointupdateaddress": "/ipns/webapp.qri.io",
-    "entrypointhash": "/ipfs/QmXofmXcQKnYTMjsfhgTGqzzLLPyS9enaHsfaRR5AxTGBK"
-  },
   "RPC": {
     "enabled": true,
-    "port": 2504
+    "address":  "/ip4/127.0.0.1/tcp/2504"
   },
   "Logging": {
     "levels": {
@@ -220,9 +202,5 @@ const qriConfig = `{
       "qrip2p": "info",
       "remote": "info"
     }
-  },
-  "Render": {
-    "templateUpdateAddress": "/ipns/defaulttmpl.qri.io",
-    "defaultTemplateHash": "/ipfs/QmeqeRTf2Cvkqdx4xUdWi1nJB2TgCyxmemsL3H4f1eTBaw"
   }
 }`

--- a/test/utils/testQriBackend.ts
+++ b/test/utils/testQriBackend.ts
@@ -4,6 +4,7 @@ import fs, { WriteStream } from 'fs'
 import childProcess from 'child_process'
 import path from 'path'
 import rimraf from 'rimraf'
+import http from 'http'
 
 // TestBackendProcess runs the qri backend binary in connected'ed mode,
 // configured for isolated testing in a temporary directory
@@ -21,17 +22,17 @@ export default class TestBackendProcess {
     this.dir = ''
   }
 
-  start () {
+  async start () {
     // const { resourcesPath = '' } = process
     // Locate the binary for the qri backend command-line
     // this.qriBinPath = this.findQriBin(['qri', resourcesPath, path.join(__dirname, '../../')])
     this.qriBinPath = this.findQriBin()
     if (this.qriBinPath === '') {
-      throw `couldn't find a qri binary on your $PATH, please install qri backend to run e2e tests`
+      throw new Error(`couldn't find a qri binary on your $PATH, please install qri backend to run e2e tests`)
     }
     // Run the binary if it is found
     console.log(`using qri binary: '${this.qriBinPath}'`)
-    this.launchProcess()
+    await this.launchProcess()
   }
 
   close () {
@@ -42,13 +43,15 @@ export default class TestBackendProcess {
     }
   }
 
-  launchProcess () {
+  async launchProcess () {
     try {
       const [ base, qriPath ] = this.setupRepo()
 
       this.stdout = fs.createWriteStream(path.join(base, 'stdout.log'))
       this.stderr = fs.createWriteStream(path.join(base, 'stderr.log'))
-      this.process = childProcess.spawn(this.qriBinPath, ['connect', '--setup'], {
+      console.log("backend err log:", path.join(base, 'stderr.log'))
+      console.log("launching backend process")
+      this.process = childProcess.spawn(this.qriBinPath, ['connect', '--setup', '--no-prompt'], {
         // stdio: ['pipe', this.stdout, this.stderr],
         env: Object.assign(process.env, {
           'QRI_SETUP_CONFIG_DATA': qriConfig,
@@ -60,19 +63,47 @@ export default class TestBackendProcess {
       this.process.stderr.pipe(this.stderr)
 
       this.process.on('error', (err: any) => { this.handleEvent('error', err) })
-      this.process.on('exit', () => { /* noop */ })
-      this.process.on('close', (err: any) => { this.teardownRepo() })
+      this.process.on('exit', (err: any) => { this.handleEvent('exit', err) })
+      this.process.on('close', (err: any) => {
+        this.handleEvent('close', err)
+        this.teardownRepo()
+      })
       this.process.on('disconnect', (err: any) => { this.handleEvent('disconnect', err) })
+      console.log("in test backend process, checking for active backend process")
+      const healthCheck = async () => {
+        return new Promise((resolve) => {
+          http.get('http://localhost:2503/health', (data) => {
+            resolve(true)
+          }).on('error', (e) => {
+            resolve(false)
+          })
+        })
+      }
+
+      var isQriRunning = await healthCheck()
+      // TODO (ramfox): this is stupid... but having a hard time understanding
+      // how to get this to block/to sleep for a second rn. Someone plz kill it with fire
+      var attempts = 1000
+      while (!isQriRunning) {
+        isQriRunning = await healthCheck()
+        attempts++
+      }
+      if (!isQriRunning) {
+        throw new Error("Test backend process has not started")
+      }
+      console.log("qri test backend has started after health checks", attempts)
+      return isQriRunning
     } catch (err) {
-      console.log('ERROR, Starting background process: ' + err)
+      console.log('ERROR, Starting background process: ', err)
     }
+    return false
   }
 
   handleEvent (kind: string, err: Error) {
     if (err) {
-      console.log(`err event '${kind}' from backend: ${err}`)
+      console.log(`test backend: err event '${kind}' from backend: ${err}`)
     } else {
-      console.log(`event '${kind}' from backend`)
+      console.log(`test backend: event '${kind}' from backend`)
     }
   }
 
@@ -92,11 +123,12 @@ export default class TestBackendProcess {
     if (fs.existsSync(filename)) {
       return filename
     }
-    throw 'Could not find qri binary'
+    throw new Error('Could not find qri binary')
   }
 
   setupRepo () {
     this.dir = path.join(os.tmpdir(), 'qri_desktop_test_backend')
+    console.log("creating test backend repo dir", this.dir)
     fs.mkdirSync(this.dir)
 
     const qriPath = path.join(this.dir, '.qri')
@@ -107,6 +139,7 @@ export default class TestBackendProcess {
 
   teardownRepo () {
     if (this.dir !== '') {
+      console.log("removing test repo dir")
       rimraf(this.dir, (err) => {
         if (err) {
           console.log(err)


### PR DESCRIPTION
Now that we can successfully migrate, let's make sure that all the other functionality that needs updating is fixed!

closes #560
closes #555 
closes #556 

make sure e2e tests are running

relies on qri-io/temp_registry_server#4