### PR TITLE
Update "Save Path" Checkout modal copy 

### DIFF
--- a/app/components/modals/LinkDataset.tsx
+++ b/app/components/modals/LinkDataset.tsx
@@ -142,7 +142,7 @@ export const LinkDatasetComponent: React.FunctionComponent<LinkDatasetProps> = (
           <TextInput
             name='datasetDirectory'
             label='Dataset Directory'
-            helpText="The name of the directory which contains this dataset's components"
+            helpText="The name of the directory which will contain this dataset's components"
             showHelpText
             type=''
             value={datasetDirectory}
@@ -155,7 +155,7 @@ export const LinkDatasetComponent: React.FunctionComponent<LinkDatasetProps> = (
             <TextInput
               name='path'
               label='Save Path'
-              helpText='The file path where the dataset will be saved on your machine'
+              helpText='The file path where the dataset directory will be saved on your machine'
               showHelpText
               type=''
               value={path}

--- a/app/components/modals/LinkDataset.tsx
+++ b/app/components/modals/LinkDataset.tsx
@@ -154,7 +154,7 @@ export const LinkDatasetComponent: React.FunctionComponent<LinkDatasetProps> = (
           <div className='flex-space-between'>
             <TextInput
               name='path'
-              label='Save Path'
+              label='Checkout Location'
               helpText='The file path where the dataset directory will be saved on your machine'
               showHelpText
               type=''

--- a/app/components/modals/LinkDataset.tsx
+++ b/app/components/modals/LinkDataset.tsx
@@ -163,7 +163,7 @@ export const LinkDatasetComponent: React.FunctionComponent<LinkDatasetProps> = (
               maxLength={600}
               errorText={alreadyDatasetError}
             />
-            <div className='margin-left'><ButtonInput id='chooseSavePath' onClick={() => handlePickerDialog(showDirectoryPicker)} >Choose...</ButtonInput></div>
+            <div className='margin-left'><ButtonInput id='chooseCheckoutLocation' onClick={() => handlePickerDialog(showDirectoryPicker)} >Choose...</ButtonInput></div>
           </div>
         </div>
       </div>

--- a/app/components/modals/LinkDataset.tsx
+++ b/app/components/modals/LinkDataset.tsx
@@ -142,16 +142,21 @@ export const LinkDatasetComponent: React.FunctionComponent<LinkDatasetProps> = (
           <TextInput
             name='datasetDirectory'
             label='Dataset Directory'
+            helpText="The name of the directory which contains this dataset's components"
+            showHelpText
             type=''
             value={datasetDirectory}
             onChange={handleChanges}
             maxLength={600}
             errorText={alreadyDatasetError}
           />
+          <br />
           <div className='flex-space-between'>
             <TextInput
               name='path'
               label='Save Path'
+              helpText='The file path where the dataset will be saved on your machine'
+              showHelpText
               type=''
               value={path}
               onChange={handleChanges}

--- a/test/e2e/e2e.spec.ts
+++ b/test/e2e/e2e.spec.ts
@@ -411,8 +411,8 @@ describe('Qri End to End tests', function spec () {
 
     // mock the dialog
     await fakeDialog.mock([ { method: 'showOpenDialogSync', value: [backend.dir] } ])
-    // click #chooseSavePath to open dialog
-    await click('#chooseSavePath')
+    // click #chooseCheckoutLocation to open dialog
+    await click('#chooseCheckoutLocation')
     // click #submit
     await click('#submit')
     // expect modal to be gone


### PR DESCRIPTION
Closes #205 

Update copy from "Save Path" to "Checkout Location" and include help text to clarify what the fields in the checkout modal refer to

<img width="526" alt="Screen Shot 2020-09-29 at 1 36 36 PM" src="https://user-images.githubusercontent.com/31083146/94601297-e65a7e80-0258-11eb-9807-614187e7a2c1.png">
