### PR TITLE
wip: style network tab home

### DIFF
--- a/app/components/chrome/Icon.tsx
+++ b/app/components/chrome/Icon.tsx
@@ -39,7 +39,9 @@ import {
   faMinus,
   faSync,
   faBars,
-  faPencilAlt
+  faPencilAlt,
+  faCircle,
+  faEye
 } from '@fortawesome/free-solid-svg-icons'
 
 import {
@@ -110,14 +112,16 @@ const icons: Record<string, any> = {
   'hdd': faHdd,
   'stickyNote': faStickyNote,
   'pencil': faPencilAlt,
-  'trash': faTrashAlt
+  'trash': faTrashAlt,
+  'circle': faCircle,
+  'eye': faEye
 }
 
 const sizes: {[key: string]: FontAwesomeIconProps['size']} = {
   'xs': 'xs',
   'sm': 'sm',
-  'md': 'lg',
-  'lg': '2x'
+  'md': undefined,
+  'lg': 'lg'
 }
 
 export const iconsList = Object.keys(icons)
@@ -125,7 +129,7 @@ export const iconsList = Object.keys(icons)
 const Icon: React.FunctionComponent<IconProps> = ({
   icon = 'unknown',
   size = 'md',
-  color = 'dark',
+  color = 'default',
   className
 }) => {
   if (icon === 'commit') {

--- a/app/components/chrome/ListItem.tsx
+++ b/app/components/chrome/ListItem.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+
+interface ListItemProps {
+  link?: string
+  onClick: () => void
+}
+
+const ListItem: React.FunctionComponent<ListItemProps> = ({ link, children, onClick }) => {
+  let content = (
+    <div className='card-body'>
+      {children}
+    </div>
+  )
+
+  if (onClick) {
+    content = (
+      <a href={link} onClick={(e) => { e.preventDefault(); onClick() }}>{content}</a>
+    )
+  }
+
+  return (
+    <div className='list-item card'>
+      {content}
+    </div>
+  )
+}
+
+export default ListItem

--- a/app/components/chrome/SearchBox.tsx
+++ b/app/components/chrome/SearchBox.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import Icon from '../chrome/Icon'
 
 interface SearchBoxProps {
   id?: string
@@ -16,15 +17,11 @@ const SearchBox: React.FunctionComponent<SearchBoxProps> = ({ id, value, onChang
     }
   }
   return (
-    <div className={`searchbox ${big && 'big'}`}>
-      <svg className='search_icon' width="20px" height="20px" viewBox="0 0 20 20" version="1.1">
-        <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-          <g transform="translate(1.000000, 0.000000)" fill="#CBCBCB" fillRule="nonzero" id="Shape">
-            <path d="M18.7416052,17.2912801 L15.0415299,13.3971292 C14.8745255,13.2213651 14.6481417,13.1237184 14.4106244,13.1237184 L13.8056973,13.1237184 C14.829991,11.7449468 15.4386292,10.0107411 15.4386292,8.12420662 C15.4386292,3.63636364 11.9834937,0 7.71931462,0 C3.45513554,0 0,3.63636364 0,8.12420662 C0,12.6120496 3.45513554,16.2484132 7.71931462,16.2484132 C9.51182855,16.2484132 11.1596053,15.6078508 12.4696621,14.5298311 L12.4696621,15.1664876 C12.4696621,15.4164632 12.5624423,15.6547212 12.7294467,15.8304853 L16.429522,19.7246363 C16.7783757,20.0917879 17.3424794,20.0917879 17.6876219,19.7246363 L18.737894,18.6192755 C19.0867476,18.2521238 19.0867476,17.6584318 18.7416052,17.2912801 Z M7.71931462,13.1237184 C5.09548989,13.1237184 2.96896716,10.8895616 2.96896716,8.12420662 C2.96896716,5.36275754 5.09177868,3.12469485 7.71931462,3.12469485 C10.3431394,3.12469485 12.4696621,5.35885167 12.4696621,8.12420662 C12.4696621,10.8856557 10.3468506,13.1237184 7.71931462,13.1237184 Z"></path>
-          </g>
-        </g>
-      </svg>
-      <input id={id} value={value} onChange={onChange} onKeyUp={handleKeyUp} placeholder='search' />
+    <div className='filter-search-input searchbox'>
+      <div className='filter-input-container'>
+        <Icon icon='search' />
+        <input id={id} className='input' value={value} onChange={onChange} onKeyUp={handleKeyUp} placeholder='search for datasets' />
+      </div>
     </div>
   )
 }

--- a/app/components/collection/collectionHome/DatasetList.tsx
+++ b/app/components/collection/collectionHome/DatasetList.tsx
@@ -135,7 +135,7 @@ export const DatasetListComponent: React.FC<DatasetListProps> = (props) => {
   return (
     <div id='dataset-list'>
       <header>
-        <div id='dataset-list-filter'>
+        <div className='filter-search-input'>
           <div className='filter-input-container'>
             <input
               type='text'

--- a/app/components/dataset/DatasetStat.tsx
+++ b/app/components/dataset/DatasetStat.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import numeral from 'numeral'
+
+import Icon from '../chrome/Icon'
+
+interface DatasetStatProps {
+  icon: string
+  title: string
+  value: number
+  center?: boolean
+}
+
+const DatasetStat: React.FunctionComponent<DatasetStatProps> = ({ title, icon, value }) => {
+  return (
+    <div className='metric' title={title}>
+      <Icon icon={icon} />&nbsp;&nbsp;{value > 1000 ? numeral(value).format('0.0a') : value}
+    </div>
+  )
+}
+
+export default DatasetStat

--- a/app/components/dataset/DatasetSummary.tsx
+++ b/app/components/dataset/DatasetSummary.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import numeral from 'numeral'
+
+import Icon from '../chrome/Icon'
+import ListItem from '../chrome/ListItem'
+import RelativeTimestamp from '../RelativeTimestamp'
+import DatasetStat from './DatasetStat'
+
+interface DatasetSummaryProps {
+  dataset: any
+  onClick: (username: string, name: string) => void
+}
+
+const DatasetSummary: React.FunctionComponent<DatasetSummaryProps> = ({ dataset, onClick }) => {
+  const {
+    path,
+    peername,
+    name,
+    meta,
+    structure,
+    commit,
+    stats,
+    issue_stats: { open_issues: openIssues },
+    follow_stats: { follow_count: followCount }
+  } = dataset
+
+  const title = meta && meta.title ? meta.title : `No Title - ${name}`
+  const description = meta && meta.description ? meta.description : `No Description`
+
+  const { entries, format, length } = structure
+  const { timestamp } = commit
+  const { download_count: downloadCount, pull_count: pullCount } = stats
+  const displayDownloads = downloadCount + pullCount // eslint-disable-line
+
+  let keywordElements
+
+  if (meta && meta.keywords) {
+    keywordElements = meta.keywords.map((keyword: string) => (
+      <div key={keyword} className='keyword badge badge-secondary'>{keyword}</div>
+    ))
+  }
+
+  return (
+    <ListItem key={path} onClick={() => { onClick(peername, name) }}>
+
+      <div className='row dataset-summary'>
+        <div className='col-12 pb-1'>
+          <div className='row'>
+            <div className='dataset-summary-reference col-6'>
+              {peername}/{name}
+            </div>
+            <div className='metrics text-right col-6'>
+              {(followCount > 0) && (
+                <DatasetStat title='followers' icon='eye' value={followCount} />
+              )}
+              {(openIssues > 0) && (
+                <DatasetStat title='open issues' icon='circle' value={openIssues} />
+
+              )}
+              <DatasetStat title='downloads' icon='download' value={displayDownloads} />
+            </div>
+          </div>
+        </div>
+        <div className='title col col-12'>
+          { title }
+        </div>
+        <div className='description col-12 mb-2'>
+          {description}
+        </div>
+        <div className='col-12 col-md-6 mb-2 mb-md-0'>
+          <span className='dataset-details'><Icon icon='clock' size='sm'/><RelativeTimestamp timestamp={timestamp}/></span>
+          <span className='dataset-details'><Icon icon='hdd' size='sm'/>{numeral(length).format('0.0b')}</span>
+          <span className='dataset-details'><Icon icon='bars' size='sm'/>{numeral(entries).format('0,0')} rows</span>
+          <span className='dataset-details'><Icon icon='file' size='sm'/>{format}</span>
+        </div>
+        <div className='keyword-container col-12 col-md-6 text-md-right'>
+          {keywordElements}
+        </div>
+      </div>
+    </ListItem>
+  )
+}
+
+export default DatasetSummary

--- a/app/components/dataset/FeaturedDatasets.tsx
+++ b/app/components/dataset/FeaturedDatasets.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import DatasetSummary from './DatasetSummary'
+
+interface FeaturedDatasets {
+  datasets: any[]
+  onClick: () => void
+}
+
+const FeaturedDatasets: React.FunctionComponent<FeaturedDatasets> = ({ datasets = [], onClick }) => {
+  if (!datasets) {
+    datasets = []
+  }
+
+  const listItems = datasets.map((dataset) => (
+    <div key={dataset.path} className='card-col col-12 col-md-6'>
+      <DatasetSummary dataset={dataset} onClick={onClick}/>
+    </div>
+  ))
+
+  return (
+    <div className='featured-datasets list row d-flex align-items-stretch'>
+      {(listItems.length !== 0) ? listItems : <NoDatasets />}
+    </div>
+  )
+}
+
+const NoDatasets: React.FunctionComponent = () => (
+  <h4>No Datasets!</h4>
+)
+
+export default FeaturedDatasets

--- a/app/components/network/Network.tsx
+++ b/app/components/network/Network.tsx
@@ -98,7 +98,7 @@ const NetworkComponent: React.FunctionComponent<NetworkProps> = (props) => {
         {
           qriRef.username && qriRef.name && !inCollection &&
           <SidebarActionButton
-            text='Clone Dataset'
+            text='Pull Dataset'
             onClick={() => pullDatasetAndFetch(qriRef.username, qriRef.name)}
           />
         }

--- a/app/components/network/NetworkHome.tsx
+++ b/app/components/network/NetworkHome.tsx
@@ -1,16 +1,15 @@
 import React from 'react'
 
-import { BACKEND_URL } from '../../constants'
 import { NetworkHomeData } from '../../models/network'
-import { VersionInfo, RouteProps } from '../../models/store'
+import { RouteProps } from '../../models/store'
 import { Modal, ModalType } from '../../models/modals'
 import { connectComponentToPropsWithRouter } from '../../utils/connectComponentToProps'
 import { setModal } from '../../actions/ui'
 
 import Spinner from '../chrome/Spinner'
-import DatasetItem from '../item/DatasetItem'
 import { pathToNetworkDataset } from '../../paths'
 import SearchBox from '../chrome/SearchBox'
+import FeaturedDatasets from '../dataset/FeaturedDatasets'
 
 const initialDataState: NetworkHomeData = {
   featured: [],
@@ -41,7 +40,7 @@ export const NetworkHome: React.FunctionComponent<NetworkHomeProps> = ({ history
   }, [false])
 
   if (loading) {
-    return <Spinner />
+    return <div className='spinner-container'><Spinner /></div>
   } else if (error) {
     return <div><h3>{JSON.stringify(error)}</h3></div>
   }
@@ -52,27 +51,25 @@ export const NetworkHome: React.FunctionComponent<NetworkHomeProps> = ({ history
 
   const { featured, recent } = data
 
+  const onClick = (username: string, name: string) => {
+    history.push(pathToNetworkDataset(username, name))
+  }
+
   return (
-    <div className='network_home'>
-      <h2>Home</h2>
+    <>
       <SearchBox onEnter={handleOnEnter} id='search-box' />
-      {featured && featured.length && <div>
-        <h4>Featured Datasets</h4>
-        {featured.map((vi: VersionInfo, i) => <div key={i} className='featured-datasets-item'>
-          <DatasetItem onClick={(username: string, name: string) => {
-            history.push(pathToNetworkDataset(username, name))
-          }} data={vi} id={`featured-${i}`}/>
-        </div>)}
-      </div>}
-      {recent && recent.length && <div>
-        <h4>Recent Datasets</h4>
-        {recent.map((vi: VersionInfo, i) => <div key={i} className='recent-datasets-item'>
-          <DatasetItem onClick={(username: string, name: string) => {
-            history.push(pathToNetworkDataset(username, name))
-          }} data={vi} id={`recent-${i}`} />
-        </div>)}
-      </div>}
-    </div>
+      <div className='network_home'>
+        {featured && featured.length && <div>
+          <h4>Featured Datasets</h4>
+          <FeaturedDatasets datasets={featured} onClick={onClick}/>
+        </div>
+        }
+        {recent && recent.length && <div>
+          <h4>Recent Datasets</h4>
+          <FeaturedDatasets datasets={recent} onClick={onClick}/>
+        </div>}
+      </div>
+    </>
   )
 }
 
@@ -90,7 +87,7 @@ async function homeFeed (): Promise<NetworkHomeData> {
     method: 'GET'
   }
 
-  const r = await fetch(`${BACKEND_URL}/feeds`, options)
+  const r = await fetch(`https://registry.qri.cloud/dataset_summary/splash`, options)
   const res = await r.json()
   if (res.meta.code !== 200) {
     var err = { code: res.meta.code, message: res.meta.error }

--- a/app/scss/0.4.0/network.scss
+++ b/app/scss/0.4.0/network.scss
@@ -1,5 +1,10 @@
 .network_home {
   padding: 10px;
+
+  h4 {
+    padding: 8px;
+    margin-bottom: 0;
+  }
 }
 
 .page-navbar {
@@ -43,13 +48,13 @@
   }
 }
 
-.searchbox {
+.filter-search-input.searchbox {
   position: relative;
 
-  .search_icon {
+  svg {
     position: absolute;
-    top: 6px;
-    left: 7px;
+    top: 13px;
+    left: 11px;
   }
 
   input {
@@ -57,15 +62,9 @@
     background: #E8EDF2;
     border-radius: 5px;
     border: none;
-    padding: 6px 8px 6px 30px;
+    padding: 6px 8px 6px 38px;
     font-size: 16px;
-    font-weight: bold;
     color: #333;
-  }
-
-  input::placeholder {
-    font-weight: normal;
-    color: #CBCBCB;
   }
 }
 

--- a/app/scss/_dataset-list.scss
+++ b/app/scss/_dataset-list.scss
@@ -8,41 +8,6 @@
     display: flex;
     flex-direction: column;
 
-    #dataset-list-filter {
-      padding: 13px 16px 4px 16px;
-      width: 100%;
-      display: flex;
-
-      .filter-input-container {
-        width: 30%;
-        max-width: 40%;
-        flex: 1;
-        display: flex;
-        position: relative;
-
-        input {
-          height: 40px;
-          width: 100%;
-          background: #e1e4e8;
-          border-radius: 4px;
-          padding: 2px 5px;
-          box-shadow: none;
-          border: 1px solid transparent;
-
-          &:focus {
-            outline: none;
-            border-color: $primary;
-          }
-        }
-
-        .close {
-          position: absolute;
-          right: 10px;
-          top: 10px;
-        }
-      }
-    }
-
     .list-picker-and-bulk-actions {
       display: flex;
       padding: 0 9px;
@@ -126,6 +91,41 @@
         position: relative;
         padding: 0;
       }
+    }
+  }
+}
+
+.filter-search-input {
+  padding: 13px 16px 4px 16px;
+  width: 100%;
+  display: flex;
+  
+  .filter-input-container {
+    width: 30%;
+    max-width: 40%;
+    flex: 1;
+    display: flex;
+    position: relative;
+
+    input {
+      height: 40px;
+      width: 100%;
+      background: #e1e4e8;
+      border-radius: 4px;
+      padding: 2px 5px;
+      box-shadow: none;
+      border: 1px solid transparent;
+
+      &:focus {
+        outline: none;
+        border-color: $primary;
+      }
+    }
+
+    .close {
+      position: absolute;
+      right: 10px;
+      top: 10px;
     }
   }
 }

--- a/app/scss/_dataset.scss
+++ b/app/scss/_dataset.scss
@@ -619,7 +619,6 @@ $header-font-size: .9rem;
   display: inline;
   color: #123459;
   background-color: #4FC7F3;
-  height: 15px;
   padding: 0 5px;
   border-radius: 8px;
   position: relative;

--- a/app/scss/_dataset_summary.scss
+++ b/app/scss/_dataset_summary.scss
@@ -1,0 +1,104 @@
+.dataset-summary {
+  a:hover {
+    text-decoration: none;
+
+    .dataset-summary-title {
+      text-decoration: underline;
+    }
+  }
+
+  .dataset-summary-reference {
+    color: #797878;
+    font-family: "Lucida Console", Monaco, monospace;
+    font-size: 12px;
+    font-weight: 500;
+    display: inline-block;
+  }
+
+  .pb-1, .py-1 {
+    padding-bottom: 0.25rem !important;
+  }
+
+  .mb-2, .my-2 {
+    margin-bottom: 0.5rem !important;
+  }
+}
+
+
+
+.featured-datasets {
+
+  .list-item {
+    border: 1px solid rgba(0,0,0,0.125) !important;
+
+    a:hover .title {
+      text-decoration: underline;
+    }
+
+    .title {
+      font-size: 20px;
+      font-weight: 500;
+      color: #0461A6;
+    }
+
+    .metrics {
+      color: #797878;
+      font-size: 14px;
+      font-weight: 500;
+      float: right;
+
+      .metric {
+        display: inline-block;
+        margin-right: 12px;
+
+        &:last-child {
+          margin-right: 0;
+        }
+      }
+    }
+
+    .description {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      font-size: 14px;
+    }
+  }
+
+  .card-col {
+    padding: 8px;
+  }
+
+  .card-body {
+    padding: 1.25rem !important;
+  }
+
+  .card {
+    -webkit-box-shadow: 0px 0px 6px 1px #ededed;
+    -moz-box-shadow: 0px 0px 6px 1px #ededed;
+    box-shadow: 0px 0px 6px 1px #ededed;
+    border-radius: 0.25rem !important;
+  }
+
+  .badge {
+    display: inline-block;
+    padding: 0.25em 0.4em;
+    font-size: 75%;
+    font-weight: 700;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: 0.25rem;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    font-weight: 400;
+    background: #F0F0F0;
+    margin: 2px;
+  }
+
+  .keyword {
+    color: #F8AB31;
+  }
+}

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -24,6 +24,7 @@
 @import "stylesheet";
 
 @import "dataset";
+@import "dataset_summary";
 @import "transfers";
 @import "drag-drop";
 @import "commit";


### PR DESCRIPTION
Brings in components and CSS to style network pane featured datasets.
- Is making a call directly to cloud to get all the needed info for `DatasetSummary`, should be routed through backend.
- No work done on search modal, we wanted to eliminate that modal and just show the results in the network pane.