### PR TITLE
feat(Remove dataset): add warning for when a user removes own dataset

### DIFF
--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -1,7 +1,7 @@
 // a layout component for the resizable sidebar with main content area
 import * as React from 'react'
 import { Resizable } from './Resizable'
-import NavTopbar from '../components/nav/NavTopBar'
+import NavTopbar from '../components/nav/NavTopbar'
 
 interface LayoutProps {
   id: string

--- a/app/components/modals/RemoveDataset.tsx
+++ b/app/components/modals/RemoveDataset.tsx
@@ -8,7 +8,7 @@ import { connectComponentToProps } from '../../utils/connectComponentToProps'
 import { dismissModal } from '../../actions/ui'
 import { removeDatasetAndFetch } from '../../actions/api'
 
-import { selectModal } from '../../selections'
+import { selectModal, selectSessionUsername } from '../../selections'
 
 import CheckboxInput from '../form/CheckboxInput'
 import Modal from './Modal'
@@ -17,12 +17,13 @@ import Buttons from './Buttons'
 
 interface RemoveDatasetProps {
   modal: RemoveDatasetModal
+  sessionUsername: string
   onDismissed: () => void
   onSubmit: (username: string, name: string, isLinked: boolean, keepFiles: boolean) => Promise<ApiAction>
 }
 
 export const RemoveDatasetComponent: React.FunctionComponent<RemoveDatasetProps> = (props: RemoveDatasetProps) => {
-  const { modal, onDismissed, onSubmit } = props
+  const { modal, sessionUsername, onDismissed, onSubmit } = props
   const { username, name, fsiPath } = modal
 
   const [keepFiles, setKeepFiles] = React.useState(true)
@@ -63,7 +64,11 @@ export const RemoveDatasetComponent: React.FunctionComponent<RemoveDatasetProps>
     >
       <div className='content-wrap'>
         <div className='content'>
-          <div className='content-main'>Are you sure you want to remove <br/> <div className='code-highlight'>{username}/{name}</div>&nbsp;?</div>
+          <div className='content-main'>
+            Are you sure you want to remove <br/> <div className='code-highlight'>{username}/{name}</div>&nbsp;?
+            <br/><br/>
+            {sessionUsername === username && <div className='warning'>Warning: removing a dataset which belongs to you means you cannot return to that dataset&apos;s history.</div>}
+          </div>
           { fsiPath &&
             <CheckboxInput
               name='should-remove-files'
@@ -95,7 +100,8 @@ export default connectComponentToProps(
   (state: any, ownProps: RemoveDatasetProps) => {
     return {
       ...ownProps,
-      modal: selectModal(state)
+      modal: selectModal(state),
+      sessionUsername: selectSessionUsername(state)
     }
   },
   {


### PR DESCRIPTION
Closes #534 

Here's a preview of what the modal now looks like when a user attempts to delete a dataset under their own username
<img width="530" alt="Screen Shot 2020-09-29 at 12 00 26 PM" src="https://user-images.githubusercontent.com/31083146/94590125-d4261380-024b-11eb-8b79-6dcd5db5c5bb.png">
