### PR TITLE
fix: external readme links

### DIFF
--- a/app/components/collection/WorkingComponentList.tsx
+++ b/app/components/collection/WorkingComponentList.tsx
@@ -172,7 +172,6 @@ export const WorkingComponentListComponent: React.FunctionComponent<WorkingCompo
                 onClick={(component: SelectedComponent) => {
                   history.push(pathToEdit(username, datasetName, component))
                 }}
-                color='light'
               />
             </ContextMenuArea>
           )

--- a/app/components/collection/datasetComponents/Readme.tsx
+++ b/app/components/collection/datasetComponents/Readme.tsx
@@ -2,11 +2,16 @@ import * as React from 'react'
 
 import Store, { RouteProps } from '../../../models/store'
 import { refStringFromQriRef, QriRef, qriRefFromRoute } from '../../../models/qriRef'
+import { onClick as openExternal } from '../../platformSpecific/ExternalLink.electron'
 
 import { connectComponentToProps } from '../../../utils/connectComponentToProps'
 
 export interface ReadmeProps extends RouteProps {
   qriRef: QriRef
+}
+
+const handleClick = (e: React.SyntheticEvent) => {
+  openExternal(e, e.target.href)
 }
 
 export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => {
@@ -40,6 +45,7 @@ export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => 
       // use "editor-preview" class to piggie-back off the simplemde styling
       className="editor-preview"
       ref={ref}
+      onClick={handleClick}
     >loading...
     </div>
   )

--- a/app/components/collection/datasetComponents/Readme.tsx
+++ b/app/components/collection/datasetComponents/Readme.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import Store, { RouteProps } from '../../../models/store'
 import { refStringFromQriRef, QriRef, qriRefFromRoute } from '../../../models/qriRef'
-import { onClick as openExternal } from '../../platformSpecific/ExternalLink.electron'
+import { onClick as openExternal } from '../../platformSpecific/ExternalLink.TARGET_PLATFORM'
 
 import { connectComponentToProps } from '../../../utils/connectComponentToProps'
 

--- a/app/components/collection/datasetComponents/Readme.tsx
+++ b/app/components/collection/datasetComponents/Readme.tsx
@@ -10,7 +10,7 @@ export interface ReadmeProps extends RouteProps {
   qriRef: QriRef
 }
 
-const handleClick = (e: React.SyntheticEvent) => {
+const handleClick = (e: React.MouseEvent) => {
   openExternal(e, e.target.href)
 }
 

--- a/app/components/collection/datasetComponents/ReadmeEditor.tsx
+++ b/app/components/collection/datasetComponents/ReadmeEditor.tsx
@@ -8,7 +8,7 @@ import hasParseError from '../../../utils/hasParseError'
 import Dataset from '../../../models/dataset'
 import { refStringFromQriRef, QriRef, qriRefFromRoute } from '../../../models/qriRef'
 import Store, { StatusInfo, RouteProps } from '../../../models/store'
-import { onClick as openExternal } from '../../platformSpecific/ExternalLink.electron'
+import { onClick as openExternal } from '../../platformSpecific/ExternalLink.TARGET_PLATFORM'
 
 import { writeDataset } from '../../../actions/workbench'
 

--- a/app/components/collection/datasetComponents/ReadmeEditor.tsx
+++ b/app/components/collection/datasetComponents/ReadmeEditor.tsx
@@ -8,6 +8,7 @@ import hasParseError from '../../../utils/hasParseError'
 import Dataset from '../../../models/dataset'
 import { refStringFromQriRef, QriRef, qriRefFromRoute } from '../../../models/qriRef'
 import Store, { StatusInfo, RouteProps } from '../../../models/store'
+import { onClick as openExternal } from '../../platformSpecific/ExternalLink.electron'
 
 import { writeDataset } from '../../../actions/workbench'
 
@@ -29,6 +30,8 @@ export interface ReadmeEditorProps extends RouteProps {
   statusInfo: StatusInfo
   write: (peername: string, name: string, dataset: any) => ApiActionThunk | void
 }
+
+const passEventToOpenExternal = (e: MouseEvent) => { openExternal(e, e.target.href) }
 
 export const ReadmeEditorComponent: React.FunctionComponent<ReadmeEditorProps> = (props) => {
   const {
@@ -77,6 +80,8 @@ export const ReadmeEditorComponent: React.FunctionComponent<ReadmeEditorProps> =
     setInternalValue(value)
   }
 
+  const [ listenerAdded, setListenerAdded ] = React.useState(false)
+
   /**
    * TODO (ramfox): this func is getting to the point where it probably should
    * live outside of this component, however, I'm not sure where it should live
@@ -85,6 +90,11 @@ export const ReadmeEditorComponent: React.FunctionComponent<ReadmeEditorProps> =
    * are okay living where they work
    */
   const getPreview = (plainText: string, preview: HTMLElement) => {
+    if (!listenerAdded) {
+      preview.addEventListener('click', passEventToOpenExternal)
+      setListenerAdded(true)
+    }
+
     if (isLinked) {
       fetch(`http://localhost:2503/render/${refStringFromQriRef(qriRef)}?fsi=true`)
         .then(async (res) => res.text())

--- a/app/scss/0.4.0/dataset.scss
+++ b/app/scss/0.4.0/dataset.scss
@@ -94,6 +94,9 @@
 }
 
 .structure {
+  height: 100%;
+  overflow-y: scroll;
+
   > div {
     padding: 15px;
   }
@@ -214,4 +217,15 @@
     width: 100%;
     border-radius: 3px;
   }
+}
+
+// easyMDE (readme)
+.EasyMDEContainer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.cm-s-easymde {
+  height: 100%;
 }

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -597,7 +597,6 @@ $header-font-size: .9rem;
     flex: 1;
     height: 100%;
     width: 100%;
-    overflow-y: auto;
     position:relative;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Adds click listeners to hijack clicks on rendered readmes (both in historic commit readme display and when previewing a working readme), so that links are intercepted and sent to electron's external link opener.

Includes some css cleanup to fix a double vertical scrollbar on the readme editor and a non-scrolling structure viewer.  All components should overflow/scroll in the same way now.

Removes `color='light'` prop on WorkingComponentList items so each component's icon is shown (they were white on white and not visible)

closes #540 