### PR TITLE
feat(Header & DatasetStatus): add new Header and DatasetStatus components

### DIFF
--- a/app/components/ExternalLink.tsx
+++ b/app/components/ExternalLink.tsx
@@ -2,12 +2,13 @@ import * as React from 'react'
 import { onClick } from './platformSpecific/ExternalLink.TARGET_PLATFORM'
 
 export interface ExternalLinkProps {
-  id: string
+  id?: string
   href: string
   children: React.ReactNode
+  className?: string
 }
 
-const ExternalLink: React.FunctionComponent<ExternalLinkProps> = ({ id, href, children }) =>
-  <a id={id} href={href} onClick={(e) => onClick(e, href)} target='_blank' rel="noopener noreferrer">{children}</a>
+const ExternalLink: React.FunctionComponent<ExternalLinkProps> = ({ id, href, children, className }) =>
+  <a id={id} href={href} onClick={(e) => onClick(e, href)} target='_blank' rel="noopener noreferrer" className={className}>{children}</a>
 
 export default ExternalLink

--- a/app/components/ExternalLink.tsx
+++ b/app/components/ExternalLink.tsx
@@ -6,9 +6,10 @@ export interface ExternalLinkProps {
   href: string
   children: React.ReactNode
   className?: string
+  tooltip?: string
 }
 
-const ExternalLink: React.FunctionComponent<ExternalLinkProps> = ({ id, href, children, className }) =>
-  <a id={id} href={href} onClick={(e) => onClick(e, href)} target='_blank' rel="noopener noreferrer" className={className}>{children}</a>
+const ExternalLink: React.FunctionComponent<ExternalLinkProps> = ({ id, href, children, className, tooltip }) =>
+  <a id={id} href={href} onClick={(e) => onClick(e, href)} target='_blank' rel="noopener noreferrer" className={className} data-tip={tooltip}>{children}</a>
 
 export default ExternalLink

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -15,7 +15,7 @@ interface HeaderProps {
 }
 
 export const Header: React.FC<HeaderProps> = ({ title, setModal }) => (
-  <header className="header">
+  <header className="collection-header">
     <h3 className="header-title">{title}</h3>
     <div className="header-column">
       <HeaderColumnButton

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { faPlus, faDownload } from '@fortawesome/free-solid-svg-icons'
+
+import { Modal, ModalType } from '../models/modals'
+
+import { connectComponentToProps } from '../utils/connectComponentToProps'
+
+import { setModal } from '../actions/ui'
+
+import HeaderColumnButton from './chrome/HeaderColumnButton'
+
+interface HeaderProps {
+  title: string
+
+  // setting action
+  setModal: (modal: Modal) => void
+}
+
+export const Header: React.FC<HeaderProps> = ({ title, setModal }) => (
+  <header className="header">
+    <h3 className="header-title">{title}</h3>
+    <div className="header-column">
+      <HeaderColumnButton
+        id="create-dataset"
+        icon={faPlus}
+        label="Create new Dataset"
+        onClick={() => setModal({ type: ModalType.CreateDataset })}
+      />
+      <HeaderColumnButton
+        id="add-dataset"
+        icon={faDownload}
+        label="Add existing Dataset"
+        onClick={() => setModal({ type: ModalType.AddDataset })}
+      />
+    </div>
+  </header>
+)
+
+export default connectComponentToProps(
+  Header,
+  {},
+  { setModal }
+)

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import { faPlus, faDownload } from '@fortawesome/free-solid-svg-icons'
 
 import { Modal, ModalType } from '../models/modals'
-
 import { connectComponentToProps } from '../utils/connectComponentToProps'
-
 import { setModal } from '../actions/ui'
 
 import HeaderColumnButton from './chrome/HeaderColumnButton'

--- a/app/components/chrome/Icon.tsx
+++ b/app/components/chrome/Icon.tsx
@@ -34,7 +34,8 @@ import {
   faEllipsisH,
   faSort,
   faMinus,
-  faSave
+  faSave,
+  faSync
 } from '@fortawesome/free-solid-svg-icons'
 
 interface IconProps {
@@ -89,7 +90,8 @@ const icons: Record<string, any> = {
   'expand': faExpandArrowsAlt,
   'hamburger': faEllipsisH,
   'minus': faMinus,
-  'plus': faPlus
+  'plus': faPlus,
+  'sync': faSync
 }
 
 export const iconsList = Object.keys(icons)

--- a/app/components/collection-v2/DatasetStatus.tsx
+++ b/app/components/collection-v2/DatasetStatus.tsx
@@ -19,7 +19,7 @@ export interface DatasetStatusProps {
 
 const DatasetStatus: React.FC<DatasetStatusProps> = ({ published, linkedToFilesystem, qriRef: { username, name }, fsiPath, updatesAvailable, updateDataset }) => (
   <div className="flex-space-between">
-    <ExternalLink href={`${QRI_CLOUD_URL}/${username}/${name}`} className="dataset-link" data-tip="Published">
+    <ExternalLink href={`${QRI_CLOUD_URL}/${username}/${name}`} className="dataset-link" tooltip="Published">
       <Icon icon="publish" size="sm" color={published ? 'dark' : 'medium'}/>
     </ExternalLink>
     <a onClick={(e) => onClickOpenInFinder(e, fsiPath)} className="dataset-link" data-tip="Linked to filesystem">

--- a/app/components/collection-v2/DatasetStatus.tsx
+++ b/app/components/collection-v2/DatasetStatus.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import Icon from '../chrome/Icon'
+import ExternalLink from '../ExternalLink'
+import { QriRef } from '../../models/qriRef'
+import { QRI_CLOUD_URL } from '../../constants'
+import { onClickOpenInFinder } from '../platformSpecific/DatasetStatus.TARGET_PLATFORM'
+import { ApiActionThunk } from '../../store/api'
+
+export interface DatasetStatusProps {
+  qriRef: QriRef
+  fsiPath: string
+  published: boolean
+  linkedToFilesystem: boolean
+  updatesAvailable: boolean
+
+  // fetching action
+  updateDataset(username: string, name: string): ApiActionThunk
+}
+
+const DatasetStatus: React.FC<DatasetStatusProps> = ({ published, linkedToFilesystem, qriRef: { username, name }, fsiPath, updatesAvailable, updateDataset }) => (
+  <div className="flex-space-between">
+    <ExternalLink href={`${QRI_CLOUD_URL}/${username}/${name}`} className="dataset-link" data-tip="Published">
+      <Icon icon="publish" size="sm" color={published ? 'dark' : 'medium'}/>
+    </ExternalLink>
+    <a onClick={(e) => onClickOpenInFinder(e, fsiPath)} className="dataset-link" data-tip="Linked to filesystem">
+      <Icon icon="openInFinder" size="sm" color={linkedToFilesystem ? 'dark' : 'medium'}/>
+    </a>
+    <button onClick={() => updateDataset(username, name)} className="dataset-button" data-tip="Updates available">
+      <Icon icon="sync" size="sm" color={updatesAvailable ? 'dark' : 'medium'}/>
+    </button>
+  </div>
+)
+
+export default DatasetStatus

--- a/app/components/collection-v2/DatasetStatus.tsx
+++ b/app/components/collection-v2/DatasetStatus.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
-import Icon from '../chrome/Icon'
-import ExternalLink from '../ExternalLink'
+
 import { QriRef } from '../../models/qriRef'
 import { QRI_CLOUD_URL } from '../../constants'
 import { onClickOpenInFinder } from '../platformSpecific/DatasetStatus.TARGET_PLATFORM'
 import { ApiActionThunk } from '../../store/api'
+
+import Icon from '../chrome/Icon'
+import ExternalLink from '../ExternalLink'
 
 export interface DatasetStatusProps {
   qriRef: QriRef

--- a/app/components/platformSpecific/DatasetStatus.electron.tsx
+++ b/app/components/platformSpecific/DatasetStatus.electron.tsx
@@ -1,0 +1,3 @@
+import { shell } from 'electron'
+
+export const onClickOpenInFinder = (_: React.MouseEvent, fsiPath: string) => shell.openItem(fsiPath)

--- a/app/components/platformSpecific/DatasetStatus.web.tsx
+++ b/app/components/platformSpecific/DatasetStatus.web.tsx
@@ -1,0 +1,1 @@
+export const onClickOpenInFinder = () => undefined

--- a/app/components/platformSpecific/DatasetStatus.web.tsx
+++ b/app/components/platformSpecific/DatasetStatus.web.tsx
@@ -1,1 +1,4 @@
+// This file is needed for webpack to build DatasetStatus for in-browser rendering without loading
+// the electron dependency, but in practice we do not expect the "open in finder" icon to ever be
+// used on Web so this function should never be called.
 export const onClickOpenInFinder = () => undefined

--- a/app/components/platformSpecific/ExternalLink.web.tsx
+++ b/app/components/platformSpecific/ExternalLink.web.tsx
@@ -1,1 +1,4 @@
+// This file is needed for webpack to build ExternalLink for in-browser rendering without loading
+// the electron dependency. When ExternalLink is rendered on Web, this function is a noop
+// and the href is preferred.
 export const onClick = () => undefined

--- a/app/scss/_dataset-status.scss
+++ b/app/scss/_dataset-status.scss
@@ -1,0 +1,8 @@
+.dataset-link {
+  padding: 1px 6px;
+}
+
+.dataset-button {
+  background: none;
+  border: none;
+}

--- a/app/scss/_header.scss
+++ b/app/scss/_header.scss
@@ -1,4 +1,4 @@
-.header {
+.collection-header {
   height: 100px;
   display: flex;
   justify-content: space-between;

--- a/app/scss/_header.scss
+++ b/app/scss/_header.scss
@@ -1,0 +1,41 @@
+.header {
+  height: 100px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+
+  .header-title {
+    color: $black;
+    font-size: 1.2rem;
+    font-weight: 900;
+  }
+
+  .header-column {
+    display: inline-flex;
+    padding: 10px 0px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    align-items: center;
+    cursor: pointer;
+
+    &:last-child {
+      padding-left: 20px;
+    }
+
+    .header-column-icon {
+      color: $text-light;
+      margin-right: 8px;
+    }
+    .header-column-text {
+      color: $light-blue-accent;
+    }
+  }
+
+  #create-dataset:hover,
+  #add-dataset:hover {
+    .header-column-icon {
+      color: $text-muted;
+      transition: color $active-item-highlight-transition;
+    }
+  }
+}

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -37,6 +37,7 @@
 @import "tableDiff";
 @import "navbar";
 @import "sidebar-layout";
+@import "header";
 
 @import '~easymde/dist/easymde.min.css';
 @import "dialog";

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -38,6 +38,7 @@
 @import "navbar";
 @import "sidebar-layout";
 @import "header";
+@import "dataset-status";
 
 @import '~easymde/dist/easymde.min.css';
 @import "dialog";

--- a/stories/Collection.stories.tsx
+++ b/stories/Collection.stories.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { AnyAction } from 'redux'
+
+import DatasetStatus, { DatasetStatusProps } from '../app/components/collection-v2/DatasetStatus'
+
+export default {
+  title: 'Collection View',
+  parameters: {
+    notes: 'Revised Collection View components'
+  }
+}
+
+const datasetStatusWrapperStyles = { height: '50px', width: '110px', padding: 15 }
+
+const qriRef = {
+  location: 'foo/bar/at/ipfs/QmFme0d/body',
+  username: 'honeyBadger',
+  name: 'achievements-of-neville-longbottom',
+  path: '/ipfs/QmaanFJb4CxktD1spk57oCr4fUSmL8AASpNHnzeUyrRub3'
+}
+
+const datasetStatusBaseProps = {
+  qriRef,
+  fsiPath: '/downloads/herbology-greats/neville',
+  updateDataset: () => () => new Promise<AnyAction>((resolve) => resolve({ type: 'Collection view update action'}))
+}
+
+const datasetPublishedProps: DatasetStatusProps = {
+  ...datasetStatusBaseProps,  
+  published: true,
+  linkedToFilesystem: false,
+  updatesAvailable: false,
+}
+
+export const datasetPublished = () => {
+    return (
+    <>
+      <p>Dataset Published</p>  
+      <div style={{...datasetStatusWrapperStyles}}>
+        <DatasetStatus {...datasetPublishedProps} />
+      </div>
+    </>
+  )
+}
+
+datasetPublished.story = {
+    name: 'Published',
+    parameters: {
+      notes: 'Dataset has been published to qri Cloud'
+    }
+}
+
+const datasetLinkedToFilesystemProps: DatasetStatusProps = {
+  ...datasetStatusBaseProps,
+  published: false,
+  linkedToFilesystem: true,
+  updatesAvailable: false,
+}
+
+export const datasetLinkedToFilesystem = () => {
+    return (
+    <>
+      <p>Dataset Linked to Filesystem</p>  
+      <div style={{...datasetStatusWrapperStyles}}>
+        <DatasetStatus {...datasetLinkedToFilesystemProps} />
+      </div>
+    </>
+  )
+}
+
+datasetLinkedToFilesystem.story = {
+  name: 'Linked to filesystem',
+  parameters: {
+    notes: 'Dataset has been linked to file system'
+  }
+}
+
+const datasetUpdatesAvailableProps: DatasetStatusProps = {
+  ...datasetStatusBaseProps,
+  published: false,
+  linkedToFilesystem: false,
+  updatesAvailable: true,
+}
+
+export const datasetUpdatesAvailable = () => {
+    return (
+    <>
+      <p>Dataset Updates Available</p>  
+      <div style={{...datasetStatusWrapperStyles}}>
+        <DatasetStatus {...datasetUpdatesAvailableProps} />
+      </div>
+    </>
+  )
+}
+
+datasetUpdatesAvailable.story = {
+  name: 'Updates Available',
+  parameters: {
+    notes: 'Dataset has updates available'
+  }
+}
+
+const datasetLinkedToFSAndUpdatesAvailableProps: DatasetStatusProps = {
+  ...datasetStatusBaseProps,
+  published: false,
+  linkedToFilesystem: true,
+  updatesAvailable: true,
+}
+
+export const datasetLinkedToFSAndUpdatesAvailable = () => {
+    return (
+    <>
+      <p>Dataset Linked to Filesystem and Updates Available</p>  
+      <div style={{...datasetStatusWrapperStyles}}>
+        <DatasetStatus {...datasetLinkedToFSAndUpdatesAvailableProps} />
+      </div>
+    </>
+  )
+}
+
+datasetLinkedToFSAndUpdatesAvailable.story = {
+  name: 'Linked to Filesystem and Updates Available',
+  parameters: {
+    notes: 'Dataset is linked to filesystem and has updates available'
+  }
+}

--- a/stories/Collection.stories.tsx
+++ b/stories/Collection.stories.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
+import ReactTooltip from 'react-tooltip'
 import { AnyAction } from 'redux'
 
 import DatasetStatus, { DatasetStatusProps } from '../app/components/collection-v2/DatasetStatus'
@@ -10,7 +11,21 @@ export default {
   }
 }
 
-const datasetStatusWrapperStyles = { height: '50px', width: '110px', padding: 15 }
+const tooltipWrapper = (component: ReactElement, storyTitle: string) => (
+  <>
+    <ReactTooltip 
+      place='bottom'
+      type='dark'
+      effect='solid'
+      delayShow={200}
+      multiline 
+    />
+    <p>{storyTitle}</p>
+    <div style={{ height: '50px', width: '110px', padding: 15 }}>
+      {component}
+    </div>
+  </>
+)
 
 const qriRef = {
   location: 'foo/bar/at/ipfs/QmFme0d/body',
@@ -32,16 +47,7 @@ const datasetPublishedProps: DatasetStatusProps = {
   updatesAvailable: false,
 }
 
-export const datasetPublished = () => {
-    return (
-    <>
-      <p>Dataset Published</p>  
-      <div style={{...datasetStatusWrapperStyles}}>
-        <DatasetStatus {...datasetPublishedProps} />
-      </div>
-    </>
-  )
-}
+export const datasetPublished = () => tooltipWrapper(<DatasetStatus {...datasetPublishedProps} />, 'Dataset Published')
 
 datasetPublished.story = {
     name: 'Published',
@@ -57,16 +63,7 @@ const datasetLinkedToFilesystemProps: DatasetStatusProps = {
   updatesAvailable: false,
 }
 
-export const datasetLinkedToFilesystem = () => {
-    return (
-    <>
-      <p>Dataset Linked to Filesystem</p>  
-      <div style={{...datasetStatusWrapperStyles}}>
-        <DatasetStatus {...datasetLinkedToFilesystemProps} />
-      </div>
-    </>
-  )
-}
+export const datasetLinkedToFilesystem = () => tooltipWrapper(<DatasetStatus {...datasetLinkedToFilesystemProps} />, 'Dataset Linked to Filesystem')
 
 datasetLinkedToFilesystem.story = {
   name: 'Linked to filesystem',
@@ -82,16 +79,7 @@ const datasetUpdatesAvailableProps: DatasetStatusProps = {
   updatesAvailable: true,
 }
 
-export const datasetUpdatesAvailable = () => {
-    return (
-    <>
-      <p>Dataset Updates Available</p>  
-      <div style={{...datasetStatusWrapperStyles}}>
-        <DatasetStatus {...datasetUpdatesAvailableProps} />
-      </div>
-    </>
-  )
-}
+export const datasetUpdatesAvailable = () => tooltipWrapper(<DatasetStatus {...datasetUpdatesAvailableProps} />, 'Dataset Updates Available')
 
 datasetUpdatesAvailable.story = {
   name: 'Updates Available',
@@ -107,16 +95,7 @@ const datasetLinkedToFSAndUpdatesAvailableProps: DatasetStatusProps = {
   updatesAvailable: true,
 }
 
-export const datasetLinkedToFSAndUpdatesAvailable = () => {
-    return (
-    <>
-      <p>Dataset Linked to Filesystem and Updates Available</p>  
-      <div style={{...datasetStatusWrapperStyles}}>
-        <DatasetStatus {...datasetLinkedToFSAndUpdatesAvailableProps} />
-      </div>
-    </>
-  )
-}
+export const datasetLinkedToFSAndUpdatesAvailable = () => tooltipWrapper(<DatasetStatus {...datasetLinkedToFSAndUpdatesAvailableProps} />, 'Dataset Linked to Filesystem and Updates Available')
 
 datasetLinkedToFSAndUpdatesAvailable.story = {
   name: 'Linked to Filesystem and Updates Available',

--- a/stories/Header.stories.tsx
+++ b/stories/Header.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+
 import { Modal } from '../app/models/modals'
+
 import { Header } from '../app/components/Header'
 
 export default {

--- a/stories/Header.stories.tsx
+++ b/stories/Header.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Modal } from '../app/models/modals'
+import { Header } from '../app/components/Header'
+
+export default {
+  title: 'Header',
+  parameters: {
+    notes: 'app-wide header'
+  }
+}
+
+export const collectionViewHeader = () => {
+  return (
+    <div style={{ width: 960, margin: '0 auto'}}>
+      <Header title="Collection" setModal={(modal: Modal) => console.log(`Set modal dispatched action for ${modal}`)}/>
+    </div> 
+  )
+}
+
+collectionViewHeader.story = {
+  name: 'Collection View',
+  parameters: { note: 'Shows add and create dataset buttons' }
+}


### PR DESCRIPTION
This PR checks off the first 2 components I enumerated in #576, which builds off designs from #554 

- A new `Header` component to eventually be used across the app but built just for Collection View for now
- A new `DatasetStatus` component to be utilized in the new Collection table view