### PR TITLE
fix(*): clean up `discardChanges`, double-fetching bugs, and the "uncommited changes" prompt

### DIFF
--- a/app/actions/api.ts
+++ b/app/actions/api.ts
@@ -5,7 +5,12 @@ import { CALL_API, ApiAction, ApiActionThunk, chainSuccess } from '../store/api'
 import { SelectedComponent } from '../models/store'
 import { actionWithPagination } from '../utils/pagination'
 import { openToast, setImportFileDetails } from './ui'
-import { setSaveComplete, resetMutationsDataset, resetMutationsStatus } from './mutations'
+import {
+  setSaveComplete,
+  resetMutationsDataset,
+  resetMutationsStatus,
+  discardMutationsChanges
+} from './mutations'
 
 import {
   mapDataset,
@@ -592,6 +597,7 @@ export function discardChangesAndFetch (username: string, name: string, componen
     let response: Action
     response = await discardChanges(username, name, component)(dispatch, getState)
       .then((res) => {
+        dispatch(discardMutationsChanges(component))
         dispatch(fetchWorkingDataset(username, name))
         dispatch(fetchWorkingStatus(username, name))
         return res

--- a/app/actions/workbench.ts
+++ b/app/actions/workbench.ts
@@ -6,7 +6,9 @@ import {
   setCommitTitle,
   setCommitMessage,
   setMutationsStatus,
-  setMutationsDataset
+  setMutationsDataset,
+  resetMutationsDataset,
+  resetMutationsStatus
 } from './mutations'
 
 import {
@@ -48,6 +50,8 @@ export function fetchWorkbench (qriRef: QriRef): LaunchedFetchesAction {
        (routeUsername !== workingUsername ||
         routeName !== workingName)) {
       fetchLog(routeUsername, routeName)(dispatch, getState)
+      dispatch(resetMutationsDataset())
+      dispatch(resetMutationsStatus())
       dispatch(fetchWorkingDataset(routeUsername, routeName))
       dispatch(fetchWorkingStatus(routeUsername, routeName))
       dispatch(fetchStats(routeUsername, routeName))

--- a/app/components/collection/UncommitedChangesPrompt.tsx
+++ b/app/components/collection/UncommitedChangesPrompt.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Prompt, RouteProps } from 'react-router-dom'
+import { Action } from 'redux'
+
+import { connectComponentToPropsWithRouter } from '../../utils/connectComponentToProps'
+import { QriRef } from '../../models/qriRef'
+import { resetMutationsDataset, resetMutationsStatus } from '../../actions/mutations'
+import { selectMutationsIsDirty, selectRecentEditRef } from '../../selections'
+
+interface UncommitedChangesPromptProps extends RouteProps {
+  recentEditRef: QriRef
+  modified: boolean
+  resetMutationsDataset: () => Action
+  resetMutationsStatus: () => Action
+}
+
+export const UncommitedChangesPromptComponent: React.FC<UncommitedChangesPromptProps> = (props) => {
+  const {
+    recentEditRef,
+    modified,
+    resetMutationsDataset,
+    resetMutationsStatus
+  } = props
+
+  React.useEffect(() => {
+    return () => {
+      resetMutationsDataset()
+      resetMutationsStatus()
+    }
+  }, [])
+
+  const okToContinue = (newPath: string) => {
+    return recentEditRef.location === '' ||
+            (newPath.includes(recentEditRef.username) &&
+            newPath.includes(recentEditRef.name))
+  }
+
+  const uncommitedChangesText = `You have uncommited changes! Click 'cancel' and commit these changes before you navigate away or you will lose your work.`
+
+  return (
+    <Prompt when={modified} message={(location) => {
+      if (okToContinue(location.pathname)) return true
+      return uncommitedChangesText
+    }}/>
+  )
+}
+
+export default connectComponentToPropsWithRouter(
+  UncommitedChangesPromptComponent,
+  (state: any, ownProps: UncommitedChangesPromptProps) => {
+    return {
+      ...ownProps,
+      recentEditRef: selectRecentEditRef(state),
+      modified: selectMutationsIsDirty(state)
+    }
+  },
+  {
+    resetMutationsDataset,
+    resetMutationsStatus
+  }
+)

--- a/app/components/collection/UncommittedChangesPrompt.tsx
+++ b/app/components/collection/UncommittedChangesPrompt.tsx
@@ -1,33 +1,20 @@
 import React from 'react'
 import { Prompt, RouteProps } from 'react-router-dom'
-import { Action } from 'redux'
 
 import { connectComponentToPropsWithRouter } from '../../utils/connectComponentToProps'
 import { QriRef } from '../../models/qriRef'
-import { resetMutationsDataset, resetMutationsStatus } from '../../actions/mutations'
 import { selectMutationsIsDirty, selectRecentEditRef } from '../../selections'
 
-interface UncommitedChangesPromptProps extends RouteProps {
+interface UncommittedChangesPromptProps extends RouteProps {
   recentEditRef: QriRef
   modified: boolean
-  resetMutationsDataset: () => Action
-  resetMutationsStatus: () => Action
 }
 
-export const UncommitedChangesPromptComponent: React.FC<UncommitedChangesPromptProps> = (props) => {
+export const UncommittedChangesPromptComponent: React.FC<UncommittedChangesPromptProps> = (props) => {
   const {
     recentEditRef,
-    modified,
-    resetMutationsDataset,
-    resetMutationsStatus
+    modified
   } = props
-
-  React.useEffect(() => {
-    return () => {
-      resetMutationsDataset()
-      resetMutationsStatus()
-    }
-  }, [])
 
   const okToContinue = (newPath: string) => {
     return recentEditRef.location === '' ||
@@ -35,27 +22,27 @@ export const UncommitedChangesPromptComponent: React.FC<UncommitedChangesPromptP
             newPath.includes(recentEditRef.name))
   }
 
-  const uncommitedChangesText = `You have uncommited changes! Click 'cancel' and commit these changes before you navigate away or you will lose your work.`
+  const uncommittedChangesText = `You have uncommitted changes to dataset ${recentEditRef.username}/${recentEditRef.name} that will be lost if you navigate to a different dataset. 
+  
+Click 'cancel', navigate to dataset ${recentEditRef.username}/${recentEditRef.name}, and commit those changes to save.
+ 
+Click 'ok' to continue and lose those changes.`
 
   return (
     <Prompt when={modified} message={(location) => {
       if (okToContinue(location.pathname)) return true
-      return uncommitedChangesText
+      return uncommittedChangesText
     }}/>
   )
 }
 
 export default connectComponentToPropsWithRouter(
-  UncommitedChangesPromptComponent,
-  (state: any, ownProps: UncommitedChangesPromptProps) => {
+  UncommittedChangesPromptComponent,
+  (state: any, ownProps: UncommittedChangesPromptProps) => {
     return {
       ...ownProps,
       recentEditRef: selectRecentEditRef(state),
       modified: selectMutationsIsDirty(state)
     }
-  },
-  {
-    resetMutationsDataset,
-    resetMutationsStatus
   }
 )

--- a/app/components/collection/collectionHome/CollectionHome.tsx
+++ b/app/components/collection/collectionHome/CollectionHome.tsx
@@ -8,6 +8,7 @@ import { Modal, ModalType } from '../../../models/modals'
 
 import Layout from '../../Layout'
 import DatasetCollection from './DatasetCollection'
+import UncommittedChangesPrompt from '../UncommittedChangesPrompt'
 
 interface CollectionHomeProps {
   setModal: (modal: Modal) => void
@@ -19,29 +20,32 @@ export const CollectionHome: React.FC<CollectionHomeProps> = ({ setModal }) => {
   }, [])
 
   return (
-    <Layout
-      id='collection-container'
-      title='Collection'
-      topbarButtons={
-        [
-          {
-            type: 'button',
-            id: 'create-dataset',
-            icon: faPlus,
-            label: 'New Dataset',
-            onClick: () => { setModal({ type: ModalType.NewDataset }) }
-          },
-          {
-            type: 'button',
-            id: 'pull-dataset',
-            icon: faDownload,
-            label: 'Pull Dataset',
-            onClick: () => { setModal({ type: ModalType.PullDataset }) }
-          }
-        ]
-      }
-      mainContent={<DatasetCollection />}
-    />
+    <>
+      <UncommittedChangesPrompt />
+      <Layout
+        id='collection-container'
+        title='Collection'
+        topbarButtons={
+          [
+            {
+              type: 'button',
+              id: 'create-dataset',
+              icon: faPlus,
+              label: 'New Dataset',
+              onClick: () => { setModal({ type: ModalType.NewDataset }) }
+            },
+            {
+              type: 'button',
+              id: 'pull-dataset',
+              icon: faDownload,
+              label: 'Pull Dataset',
+              onClick: () => { setModal({ type: ModalType.PullDataset }) }
+            }
+          ]
+        }
+        mainContent={<DatasetCollection />}
+      />
+    </>
   )
 }
 

--- a/app/components/collection/layouts/DatasetLayout.tsx
+++ b/app/components/collection/layouts/DatasetLayout.tsx
@@ -10,7 +10,6 @@ import { selectSidebarWidth } from '../../../selections'
 
 import Layout from '../../Layout'
 import DatasetSidebar from './DatasetSidebar'
-import DatasetMainContent from './DatasetMainContent'
 
 interface DatasetLayoutProps {
   // from connect
@@ -41,7 +40,7 @@ const DatasetLayoutComponent: React.FunctionComponent<DatasetLayoutProps> = (pro
       sidebarWidth={sidebarWidth}
       headerContent={headerContent}
       onSidebarResize={onSidebarResize}
-      mainContent={<DatasetMainContent>{mainContent}</DatasetMainContent>}
+      mainContent={mainContent}
       sidebarContent={<DatasetSidebar />}
     />
   )

--- a/app/components/collection/layouts/DatasetMainContent.tsx
+++ b/app/components/collection/layouts/DatasetMainContent.tsx
@@ -2,14 +2,12 @@ import * as React from 'react'
 
 import LinkButton from '../headerButtons/LinkButton'
 import PublishButton from '../headerButtons/PublishButton'
-import UncommitedChangesPrompt from '../UncommitedChangesPrompt'
 
 const DatasetMainContentComponent: React.FunctionComponent = (props) => {
   const {
     children
   } = props
   return <>
-    <UncommitedChangesPrompt />
     <div className='main-content-header'>
       <LinkButton />
       <PublishButton />

--- a/app/components/collection/layouts/DatasetMainContent.tsx
+++ b/app/components/collection/layouts/DatasetMainContent.tsx
@@ -1,39 +1,21 @@
 import * as React from 'react'
 
-import { connectComponentToPropsWithRouter } from '../../../utils/connectComponentToProps'
-import { QriRef, qriRefFromRoute } from '../../../models/qriRef'
-import { RouteProps } from '../../../models/store'
-import { ApiActionThunk } from '../../../store/api'
-import { fetchWorkingDatasetDetails } from '../../../actions/api'
-import { selectFsiPath, selectMutationsIsDirty } from '../../../selections'
+import LinkButton from '../headerButtons/LinkButton'
+import PublishButton from '../headerButtons/PublishButton'
+import UncommitedChangesPrompt from '../UncommitedChangesPrompt'
 
-interface DatasetMainContentProps extends RouteProps {
-  qriRef: QriRef
-  modified: boolean
-  fsiPath: string
-  fetchWorkingDatasetDetails: (username: string, name: string) => ApiActionThunk
+const DatasetMainContentComponent: React.FunctionComponent = (props) => {
+  const {
+    children
+  } = props
+  return <>
+    <UncommitedChangesPrompt />
+    <div className='main-content-header'>
+      <LinkButton />
+      <PublishButton />
+    </div>
+    {children}
+  </>
 }
 
-const DatasetMainContentComponent: React.FunctionComponent<DatasetMainContentProps> = (props) => {
-  const { children } = props
-  return (
-    <>
-      {children}
-    </>
-  )
-}
-
-export default connectComponentToPropsWithRouter(
-  DatasetMainContentComponent,
-  (state: any, ownProps: DatasetMainContentProps) => {
-    return {
-      ...ownProps,
-      qriRef: qriRefFromRoute(ownProps),
-      fsiPath: selectFsiPath(state),
-      modified: selectMutationsIsDirty(state)
-    }
-  },
-  {
-    fetchWorkingDatasetDetails
-  }
-)
+export default DatasetMainContentComponent

--- a/app/components/item/VersionInfoItem.tsx
+++ b/app/components/item/VersionInfoItem.tsx
@@ -19,9 +19,12 @@ interface VersionInfoItemProps {
   onClickFolder?: (data: VersionInfo, e: React.MouseEvent) => void
 }
 
+const zeroTimeString = '0001-01-01T00:00:00Z'
+
 const VersionInfoItem: React.FC<VersionInfoItemProps> = (props) => {
   const { data, selected = false, onToggleSelect, onClick, onClickFolder } = props
   const { username, name, commitTime, bodySize, bodyRows, fsiPath, published } = data
+
   return (
     <tr
       id={`${username}-${name}`}
@@ -40,7 +43,7 @@ const VersionInfoItem: React.FC<VersionInfoItemProps> = (props) => {
         <span className='ref text' onClick={(e: React.MouseEvent) => { onClick(data, e) }}>{username}/{name}</span>
       </td>
       <td>
-        <span data-tip={commitTime}>{commitTime ? moment(commitTime).fromNow() : '--'}</span>
+        <span data-tip={commitTime}>{commitTime !== zeroTimeString ? moment(commitTime).fromNow() : '--'}</span>
       </td>
       <td>{bodySize ? numeral(bodySize).format('0.00 b') : '--'}</td>
       <td>

--- a/app/components/modals/Modal.tsx
+++ b/app/components/modals/Modal.tsx
@@ -8,6 +8,33 @@ import ReactTooltip from 'react-tooltip'
  */
 const titleBarHeight = 22
 
+/**
+ * HOW TO USE MODALS
+ *
+ * Once you have created your modal component how do you wire it up to work in
+ * the app?
+ *
+ * First, look at the `/app/models/modals.ts` file. You need to create a specific
+ * `ModalType` for your new modal. Then, any parameters that you need so the
+ * modal can function should be added as fields on the modal type.
+ *
+ * When you want the modal to appear, emit the `setModal` action, with the correct
+ * modal type and appropriate details. That action will add the modal struct to
+ * UI reducer. The App component will then get the modal struct. If the modal
+ * struct is NOT of `NoModal` type, it will pass the modal struct to the `Modals`
+ * component.
+ *
+ * You must add your new modal component to the `Modals` component. This component
+ * switches on `type` to determine what modal to display.
+ *
+ * All modals should be containerized, aka, have a `connect` function that
+ * connects the modal to the state tree. It is required to get its own modal struct
+ * from the state tree (use the `selectModal` selector).
+ *
+ * Each modal should emit the `dismissModal` function to close the modal on cancel
+ * or any other action that makes sense for the modal to close.
+ *
+ */
 export interface ModalProps {
   /**
    * An optional dialog title. Most, if not all dialogs should have
@@ -74,27 +101,7 @@ export interface ModalProps {
    * An optional className to be applied to the rendered dialog element.
    */
   readonly className?: string
-
-  /**
-   * Whether or not the dialog should be disabled. All dialogs wrap their
-   * content in a <fieldset> element which, when disabled, causes all descendant
-   * form elements and buttons to also become disabled. This is useful for
-   * consumers implementing a typical save dialog where the save action isn't
-   * instantaneous (such as a sign in dialog) and they need to ensure that the
-   * user doesn't continue mutating the form state or click buttons while the
-   * save/submit action is in progress. Note that this does not prevent the
-   * dialog from being dismissed.
-   */
   readonly disabled?: boolean
-
-  /**
-   * Whether or not the dialog contents are currently involved in processing
-   * data, executing an asynchronous operation or by other means working.
-   * Setting this value will render a spinning progress icon in the dialog
-   * header (if the dialog has a header). Note that the spinning icon
-   * will temporarily replace the dialog icon (if present) for the duration
-   * of the loading operation.
-   */
   readonly loading?: boolean
 
   /**

--- a/app/models/qriRef.ts
+++ b/app/models/qriRef.ts
@@ -82,6 +82,12 @@ export function qriRefIsEmpty (qriRef: QriRef): boolean {
   return !qriRef.location || qriRef.location === '' || !qriRef.username || qriRef.username === '' || !qriRef.name || qriRef.name === ''
 }
 
+// checks if the two given qriRefs refer to the same dataset
+// aka, have the same username and name
+export function qriRefIsSameDataset (a: QriRef, b: QriRef): boolean {
+  return a.username === b.username && a.name === b.name
+}
+
 // selectedComponentFromQriRef takes a qriRef and gets the selected component
 // from the location param
 export function selectedComponentFromLocation (location: string): SelectedComponent | undefined {

--- a/app/models/store.ts
+++ b/app/models/store.ts
@@ -145,7 +145,7 @@ export interface VersionInfo {
   // commit description message
   commitMessage: string
   // commit.Timestamp field, time of version creation
-  commitTime: Date
+  commitTime: string
   // number of commits in history
   numCommits?: number
 

--- a/app/reducers/dataset.ts
+++ b/app/reducers/dataset.ts
@@ -38,7 +38,7 @@ const initialState: DatasetStore = {
   stats: []
 }
 
-const [COMMITDATASET_REQ, COMMITDATASET_SUCC, COMMITDATASET_FAIL] = apiActionTypes('commitdataset')
+export const [COMMITDATASET_REQ, COMMITDATASET_SUCC, COMMITDATASET_FAIL] = apiActionTypes('commitdataset')
 const [COMMITSTATUS_REQ, COMMITSTATUS_SUCC, COMMITSTATUS_FAIL] = apiActionTypes('commitstatus')
 const [COMMITBODY_REQ, COMMITBODY_SUCC, COMMITBODY_FAIL] = apiActionTypes('commitbody')
 const [COMMITSTATS_REQ, COMMITSTATS_SUCC, COMMITSTATS_FAIL] = apiActionTypes('commitstats')
@@ -55,6 +55,8 @@ const DatasetReducer: Reducer = (state = initialState, action: AnyAction): Datas
     case COMMITDATASET_REQ:
       return {
         ...state,
+        peername: action.segments.username,
+        name: action.segments.name,
         isLoading: true
       }
     case COMMITDATASET_SUCC:

--- a/app/reducers/workbenchRoutes.ts
+++ b/app/reducers/workbenchRoutes.ts
@@ -25,8 +25,8 @@ export const WORKBENCH_ROUTES_CLEAR = 'WORKBENCH_ROUTES_CLEAR'
 export default (state = initialState, action: AnyAction) => {
   switch (action.type) {
     case WORKBENCH_ROUTES_HISTORY_REF:
-      if (state.historyRef.username !== action.qriRef.username ||
-        state.historyRef.name !== action.qriRef.name) {
+      if ((state.historyRef.username !== '' && state.historyRef.username !== action.qriRef.username) ||
+        (state.historyRef.name !== '' && state.historyRef.name !== action.qriRef.name)) {
         return {
           ...initialState,
           historyRef: action.qriRef,
@@ -39,8 +39,8 @@ export default (state = initialState, action: AnyAction) => {
         location: action.qriRef.location
       }
     case WORKBENCH_ROUTES_EDIT_REF:
-      if (state.editRef.username !== action.qriRef.username ||
-        state.editRef.name !== action.qriRef.name) {
+      if ((state.editRef.username !== '' && state.editRef.username !== action.qriRef.username) ||
+        (state.editRef.name !== '' && state.editRef.name !== action.qriRef.name)) {
         return {
           ...initialState,
           editRef: action.qriRef,

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -5,6 +5,7 @@ import { apiActionTypes } from '../utils/actionType'
 import { reducerWithPagination, initialPageInfo } from '../utils/pagination'
 import { ipcRenderer } from 'electron'
 import bodyValue from '../utils/bodyValue'
+import { COMMITDATASET_REQ } from './dataset'
 
 import {
   REMOVE_SUCC
@@ -55,12 +56,19 @@ export const RESET_BODY = 'RESET_BODY'
 
 const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction): WorkingDataset | null => {
   switch (action.type) {
+    case COMMITDATASET_REQ:
+      if (action.segments.username !== state.peername || action.segments.name !== state.name) {
+        return initialState
+      }
+      return state
     case DATASET_REQ:
-      if (action.segments.peername === state.peername && action.segments.name === state.name) {
+      if (action.segments.username === state.peername && action.segments.name === state.name) {
         return state
       }
       return {
         ...initialState,
+        peername: action.segments.username,
+        name: action.segments.name,
         isLoading: true
       }
     case DATASET_SUCC: // when adding a new dataset, set it as the new workingDataset

--- a/app/selections.ts
+++ b/app/selections.ts
@@ -120,6 +120,10 @@ export function selectLogPageInfo (state: Store): PageInfo {
   return state.log.pageInfo
 }
 
+export function selectHasHistory (state: Store): boolean {
+  return !!state.log.value.length
+}
+
 /**
  *
  * MYDATASETS STATE TREE
@@ -176,7 +180,7 @@ export function selectMutationsDataset (state: Store): Dataset {
 }
 
 export function selectMutationsIsDirty (state: Store): boolean {
-  return !!state.mutations.dirty
+  return !!state.mutations.dirty && !state.workingDataset.fsiPath
 }
 
 export function selectIsCommiting (state: Store): boolean {


### PR DESCRIPTION
closes #617 
closes #613 

A bunch of this cleans up functionality that was changed when we refactored the routes and refactored away from the "status" and "history" tabs.

- add notes on how to integrate new modals
- fixed bug in `workbenchRoutes` that was causing the history ref to reset when there was a new edit ref, and the edit ref to reset when there was a new history ref
- fixed bug that was causing double fetching b/c we weren't storing `peername` and `name` in the state tree when we fetched any dataset information
- refactored the "you have uncommitted changes" code into one component for easier future fixes & refactored to ensure it was working as expected
- restored the ability to `Discard changes` in linked and unlinked datasets.