### PR TITLE
fix: long dataset history overlaps status button

### DIFF
--- a/app/scss/0.4.0/network.scss
+++ b/app/scss/0.4.0/network.scss
@@ -120,4 +120,6 @@
 
 #history-list {
   padding: 10px;
+  flex-grow: 1;
+  overflow: auto;
 }

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -252,7 +252,6 @@ $header-font-size: .9rem;
   }
 
   #tabs {
-    height: $header-height;
     display: flex;
 
     .tab {

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "jest": "24.9.0",
     "json-loader": "0.5.7",
     "mini-css-extract-plugin": "0.8.0",
-    "node-sass": "4.13.0",
+    "node-sass": "4.13.1",
     "react-hot-loader": "4.12.15",
     "react-test-renderer": "16.11.0",
     "redux-logger": "3.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11512,10 +11512,10 @@ node-releases@^1.1.29, node-releases@^1.1.58:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.58.tgz#8ee20eef30fa60e52755fcc0942def5a734fe935"
   integrity sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==
 
-node-sass@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
-  integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==
+node-sass@4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION
Long sidebar content in the dataset view was preventing the user from clicking the status and history tabs. Closes #551 