### PR TITLE
test(e2e): get e2e tests to pass with refactorings

### DIFF
--- a/app/components/collection/LogList.tsx
+++ b/app/components/collection/LogList.tsx
@@ -16,7 +16,7 @@ import { selectLog, selectLogPageInfo, selectInNamespace, selectRecentEditRef } 
 
 import LogListItem from '../item/LogListItem'
 import { pathToDataset, pathToEdit } from '../../paths'
-import HeadLogListItem from '../item/HeadLogListItem'
+import WorkingLogListItem from '../item/WorkingLogListItem'
 
 interface LogListProps extends RouteProps {
   qriRef: QriRef
@@ -68,7 +68,7 @@ export const LogListComponent: React.FunctionComponent<LogListProps> = (props) =
       onScroll={(e) => handleLogScroll(e)}
     >
       {
-        editableDataset && <HeadLogListItem
+        editableDataset && <WorkingLogListItem
           onClick={() => {
             if (qriRefIsEmpty(recentEditRef)) {
               history.push(pathToEdit(username, name))
@@ -82,11 +82,12 @@ export const LogListComponent: React.FunctionComponent<LogListProps> = (props) =
       }
       {
         log.map((item, i) => {
+          const id = `HEAD-${i}`
           if (item.foreign) {
             return <LogListItem
               data={item}
               key={item.path}
-              id={`HEAD-${i + 1}`}
+              id={id}
               first={i === 0}
               last={i === log.length - 1}
               selected={qriRef.path === item.path}
@@ -108,7 +109,7 @@ export const LogListComponent: React.FunctionComponent<LogListProps> = (props) =
               <LogListItem
                 data={item}
                 key={item.path}
-                id={`HEAD-${i + 1}`}
+                id={id}
                 first={i === 0}
                 last={i === log.length - 1}
                 selected={qriRef.path === item.path}

--- a/app/components/collection/collectionHome/CollectionHome.tsx
+++ b/app/components/collection/collectionHome/CollectionHome.tsx
@@ -31,8 +31,8 @@ export const CollectionHome: React.FC<CollectionHomeProps> = ({ setModal }) => {
               type: 'button',
               id: 'create-dataset',
               icon: faPlus,
-              label: 'New Dataset',
-              onClick: () => { setModal({ type: ModalType.NewDataset }) }
+              label: 'Create Dataset',
+              onClick: () => { setModal({ type: ModalType.CreateDataset }) }
             },
             {
               type: 'button',

--- a/app/components/collection/layouts/DatasetSidebar.tsx
+++ b/app/components/collection/layouts/DatasetSidebar.tsx
@@ -9,6 +9,7 @@ import { selectVersionInfoFromWorkingDataset } from '../../../selections'
 
 import ReactTooltip from 'react-tooltip'
 import LogList from '../LogList'
+import DatasetReference from '../../DatasetReference'
 
 export interface DatasetSidebarProps extends RouteProps {
   qriRef: QriRef
@@ -25,6 +26,9 @@ export const DatasetSidebarComponent: React.FunctionComponent<DatasetSidebarProp
 
   return (
     <div className='sidebar'>
+      <div className='sidebar-header'>
+        <DatasetReference qriRef={qriRef} />
+      </div>
       <LogList qriRef={qriRef} />
     </div>
   )

--- a/app/components/item/VersionInfoItem.tsx
+++ b/app/components/item/VersionInfoItem.tsx
@@ -40,7 +40,7 @@ const VersionInfoItem: React.FC<VersionInfoItemProps> = (props) => {
         />
       </td>
       <td>
-        <span className='ref text' onClick={(e: React.MouseEvent) => { onClick(data, e) }}>{username}/{name}</span>
+        <span id={`${username}-${name}-link`} className='ref text' onClick={(e: React.MouseEvent) => { onClick(data, e) }}>{username}/{name}</span>
       </td>
       <td>
         <span data-tip={commitTime}>{commitTime !== zeroTimeString ? moment(commitTime).fromNow() : '--'}</span>

--- a/app/components/item/WorkingLogListItem.tsx
+++ b/app/components/item/WorkingLogListItem.tsx
@@ -2,16 +2,16 @@ import React from 'react'
 import { Action } from 'redux'
 import classNames from 'classnames'
 
-export interface HeadLogListItemProps {
+export interface WorkingLogListItemProps {
   selected?: boolean
   last?: boolean
   onClick?: () => Action
 }
 
-const HeadLogListItem: React.FunctionComponent<HeadLogListItemProps> = ({ last, selected, onClick }) => {
+const WorkingLogListItem: React.FunctionComponent<WorkingLogListItemProps> = ({ last, selected, onClick }) => {
   return (
     <div
-      id='head'
+      id='working-version'
       className={classNames(
         'sidebar-list-item',
         'sidebar-list-item-text',
@@ -38,4 +38,4 @@ const HeadLogListItem: React.FunctionComponent<HeadLogListItemProps> = ({ last, 
   )
 }
 
-export default HeadLogListItem
+export default WorkingLogListItem

--- a/app/components/modals/CreateDataset.tsx
+++ b/app/components/modals/CreateDataset.tsx
@@ -1,0 +1,167 @@
+import * as React from 'react'
+import path from 'path'
+import { remote } from 'electron'
+import fs from 'fs'
+import changeCase from 'change-case'
+
+import { CreateDatasetModal } from '../../models/modals'
+import { ApiAction } from '../../store/api'
+
+import { connectComponentToProps } from '../../utils/connectComponentToProps'
+
+import { dismissModal } from '../../actions/ui'
+import { importFile } from '../../actions/api'
+
+import { selectModal } from '../../selections'
+
+import { QRI_IO_URL } from '../../constants'
+
+import Modal from './Modal'
+import ExternalLink from '../ExternalLink'
+import TextInput from '../form/TextInput'
+import Error from './Error'
+import Buttons from './Buttons'
+import ButtonInput from '../form/ButtonInput'
+
+interface CreateDatasetProps {
+  onDismissed: () => void
+  importFile: (filePath: string, fileName: string, fileSize: number) => Promise<ApiAction>
+  modal: CreateDatasetModal
+}
+
+const CreateDatasetComponent: React.FunctionComponent<CreateDatasetProps> = (props) => {
+  const {
+    onDismissed,
+    importFile
+  } = props
+
+  const validName = (name: string): string => {
+    // cast name to meet our specification
+    // make lower case, snakecase, and remove invalid characters
+    let coercedName = changeCase.lowerCase(name)
+    coercedName = changeCase.snakeCase(name)
+    return coercedName.replace(/^[^a-z0-9_]+$/g, '')
+  }
+
+  const [filePath, setFilePath] = React.useState('')
+  const [datasetName, setDatasetName] = React.useState(validName(path.basename(filePath, path.extname(filePath))))
+
+  const [dismissable, setDismissable] = React.useState(true)
+  const [buttonDisabled, setButtonDisabled] = React.useState(true)
+  const [alreadyDatasetError, setAlreadyDatasetError] = React.useState('')
+
+  React.useEffect(() => {
+    setButtonDisabled(filePath === '')
+  }, [filePath])
+
+  // should come from props
+  const [error, setError] = React.useState('')
+  const [loading, setLoading] = React.useState(false)
+
+  // should come from props/actions that has us check if the directory already contains a qri dataset
+  const isQriDataset = (datasetDirPath: string) => !datasetDirPath
+
+  const showFilePicker = () => {
+    const window = remote.getCurrentWindow()
+    const filePath: string[] | undefined = remote.dialog.showOpenDialogSync(window, {
+      properties: ['openFile']
+    })
+
+    if (!filePath) {
+      return
+    }
+
+    const selectedPath = filePath[0]
+    const basename = path.basename(selectedPath)
+    const name = basename.split('.')[0]
+
+    if (name && datasetName === '') {
+      setDatasetName(validName(name))
+    }
+
+    setFilePath(selectedPath)
+    const isDataset = isQriDataset(selectedPath)
+    if (isDataset) {
+      setAlreadyDatasetError('A dataset already exists in this directory.')
+      setButtonDisabled(true)
+    }
+  }
+
+  const handleFilePickerDialog = (showFunc: () => void) => {
+    new Promise(resolve => {
+      setDismissable(false)
+      resolve()
+    })
+      .then(() => showFunc())
+      .then(() => setDismissable(true))
+  }
+
+  const handleSubmit = () => {
+    if (filePath === '') return
+    setDismissable(false)
+    setLoading(true)
+    const fileName = path.basename(filePath)
+    const stats = fs.statSync(filePath)
+
+    error && setError('')
+    if (!importFile) return
+    importFile(filePath, fileName, stats.size)
+    onDismissed()
+  }
+
+  return (
+    <Modal
+      id="create_modal"
+      title={'Create a New Dataset'}
+      onDismissed={onDismissed}
+      onSubmit={() => {}}
+      dismissable={dismissable}
+      setDismissable={setDismissable}
+    >
+      <div className='content-wrap' >
+        <div className='content'>
+          <p>Qri will create a directory for your new dataset, containing files linked to each of the dataset&apos;s <ExternalLink href={`${QRI_IO_URL}/docs/concepts/dataset/`}>components</ExternalLink>.</p>
+          <p>The data file you specify will become your new dataset&apos;s <ExternalLink href={`${QRI_IO_URL}/docs/reference/dataset/#body`}>body</ExternalLink> component.</p>
+          <div className='flex-space-between'>
+            <TextInput
+              name='filePath'
+              label='Source data file'
+              labelTooltip='Select a CSV or JSON file on your computer.<br/>Qri will import the data and leave the file in place.'
+              type=''
+              value={filePath}
+              onChange={(e: React.ChangeEvent) => {
+                setButtonDisabled(e.target.value === '')
+              }}
+              maxLength={600}
+              errorText={alreadyDatasetError}
+              tooltipFor='modal-tooltip'
+            />
+            <div className='margin-left'><ButtonInput id='chooseBodyFilePath' onClick={() => handleFilePickerDialog(showFilePicker)} >Choose...</ButtonInput></div>
+          </div>
+        </div>
+      </div>
+      <Error id={'create-modal-error'} text={error} />
+      <Buttons
+        cancelText='cancel'
+        onCancel={onDismissed}
+        submitText='Create Dataset'
+        onSubmit={handleSubmit}
+        disabled={buttonDisabled}
+        loading={loading}
+      />
+    </Modal>
+  )
+}
+
+export default connectComponentToProps(
+  CreateDatasetComponent,
+  (state: any, ownProps: CreateDatasetProps) => {
+    return {
+      modal: selectModal(state)
+    }
+  },
+  {
+    importFile,
+    onDismissed: dismissModal
+  }
+)

--- a/app/components/modals/Modals.tsx
+++ b/app/components/modals/Modals.tsx
@@ -7,6 +7,7 @@ import LinkDataset from './LinkDataset'
 import RemoveDataset from './RemoveDataset'
 import ExportDataset from './ExportDataset'
 import NewDataset from './NewDataset'
+import CreateDataset from './CreateDataset'
 import PublishDataset from './PublishDataset'
 import UnpublishDataset from './UnpublishDataset'
 import SearchModal from './SearchModal'
@@ -21,6 +22,8 @@ const Modals: React.FunctionComponent<ModalsProps> = ({ type }) => {
       return <PullDataset />
     case ModalType.NewDataset:
       return <NewDataset />
+    case ModalType.CreateDataset:
+      return <CreateDataset />
     case ModalType.LinkDataset:
       return <LinkDataset />
     case ModalType.PublishDataset:

--- a/app/components/network/NetworkSidebar.tsx
+++ b/app/components/network/NetworkSidebar.tsx
@@ -5,9 +5,6 @@ const NetworkSidebar: React.FunctionComponent = (props) => {
   return (
     <div id='network-sidebar'>
       <div className='sidebar' >
-        <div className='sidebar-header sidebar-padded-container'>
-          <p className='pane-title'>Network</p>
-        </div>
         <div className='sidebar-content'>
           {children}
         </div>

--- a/app/models/modals.ts
+++ b/app/models/modals.ts
@@ -1,6 +1,7 @@
 export enum ModalType {
   NoModal,
   NewDataset,
+  CreateDataset,
   PullDataset,
   LinkDataset,
   RemoveDataset,
@@ -16,6 +17,10 @@ export interface PullDatasetModal {
 
 export interface NewDatasetModal {
   type: ModalType.NewDataset
+}
+
+export interface CreateDatasetModal {
+  type: ModalType.CreateDataset
 }
 
 export interface ExportDatasetModal {
@@ -56,6 +61,7 @@ export interface UnpublishDatasetModal {
 
 export type Modal = PullDatasetModal
 | NewDatasetModal
+| CreateDatasetModal
 | LinkDatasetModal
 | HideModal
 | PublishDatasetModal

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -237,6 +237,7 @@ $header-font-size: .9rem;
     .dataset-reference {
       font-size: 1.05rem;
       display: flex;
+      margin: 20px 20px 0 20px;
     }
 
     .dataset-name {

--- a/test/e2e/e2e_test_flows.md
+++ b/test/e2e/e2e_test_flows.md
@@ -1,0 +1,170 @@
+# e2e test flows
+
+This is a basic rundown of what we expect for the e2e flows as the newer features come in.
+
+Some thoughts on the e2e tests:
+They have been super helpful in catching bugs & making sure we don't regress in
+functionality. However, they are EXTREMELY stateful. Any change you make to a 
+previous test may effect a test later. Something as simple as removing a button
+or changing an id tag, if the id is relied on to find the element, can have
+adverse effects on the tests.
+
+The goal for this basic rundown is to give you a quick idea of what might get 
+effected if you make a change to an e2e test. It would also be great if we could
+keep track of relied on ids and expectations here, until we figure out a better
+method.
+
+It would also be a good idea to checkout the `/test/utils/e2eTestUtils.ts` 
+functions. The comments should give you an idea of what its expected that they
+do & how to use them. Two things to note. First, each test util function has an optional `screenshotLocation` string. If this variable is not undefined AND the test errored, a screenshot of the app will be saved to the temp directory. This is mostly used to understand what is going wrong in circle ci, as you can watch the test from your personal computer, but can't watch it in circle ci. Second, the `delayTime` variable at the start of the file adjusts the amount of time we delay when the app is NOT in headless mode. This allows the app to render each view & gives us as humans a moment to understand what's going on. You can adjust this if you feel it is too fast or slow.
+
+At the top of the e2e.spec.ts file, there are two globals I want to point out.
+The first is `takeScreenshots`. When true, there are different moments in the app where the app will take a screenshot of the current page. This can be used to see what's going on (but also was primarily used to generate screenshots of the desktop app for use on our qri.io/docs site).
+
+The second is `printConsoleLogs`. When true, any console logs that occur during the main or renderer processes will get printed. console logs from the test will get printed regardless.
+
+## onboarding
+The following flows deal with launching the app for the first time, signing out and signing in
+### open window
+- open the window
+- prove the window has loaded:
+  - expect the title to be 'Qri Desktop'
+
+### accept the terms of service
+- wait for the #welcome-page to load
+- click #accept
+- make sure we have been send to `#/onboard/signup`
+
+### create a new account
+- wait for the #signup-page to load
+- set values for the #username, #email, and #password
+- click #accept
+- make sure we have redirected to the `#/collection` page
+
+### signin and signout
+- click the #nav-options button to open the options dropdown
+- click the #signout button to signout
+- make sure we are sent to the #/onboard/signup page
+- navigate to the #signin page
+- set values for the #username and #password
+- click #accept
+- make sure you are sent to the #/collection page
+
+## creating and modifying an FSI dataset
+### create a new csv
+- make sure you are on the #/collection page
+- click the #create-dataset button
+- create a temp csv file & mock the save dialog when you click #chooseBodyFilePath
+- click #submit
+- make sure we get redirected to the new dataset page
+- ensure we are at the correct version (the latest)
+- ensure the body and structure were 'added'
+
+### navigate to the collection and back to the dataset
+- click the #collection button
+- ensure we are at the #collection
+- click on the dataset reference (#username-name-link)
+- ensure we are at the correct location
+- ensure we are the same version
+
+### checkut a dataset
+- ensure we are at the correct dataset
+- click #checkout
+- mock the dialog
+- click #chooseCheckoutLocation
+- click #submit
+- wait for the modal to go away
+- check that there is no more #checkout button
+
+### write the body to the filesystem and commit
+- navigate to the working version
+- check that we are not .clear-to-commit
+- adjust the checkedout body file
+- check that the status of 'body' is 'modified'
+- commit
+
+### fsi editing - create meta & commit
+- ensure you are on the correct dataset
+- edit meta and commit
+
+### edit structure & commit
+- ensure you are on the right dataset
+- edit structure and commit
+
+### rename a dataset
+- ensure you are on the correct dataset
+- click the dataset name
+- set an incorrect value as the name
+- ensure we get the invalid indication
+- set a good name
+- click away to submit
+
+### switch between commits
+- ensure you are at the correct dataset
+- click on each commit #HEAD-3 #HEAD-2 #HEAD-1 #HEAD-0
+- after each, ensure the title is as expected
+
+## non-checked out datasets
+The following flows are essentially the same as the above, but with a non-checked out dataset. Currently the only way for us to test updating a body in the app is via drag-and-drop. Since we don't currently have a method for mocking drag and drop in spectron, we skip the part where we modify the body and go straight to modifying the meta
+### create a dataset (same as above)
+### edit meta and commit (same as above)
+### edit structure and commit (same as above)
+### switch between commits (same as above, with one less commit)
+
+## json datasets
+# ensure we can create a json dataset
+
+## network
+This section deals with the network page
+### clicking on the network tab brings you to the network home
+- click on the network tab
+- ensure it has one dataset
+
+### search for a foreign dataset
+- click on the search bar
+- hit "enter"
+- wait for the search modal to appear
+- search for the dataset name (you can't search for the username and the dataset name because the username is randomly generated for each run of the test)
+- hit "enter"
+- ensure the resulting dataset item is the correct dataset
+- click it
+- since we don't have the username, we have to get weird with how we determine if we are on the correct dataset: ensure we are at the #/network location, and check that the #navbar-breadcrumb contains the registry dataset name
+
+### clone a foreign dataset
+- click the clone button
+- we should be sent to the dataset page of that dataset
+- navigate to the collection page and ensure that dataset is part of the collection
+
+### add another commit & see new commits in network
+- ping the registry to create another commit
+- navigate to the network tab
+- click on the dataset
+- see the new commit
+- see no 'clone' button
+
+## collection page
+### tabs
+- check that the MyDatasets tab has 3 datasets
+- check that the AllDatasets tab has 4 datasets
+- check that dataset 'earthquakes' shows that it is checked out
+- check that dataset 'all_week' shows that it is NOT checked out
+
+### filter on the collection page
+- navigate to the collection page
+- set value to the filter 'earthquakes'
+- only 1 dataset should exist on the page
+
+### publish a dataset
+- click on the earthquakes dataset
+- click on the publish button
+- page should show 'show on cloud'
+- navigate to the collections page
+- it should show as 'published'
+- navigate to to the network page
+- it should exist on the network page
+- navigate to the dataset
+- unpublish
+- navigate to the collection page
+- it should show as unpublished
+- navigate to the network page
+- it should not show up

--- a/test/utils/e2eTestUtils.ts
+++ b/test/utils/e2eTestUtils.ts
@@ -14,9 +14,9 @@ export interface E2ETestUtils {
   exists: (selectors: string[], screenshotLocation?: string) => Promise<void>
   doesNotExist: (selector: string, screenshotLocation?: string) => Promise<void>
   expectTextToBe: (selector: string, text: string, screenshotLocation?: string) => Promise<void>
+  checkDatasetReference: (username: string, name: string, screenshotLocation?: string) => Promise<void>
+  atDatasetVersion: (ver: "working" | number, screenshotLocation?: string) => Promise<void>
   expectTextToContain: (selector: string, text: string, screenshotLocation?: string) => Promise<void>
-  onHistoryTab: (screenshotLocation?: string) => Promise<void>
-  onStatusTab: (screenshotLocation?: string) => Promise<void>
   checkStatus: (component: string, status: string, screenshotLocation?: string) => Promise<void>
   delay: (time: number, screenshotLocation?: string) => Promise<unknown>
   sendKeys: (selector: string, value: string | string[], screenshotLocation?: string) => Promise<void>
@@ -29,6 +29,7 @@ export function newE2ETestUtils (app: any): E2ETestUtils {
     delay: delay,
     atLocation: atLocation(app),
     atDataset: atDataset(app),
+    checkDatasetReference: checkDatasetReference(app),
     waitForExist: waitForExist(app),
     waitForNotExist: waitForNotExist(app),
     click: click(app),
@@ -36,9 +37,8 @@ export function newE2ETestUtils (app: any): E2ETestUtils {
     exists: exists(app),
     doesNotExist: doesNotExist(app),
     expectTextToBe: expectTextToBe(app),
+    atDatasetVersion: atDatasetVersion(app),
     expectTextToContain: expectTextToContain(app),
-    onHistoryTab: onHistoryTab(app),
-    onStatusTab: onStatusTab(app),
     checkStatus: checkStatus(app),
     sendKeys: sendKeys(app),
     takeScreenshot: takeScreenshot(app),
@@ -55,11 +55,15 @@ function takeScreenshot (app: any) {
     if (delayTime !== 0) {
       await delay(delayTime)
     }
-    app.browserWindow.capturePage().then(function (imageBuffer) {
-      console.log(`writing screenshot: ${screenshotLocation}`)
-      fs.writeFileSync(screenshotLocation, imageBuffer)
-    })
+    _takeScreenshot(app, screenshotLocation)
   }
+}
+
+function _takeScreenshot (app: any, screenshotLocation: string) {
+  app.browserWindow.capturePage().then(function (imageBuffer) {
+    console.log(`writing screenshot: ${screenshotLocation}`)
+    fs.writeFileSync(screenshotLocation, imageBuffer)
+  })
 }
 
 // atLocation checks to see if the given hash location is where we expected it.
@@ -76,10 +80,7 @@ function atLocation (app: any) {
       }, 10000, `expected url to start with '${expected}', got: ${location.hash}`)
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'atLocation': ${e}`)
     }
@@ -101,10 +102,7 @@ function atDataset (app: any) {
       }, 10000, `expected url to be '#/collection/${username === '' ? 'some_username' : username}/${datasetName}', got: ${location}`)
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'atDataset': ${e}`)
     }
@@ -122,10 +120,7 @@ function waitForExist (app: any) {
       }, 10000, `element '${selector}' cannot be found`)
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'waitForExist': ${e}`)
     }
@@ -145,10 +140,7 @@ function waitForNotExist (app: any) {
       }, 10000, `element ${selector} should not exist, but is existing`)
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'waitForNotExist': ${e}`)
     }
@@ -168,10 +160,7 @@ function click (app: any) {
       await client.click(selector)
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'click', selector '${selector}': ${e}`)
     }
@@ -186,10 +175,7 @@ function setValue (app: any) {
       await app.client.element(selector).setValue(value)
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'setValue', selector '${selector}': ${e}`)
     }
@@ -205,10 +191,7 @@ function sendKeys (app: any) {
       await app.client.element(selector).keys(value)
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'sendKeys', selector '${selector}': ${e}`)
     }
@@ -225,10 +208,7 @@ function exists (app: any) {
       })
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'exists', selector '${selectors}': ${e}`)
     }
@@ -246,10 +226,7 @@ function doesNotExist (app: any) {
       expect(err.type).toBe('NoSuchElement')
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'sendKeys', selector '${selector}': ${e}`)
     }
@@ -267,12 +244,30 @@ function expectTextToBe (app: any) {
       expect(await app.client.element(selector).getText()).toBe(text)
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'expectTextToBe', selector '${selector}': ${e}`)
+    }
+    if (!headless) await delay(delayTime)
+  }
+}
+
+// checkDatasetReference takes a username and a name, checking that the given
+// dataset reference matches the one at the #dataset-reference id
+function checkDatasetReference (app: any) {
+  return async (username: string, name: string, screenshotLocation?: string) => {
+    try {
+      // TODO (ramfox): it's weird that we have to pass in this newline character
+      // to get the reference to match. It looks like because the #dataset-reference
+      // div divides the peername and name among multiple divs, we get this odd
+      // whitespace character
+      const ref = `${username}/\n${name}`
+      expect(await app.client.element('#dataset-reference').getText()).toBe(ref)
+    } catch (e) {
+      if (screenshotLocation) {
+        _takeScreenshot(app, screenshotLocation)
+      }
+      throw new Error(`function 'checkDatasetReference': ${e}`)
     }
     if (!headless) await delay(delayTime)
   }
@@ -283,59 +278,39 @@ function expectTextToContain (app: any) {
   return async (selector: string, text: string, screenshotLocation?: string) => {
     try {
       expect(await app.client.element(selector).getText()).toContain(text)
-      if (!headless) await delay(delayTime)
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`${selector}, ${text}: ${e}`)
     }
-  }
-}
-
-// onHistoryTab uses onTab to check if the we are on the history tab
-function onHistoryTab (app: any) {
-  return async (screenshotLocation?: string) => {
-    try {
-      await onTab(app, 'history')
-    } catch (e) {
-      if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
-      }
-      throw new Error(`function 'onHistoryTab': ${e}`)
-    }
     if (!headless) await delay(delayTime)
   }
 }
 
-// onStatusTab uses onTab to check if the we are on the history tab
-function onStatusTab (app: any) {
-  return async (screenshotLocation?: string) => {
+// atDatasetVersion takes a number or the string "working"
+// to determine if the expected version is the selected version.
+// the latest version of the dataset is HEAD-0, with the previous version being
+// HEAD-1. The "working" version is the version of the dataset that is being
+// edited
+function atDatasetVersion (app: any) {
+  return async (ver: "working" | number, screenshotLocation: string) => {
+    let verStr = ''
+    if (ver === "working") {
+      verStr = "#working-version"
+    } else {
+      verStr = `#HEAD-${ver}`
+    }
     try {
-      await onTab(app, 'status')
+      expect(await app.client.element(verStr).getAttribute("class")).toContain("selected")
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
-      throw new Error(`function 'onStatusTab': ${e}`)
+      throw new Error(`function 'atDatasetVersion': ${e}`)
     }
     if (!headless) await delay(delayTime)
   }
-}
-
-// onTab checks to see if the element exists with the 'active' class
-async function onTab (app: any, tab: string) {
-  expect(await app.client.element(`#${tab}-tab.active`)).toBeDefined()
-  if (!headless) await delay(delayTime)
 }
 
 // checkStatus ensures that component exists with the correct status dot class
@@ -345,10 +320,7 @@ function checkStatus (app: any) {
       expect(await app.client.element(`#${component}-status.status-dot-${status}`)).toBeDefined()
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'checkStatus': ${e}`)
     }
@@ -367,10 +339,7 @@ function isChecked (app: any) {
       return await client.element(selector).isSelected()
     } catch (e) {
       if (screenshotLocation) {
-        app.browserWindow.capturePage().then(function (imageBuffer) {
-          console.log(`writing screenshot: ${screenshotLocation}`)
-          fs.writeFileSync(screenshotLocation, imageBuffer)
-        })
+        _takeScreenshot(app, screenshotLocation)
       }
       throw new Error(`function 'waitForExist': ${e}`)
     }


### PR DESCRIPTION
**There are two tests that are still failing, both in the same way.** When we go to switch between commits & check that the commit titles are correct (this is how we determine that the versions have actually been changed, since we don't have the path information and therefore can't use the path to verify we have navigated to the correct commit). For some reason, even though the div definitely exists, we cannot find the `#history-commit` on the page. Would love it if someone could take a look.

However, this is in a good enough place that even if someone isn't able to de-bug, I'm comfortable merging, since, for most cases, folks can use this to make sure they aren't breaking expected app behavior. 

Three notes:
1) DatasetReference was added back in because otherwise there is no way to rename a dataset in the app
2) the LinkDataset and PublishDataset components were added back in because otherwise there is no way to checkout or publish/unpublish a dataset in the app
3) I added back the `CreateDataset` component (which was replaced by the `NewDataset` component), because the flow from the `NewDataset` modal, which doesn't have space to add a body file, is not finished. This flow needs to be finished before we add the `NewDataset` modal back in, because otherwise the desktop app cannot add datasets.

Otherwise, all the other tests are passing locally!