### PR TITLE
fix(commit): Don't push cursor to end of text input elements

### DIFF
--- a/app/components/form/TextAreaInput.tsx
+++ b/app/components/form/TextAreaInput.tsx
@@ -55,7 +55,7 @@ const TextAreaInput: React.FunctionComponent<TextAreaInputProps> = (props) => {
           name={name}
           maxLength={maxLength}
           className='input'
-          value={stateValue || ''}
+          defaultValue={stateValue || ''}
           placeholder={placeHolder}
           onChange={handleOnChange}
           onBlur={onBlur}

--- a/app/components/form/TextInput.tsx
+++ b/app/components/form/TextInput.tsx
@@ -67,7 +67,7 @@ const TextInput: React.FunctionComponent<TextInputProps> = (props) => {
           type={type}
           maxLength={maxLength}
           className='input'
-          value={stateValue || ''}
+          defaultValue={stateValue || ''}
           placeholder={placeHolder}
           onChange={handleOnChange}
           onBlur={onBlur}


### PR DESCRIPTION
According to: https://stackoverflow.com/questions/28922275/in-reactjs-why-does-setstate-behave-differently-when-called-synchronously/28922465#28922465, using `onChange` along with `value` on input elements leads to problems when the element is changed asynchronously. Using `defaultValue` instead fixes this problem.

Fixes https://github.com/qri-io/desktop/issues/496.