### PR TITLE
feat(export): wire up export modal with csv & zip options

### DIFF
--- a/app/actions/platformSpecific/export.electron.ts
+++ b/app/actions/platformSpecific/export.electron.ts
@@ -1,0 +1,25 @@
+import { remote, ipcRenderer } from 'electron'
+import path from 'path'
+import moment from 'moment'
+
+import { refStringFromQriRef } from '../../models/qriRef'
+import { VersionInfo, qriRefFromVersionInfo } from '../../models/store'
+
+export default function exportDatasetVersion (vi: VersionInfo, config: 'zip' | 'csv') {
+  const window = remote.getCurrentWindow()
+  const defaultPath = `${vi.username}-${vi.name}-${moment(vi.commitTime).format('YYYY-MM-DDThh-mm-ss-a')}.${config}`
+  const selectedPath: string | undefined = remote.dialog.showSaveDialogSync(window, { defaultPath })
+
+  if (!selectedPath) {
+    return
+  }
+
+  const directory = path.dirname(selectedPath)
+  const filename = path.basename(selectedPath)
+  ipcRenderer.send('export', {
+    refString: refStringFromQriRef(qriRefFromVersionInfo(vi)),
+    filename: filename,
+    directory: directory,
+    config
+  })
+}

--- a/app/actions/platformSpecific/export.web.ts
+++ b/app/actions/platformSpecific/export.web.ts
@@ -1,0 +1,5 @@
+import { VersionInfo } from '../../models/store'
+
+export default function exportDatasetVersion (_: VersionInfo) {
+  alert('can\'t export from the web!')
+}

--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -1,30 +1,27 @@
 import * as React from 'react'
 import numeral from 'numeral'
 
-import { Structure, Commit } from '../models/dataset'
+import { VersionInfo } from '../models/store'
 
 import Icon from './chrome/Icon'
 import RelativeTimestamp from './RelativeTimestamp'
 
-interface CommitDetailsProps {
-  structure: Structure
-  commit: Commit
-  path: string
-}
-
-const CommitDetails: React.FunctionComponent<CommitDetailsProps> = (props) => {
-  const { structure, commit, path } = props
-  return (
-    <>
-      <span className='dataset-details' style={{ marginBottom: '6px' }}><Icon icon='stickyNote' size='sm' color='medium' />{commit.title}</span>
-      <div className='dataset-details-container'>
-        <span className='dataset-details'><Icon icon='commit' size='sm' color='medium' /><span title={path}>{path.substring(path.length - 7)}</span></span>
-        <span className='dataset-details'><Icon icon='clock' size='sm' color='medium' /><RelativeTimestamp timestamp={commit.timestamp}/></span>
-        <span className='dataset-details'><Icon icon='hdd' size='sm' color='medium' />{numeral(structure.length).format('0.0b')}</span>
-        <span className='dataset-details'><Icon icon='bars' size='sm' color='medium' />{numeral(structure.entries).format('0,0')} rows</span>
-      </div>
-    </>
-  )
-}
+const CommitDetails: React.FunctionComponent<VersionInfo> = ({
+  commitTitle,
+  commitTime,
+  bodySize,
+  bodyRows,
+  path
+}) => (
+  <>
+    {commitTitle && <span className='dataset-details' style={{ marginBottom: '6px' }}><Icon icon='stickyNote' size='sm' color='medium' />{commitTitle}</span>}
+    <div className='dataset-details-container'>
+      <span className='dataset-details'><Icon icon='commit' size='sm' color='medium' /><span title={path}>{path.substring(path.length - 7)}</span></span>
+      <span className='dataset-details'><Icon icon='clock' size='sm' color='medium' /><RelativeTimestamp timestamp={commitTime}/></span>
+      <span className='dataset-details'><Icon icon='hdd' size='sm' color='medium' />{numeral(bodySize).format('0.0b')}</span>
+      <span className='dataset-details'><Icon icon='bars' size='sm' color='medium' />{numeral(bodyRows).format('0,0')} rows</span>
+    </div>
+  </>
+)
 
 export default CommitDetails

--- a/app/components/collection/DatasetHeader.tsx
+++ b/app/components/collection/DatasetHeader.tsx
@@ -10,16 +10,22 @@ interface DatasetHeaderProps {
   commit: Commit
 }
 
-const DatasetHeader: React.FunctionComponent<DatasetHeaderProps> = ({ path, structure, commit }) => {
-  return (
-    <div className='commit-details-header'>
-      {
-        structure && commit && (
-          <CommitDetails structure={structure} commit={commit} path={path} />
-        )
-      }
-    </div>
-  )
-}
+const DatasetHeader: React.FC<DatasetHeaderProps> = ({
+  path,
+  structure,
+  commit
+}) => (
+  <div className='commit-details-header'>
+    {structure && commit && (
+      <CommitDetails
+        bodyRows={structure.entries}
+        bodySize={structure.length}
+        commitTime={commit.timestamp}
+        commitTitle={commit.title}
+        path={path}
+      />
+    )}
+  </div>
+)
 
 export default DatasetHeader

--- a/app/components/collection/collectionHome/TableRowHamburger.tsx
+++ b/app/components/collection/collectionHome/TableRowHamburger.tsx
@@ -13,18 +13,30 @@ interface TableRowHamburgerProps {
 
 const TableRowHamburger: React.FC<TableRowHamburgerProps> = ({ data, setModal }) => {
   const { username, name, fsiPath } = data
-  const actions = [{
-    icon: 'trash',
-    text: 'Remove',
-    onClick: () => {
-      setModal({
-        type: ModalType.RemoveDataset,
-        username,
-        name,
-        fsiPath
-      })
+  const actions = [
+    {
+      icon: 'download',
+      text: 'Export',
+      onClick: () => {
+        setModal({
+          type: ModalType.ExportDataset,
+          version: data
+        })
+      }
+    },
+    {
+      icon: 'trash',
+      text: 'Remove',
+      onClick: () => {
+        setModal({
+          type: ModalType.RemoveDataset,
+          username,
+          name,
+          fsiPath
+        })
+      }
     }
-  }]
+  ]
 
   return (
     <Hamburger id={`${data.username}/${data.name}`} data={actions} />

--- a/app/components/collection/layouts/DatasetLayout.tsx
+++ b/app/components/collection/layouts/DatasetLayout.tsx
@@ -43,10 +43,10 @@ const DatasetLayoutComponent: React.FunctionComponent<DatasetLayoutProps> = (pro
   const buttons = [
     {
       type: 'button',
-      id: 'pull-dataset',
+      id: 'export-dataset',
       icon: faDownload,
       label: 'Export',
-      onClick: () => { setModal({ type: ModalType.ExportDataset }) }
+      onClick: () => { setModal({ type: ModalType.ExportDataset, version: qriRef }) }
     },
     { type: 'component', component: <LinkButton key='link-button' /> },
     { type: 'component', component: <PublishButton key='publish-button' /> }

--- a/app/components/form/ComponentAndFormatPicker.tsx
+++ b/app/components/form/ComponentAndFormatPicker.tsx
@@ -15,6 +15,8 @@ interface ComponentAndFormatPickerProps {
 interface ComponentConfig {
   body: boolean
 
+  // tri-state enum of all following fields
+  // indeterminate state means checkbox shows '-'
   other: boolean | 'indeterninate'
   meta: boolean
   structure: boolean
@@ -23,9 +25,8 @@ interface ComponentConfig {
 
 export const defaultConfig: ComponentConfig = {
   body: true,
-  // otherChecked has three states, 'true', 'false', 'indeterminate'
-  // indeterminate state means the checkbox shows a '-' instead of checked or unchecked
-  other: false as boolean | 'indeterminate',
+
+  other: false,
   meta: false,
   structure: false,
   readme: false

--- a/app/components/form/ComponentAndFormatPicker.tsx
+++ b/app/components/form/ComponentAndFormatPicker.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react'
+
+import { Dataset } from '../../models/dataset'
+
+import CheckboxInput from './CheckboxInput'
+import TristateCheckboxInput from './TristateCheckboxInput'
+import RadioInput from './RadioInput'
+
+interface ComponentAndFormatPickerProps {
+  dataset: Dataset
+  value: ComponentConfig
+  onChange: (v: ComponentConfig) => void
+}
+
+interface ComponentConfig {
+  body: boolean
+
+  other: boolean | 'indeterninate'
+  meta: boolean
+  structure: boolean
+  readme: boolean
+}
+
+export const defaultConfig: ComponentConfig = {
+  body: true,
+  // otherChecked has three states, 'true', 'false', 'indeterminate'
+  // indeterminate state means the checkbox shows a '-' instead of checked or unchecked
+  other: false as boolean | 'indeterminate',
+  meta: false,
+  structure: false,
+  readme: false
+}
+
+export const ComponentAndFormatPicker: React.FC<ComponentAndFormatPickerProps> = ({ dataset, value }) => {
+  const { meta, readme } = dataset
+  const enabledOtherComponents = ['structure'] // structure is always enabled
+  if (meta) enabledOtherComponents.push('meta')
+  if (readme) enabledOtherComponents.push('readme')
+
+  const [bodyFormat, setBodyFormat] = useState('csv')
+  const [config, setConfig] = useState(value)
+
+  const setConfigField = (field: string, value: boolean) => {
+    const update = { ...config, [field]: value }
+
+    if (field === 'other') {
+      enabledOtherComponents.forEach((compName: string) => {
+        update[compName] = value
+      })
+    } else {
+      const enabledCount = enabledOtherComponents.length
+      const checkedCount = [update.meta, update.structure, update.readme].reduce((acc, curr) => (curr ? acc + 1 : acc), 0)
+
+      // set state of parent checkbox
+      if (checkedCount === 0) {
+        update.other = false
+      } else if (checkedCount === enabledCount) {
+        update.other = true
+      } else {
+        update.other = 'indeterminate'
+      }
+    }
+
+    setConfig(update)
+  }
+
+  return (
+    <div className='component-and-format-picker dialog-text-small'>
+      <div className='input-label'>Components</div>
+      <div className='options-row'>
+        <div className='options-column'>
+          <CheckboxInput
+            name='body'
+            checked={config.body}
+            onChange={() => { setConfigField('body', !config.body) }}
+            label='Body'
+            strong
+          />
+          <div className='options-column-content'>
+            <RadioInput
+              name='csv'
+              checked={bodyFormat === 'csv'}
+              onChange={() => { setBodyFormat('csv') }}
+              label='body.csv'
+              disabled={!config.body}
+            />
+            <RadioInput
+              name='should-remove-files'
+              checked={bodyFormat === 'json'}
+              onChange={() => { setBodyFormat('json') }}
+              label='body.json'
+              disabled={!config.body}
+            />
+          </div>
+        </div>
+        <div className='options-column'>
+          <TristateCheckboxInput
+            name='other-components'
+            value={config.other}
+            onChange={(_: string, v: boolean) => { setConfigField('other', v) }}
+            label='Other Components'
+            strong
+          />
+          <div className='options-column-content'>
+            <CheckboxInput
+              name='meta'
+              checked={config.meta}
+              onChange={() => { setConfigField('meta', !config.meta) }}
+              label='meta.json'
+              disabled={meta === undefined}
+            />
+            <CheckboxInput
+              name='structure'
+              checked={config.structure}
+              onChange={() => { setConfigField('structure', !config.structure) }}
+              label='structure.json'
+            />
+            <CheckboxInput
+              name='readme'
+              checked={ config.readme }
+              onChange={() => { setConfigField('readme', !config.readme) }}
+              label='readme.md'
+              disabled={readme === undefined}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ComponentAndFormatPicker

--- a/app/components/modals/ExportDataset.tsx
+++ b/app/components/modals/ExportDataset.tsx
@@ -2,14 +2,8 @@ import React, { useState } from 'react'
 import classNames from 'classnames'
 
 import { dismissModal } from '../../actions/ui'
-import { Dataset } from '../../../app/models/dataset'
 import { ExportDatasetModal } from '../../../app/models/modals'
-import { QriRef } from '../../models/qriRef'
-import {
-  selectModal,
-  selectDatasetRef,
-  selectDataset
-} from '../../selections'
+import { selectModal } from '../../selections'
 import { connectComponentToProps } from '../../utils/connectComponentToProps'
 import exportDatasetVersion from '../../actions/platformSpecific/export.TARGET_PLATFORM'
 
@@ -21,13 +15,11 @@ import RadioInput from '../form/RadioInput'
 
 interface ExportDatasetProps {
   modal: ExportDatasetModal
-  qriRef: QriRef
-  dataset: Dataset
   onDismissed: () => void
 }
 
 export const ExportDatasetComponent: React.FC<ExportDatasetProps> = (props: ExportDatasetProps) => {
-  const { onDismissed, qriRef, dataset: { structure, commit } } = props
+  const { onDismissed } = props
   const { version } = props.modal
 
   const [dismissable, setDismissable] = useState(true)
@@ -75,10 +67,8 @@ export const ExportDatasetComponent: React.FC<ExportDatasetProps> = (props: Expo
         <div className='content'>
           <div className='export-dataset-info'>
             <div className='dialog-text-small'>
-              <code style={{ marginBottom: '15px' }}>{qriRef.username}/{qriRef.name}</code><br/>
-              {structure && commit && (
-                <CommitDetails commit={commit} structure={structure} path={qriRef.path} />
-              )}
+              <code style={{ marginBottom: '15px' }}>{version.username}/{version.name}</code><br/>
+              <CommitDetails {...version} />
             </div>
           </div>
           <div className='mode-picker'>
@@ -117,9 +107,7 @@ export default connectComponentToProps(
   (state: any, ownProps: ExportDatasetProps) => {
     return {
       ...ownProps,
-      modal: selectModal(state),
-      qriRef: selectDatasetRef(state),
-      dataset: selectDataset(state)
+      modal: selectModal(state)
     }
   },
   {

--- a/app/components/modals/RemoveDataset.tsx
+++ b/app/components/modals/RemoveDataset.tsx
@@ -1,13 +1,10 @@
-import * as React from 'react'
+import React, { useState } from 'react'
 
 import { RemoveDatasetModal } from '../../../app/models/modals'
 import { ApiAction } from '../../store/api'
-
 import { connectComponentToProps } from '../../utils/connectComponentToProps'
-
 import { dismissModal } from '../../actions/ui'
 import { removeDatasetAndFetch } from '../../actions/api'
-
 import { selectModal, selectSessionUsername } from '../../selections'
 
 import CheckboxInput from '../form/CheckboxInput'
@@ -22,16 +19,14 @@ interface RemoveDatasetProps {
   onSubmit: (username: string, name: string, isLinked: boolean, keepFiles: boolean) => Promise<ApiAction>
 }
 
-export const RemoveDatasetComponent: React.FunctionComponent<RemoveDatasetProps> = (props: RemoveDatasetProps) => {
+export const RemoveDatasetComponent: React.FC<RemoveDatasetProps> = (props: RemoveDatasetProps) => {
   const { modal, sessionUsername, onDismissed, onSubmit } = props
   const { username, name, fsiPath } = modal
 
-  const [keepFiles, setKeepFiles] = React.useState(true)
-
-  const [dismissable, setDismissable] = React.useState(true)
-
-  const [error, setError] = React.useState('')
-  const [loading, setLoading] = React.useState(false)
+  const [keepFiles, setKeepFiles] = useState(true)
+  const [dismissable, setDismissable] = useState(true)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
 
   const handleChanges = (name: string, value: any) => {
     setKeepFiles(!value)

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -125,7 +125,6 @@ app.on('ready', () =>
       mainWindow.webContents.on('did-finish-load', () => {
         mainWindow.show()
         mainWindow.focus()
-        mainWindow.webContents.send('set-debug-log-path', backendProcess.debugLogPath)
       })
 
       mainWindow.on('closed', () => {
@@ -511,8 +510,11 @@ app.on('ready', () =>
       })
 
       // catch export events
-      ipcMain.on('export', async (e, { refString, filename, directory }) => {
-        const exportUrl = `${BACKEND_URL}/get/${refString}?format=zip`
+      ipcMain.on('export', async (e, { refString, filename, directory, config = 'zip' }) => {
+        let exportUrl = `${BACKEND_URL}/get/${refString}?format=zip`
+        if (config === 'csv') {
+          exportUrl = `${BACKEND_URL}/get/${refString}/body.csv`
+        }
         const win = BrowserWindow.getFocusedWindow()
         await download(win, exportUrl, { filename, directory })
       })
@@ -578,6 +580,9 @@ app.on('ready', () =>
           }
         })
         .then(backendProcess.launchProcess)
+        .then(() => {
+          mainWindow.webContents.send('set-debug-log-path', backendProcess.debugLogPath)
+        })
         .catch(err => {
           switch (err.message) {
             case "backend-already-running":

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -516,7 +516,11 @@ app.on('ready', () =>
           exportUrl = `${BACKEND_URL}/get/${refString}/body.csv`
         }
         const win = BrowserWindow.getFocusedWindow()
-        await download(win, exportUrl, { filename, directory })
+        await download(win, exportUrl, {
+          filename,
+          directory,
+          openFolderWhenDone: true
+        })
       })
 
       ipcMain.on('block-menus', (e, blockMenus) => {

--- a/app/models/modals.ts
+++ b/app/models/modals.ts
@@ -1,3 +1,5 @@
+import { VersionInfo } from './store'
+
 export enum ModalType {
   NoModal,
   NewDataset,
@@ -21,6 +23,7 @@ export interface NewDatasetModal {
 
 export interface ExportDatasetModal {
   type: ModalType.ExportDataset
+  version: VersionInfo
 }
 
 export interface HideModal {

--- a/app/scss/0.4.0/dataset.scss
+++ b/app/scss/0.4.0/dataset.scss
@@ -191,34 +191,6 @@
   overflow: auto;
 }
 
-#export-dataset {
-  .options-row {
-    display: flex;
-    padding-top: 8px;
-
-    .options-column {
-      flex: 50%;
-
-      .options-column-content {
-        margin-top: 9px;
-        margin-left: 23px;
-
-        .checkbox-input-container, .radio-input-container {
-          margin-bottom: 6px;
-        }
-      }
-    }
-  }
-
-  .export-dataset-info {
-    background-color: #f5f5f5;
-    padding: 4px 10px 10px 10px;
-    margin-bottom: 15px;
-    width: 100%;
-    border-radius: 3px;
-  }
-}
-
 // easyMDE (readme)
 .EasyMDEContainer {
   display: flex;

--- a/app/scss/_form.scss
+++ b/app/scss/_form.scss
@@ -375,3 +375,23 @@
     }
   }
 }
+
+.component-and-format-picker {
+  .options-row {
+    display: flex;
+    padding-top: 8px;
+
+    .options-column {
+      flex: 50%;
+
+      .options-column-content {
+        margin-top: 9px;
+        margin-left: 23px;
+
+        .checkbox-input-container, .radio-input-container {
+          margin-bottom: 6px;
+        }
+      }
+    }
+  }
+}

--- a/app/scss/_modal.scss
+++ b/app/scss/_modal.scss
@@ -43,3 +43,46 @@ height: 100%;
 	font-size: .8rem;
 	color: #777;
 }
+
+.export-dataset-modal {
+  .export-dataset-info {
+    background-color: #f5f5f5;
+    padding: 4px 10px 10px 10px;
+    margin-bottom: 15px;
+    width: 100%;
+    border-radius: 3px;
+	}
+	.mode-picker {
+		.mode-item {
+			padding: 10px 5px;
+			border: 1px solid $primary-muted;
+			border-radius: 4px;
+			margin-bottom: 10px;
+			display: flex;
+			cursor: pointer;
+
+			&.selected {
+				background: #f5f5f5;
+			}
+
+			.radio-input-container {
+				flex: 1;
+				float: left;
+				width: 10%;
+				height: 100%;
+				margin: auto;
+				padding: 10px;
+			}
+
+			.text {
+				margin-left: 10px;
+				width: 90%;
+				.title {
+					color: black;
+					font-weight: bold;
+					margin-bottom: 0;
+				}
+			}
+		}
+	}
+}

--- a/stories/Network.stories.tsx
+++ b/stories/Network.stories.tsx
@@ -1,13 +1,7 @@
 import React from 'react'
 import { BrowserRouter as Router, Route } from 'react-router-dom'
 
-// import { Dataset as IDataset } from '../app/models/dataset'
-// import Navbar from '../app/components/nav/Navbar'
 import { NetworkHome } from '../app/components/network/NetworkHome'
-// import Dataset from '../app/components/dataset/Dataset'
-// import { ActionButtonProps } from '../app/components/chrome/ActionButton'
-
-// const cities = require('./data/cities.dataset.json')
 
 export default {
   title: 'Network',
@@ -20,40 +14,8 @@ export const Home = () =>
   <Router>
     <Route render={(props) => <NetworkHome {...props} />} />
   </Router>
-  
-
 
 Home.story = {
   name: 'Home',
   parameters: { note: 'caution: uses live data' }
 }
-
-// export const StdDatasetOverview = () => {
-//   const handle = (label: string) => {
-//     return (d: IDataset, e: React.SyntheticEvent) => {
-//       alert(`${label}: ${d.peername}/${d.name}`)
-//     }
-//   }
-
-//   const actions: ActionButtonProps[] = [
-//     { icon: 'clone', text: 'Clone', onClick: handle('clone') },
-//     { icon: 'edit', text: 'Edit', onClick: handle('edit') },
-//     { icon: 'export', text: 'Export', onClick: handle('export') }
-//   ]
-
-//   return (
-//     <div style={{ margin: 0, padding: 30, minHeight: '100%', background: '#F5F7FA' }}>
-//       <div style={{ width: 800, margin: '2em auto' }}>
-//         <Router>
-//           <Navbar location='foo/bar' />
-//           <Dataset data={cities} onClone={handle('clone')} onEdit={handle('edit')} onExport={handle('export')} />
-//         </Router>
-//       </div>
-//     </div>
-//   )
-// }
-
-// StdDatasetOverview.story = {
-//   name: 'Dataset Overview: Standard',
-//   parameters: { note: 'basic, ideal-input dataset overview' }
-// }

--- a/test/e2e/e2e.spec.ts
+++ b/test/e2e/e2e.spec.ts
@@ -478,6 +478,18 @@ describe('Qri End to End tests', function spec () {
     await sendKeys('#dataset-name-input', "Enter")
   })
 
+  it('export CSV version', async () => {
+    const { click, delay } = utils
+
+    const savePath = path.join(backend.dir, 'body.csv')
+    await fakeDialog.mock([ { method: 'showSaveDialogSync', value: savePath } ])
+
+    await click('#export-dataset')
+    await click('#submit')
+    await delay(200) // wait to ensure file has time to write
+    expect(fs.existsSync(savePath)).toEqual(true)
+  })
+
   // switch between commits
   it('switch between commits', async () => {
     const {

--- a/test/e2e/e2e_test_flows.md
+++ b/test/e2e/e2e_test_flows.md
@@ -113,6 +113,12 @@ The following flows deal with launching the app for the first time, signing out 
 - set a good name
 - click away to submit
 
+### export a CSV version
+- click the header export dataset button: #export-button
+- mock the electron save dialog to send to `TEST_TMP_DIR/body.csv`
+- click #submit
+- check that a file at `TEST_TMP_DIR/body.csv` exists
+
 ### switch between commits
 - ensure you are at the correct dataset
 - click on each commit #HEAD-3 #HEAD-2 #HEAD-1 #HEAD-0


### PR DESCRIPTION
we don't have support for per-component export in the backend at the moment, so I've moved the dataset component picking stuff into it's own react component for future use in an "advanced" export section.

I'd also like the option to export the entire dataset as a JSON file. I use that format a bunch, it'd be great to have at some point in the future.