### PR TITLE
feat(CollectionHome): add "pull" to row hamburger menu

### DIFF
--- a/app/components/collection/collectionHome/StatusIcons.tsx
+++ b/app/components/collection/collectionHome/StatusIcons.tsx
@@ -16,9 +16,10 @@ const StatusIcons: React.FC<StatusIconsProps> = ({ data, onClickFolder }) => {
   return (
     <>
       <span className="dataset-link" data-tip={published ? 'published' : 'unpublished'}>
-        <ExternalLink href={`${QRI_CLOUD_URL}/${username}/${name}`}>
+        {published && <ExternalLink href={`${QRI_CLOUD_URL}/${username}/${name}`}>
           <Icon icon="publish" size="sm" color={published ? 'dark' : 'medium'}/>
-        </ExternalLink>
+        </ExternalLink>}
+        {!published && <Icon icon="publish" size="sm" color={published ? 'dark' : 'medium'}/>}
       </span>
       {onClickFolder && <a onClick={(e: React.MouseEvent) => onClickFolder(row, e)} className="dataset-link" data-tip={fsiPath ? 'working directory' : 'no working directory'}>
         <Icon icon="openInFinder" size="sm" color={fsiPath ? 'dark' : 'medium'}/>

--- a/app/components/collection/collectionHome/TableRowHamburger.tsx
+++ b/app/components/collection/collectionHome/TableRowHamburger.tsx
@@ -4,7 +4,7 @@ import Hamburger from '../../chrome/Hamburger'
 
 import { VersionInfo } from '../../../models/store'
 import { Modal, ModalType } from '../../../models/modals'
-import { removeDatasetAndFetch } from '../../../actions/api'
+import { removeDatasetAndFetch, pullDataset } from '../../../actions/api'
 import { setModal } from '../../../actions/ui'
 import { connectComponentToProps } from '../../../utils/connectComponentToProps'
 
@@ -12,13 +12,21 @@ interface TableRowHamburgerProps {
   data: VersionInfo
   setModal: (modal: Modal) => void
   removeDatasetAndFetch: (...args: Parameters<typeof removeDatasetAndFetch>) => Promise<AnyAction>
+  pullDataset: (username: string, name: string) => Promise<AnyAction>
 }
 
-const TableRowHamburger: React.FC<TableRowHamburgerProps> = ({ data, setModal, removeDatasetAndFetch }) => {
+const TableRowHamburger: React.FC<TableRowHamburgerProps> = ({ data, setModal, removeDatasetAndFetch, pullDataset }) => {
   const { username, name, fsiPath } = data
   const onRemoveHandler = async (keepFiles: boolean) => removeDatasetAndFetch(username, name, !!fsiPath, keepFiles)
 
   const actions = [
+    {
+      icon: 'download',
+      text: 'Pull',
+      onClick: () => {
+        pullDataset(username, name)
+      }
+    },
     {
       icon: 'download',
       text: 'Export',
@@ -52,6 +60,7 @@ export default connectComponentToProps(
   {},
   {
     setModal,
-    removeDatasetAndFetch
+    removeDatasetAndFetch,
+    pullDataset
   }
 )

--- a/app/components/network/NetworkHome.tsx
+++ b/app/components/network/NetworkHome.tsx
@@ -54,7 +54,6 @@ export const NetworkHome: React.FunctionComponent<NetworkHomeProps> = ({ history
 
   return (
     <div className='network_home'>
-      <h2>Home</h2>
       <SearchBox onEnter={handleOnEnter} id='search-box' />
       {featured && featured.length && <div>
         <h4>Featured Datasets</h4>

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -153,7 +153,7 @@ module.exports = merge(baseConfig, {
        *
        */
       '__BUILD__': {
-        'ENABLE_SQL_WORKBENCH': JSON.stringify(true)
+        'ENABLE_SQL_WORKBENCH': JSON.stringify(false)
       }
     }),
 


### PR DESCRIPTION
* fix: remove "home" header from network home
* fix: clicking an unpublished status icon in collection home no longer opens a link
* fix: disable SQL / compare view in production AND dev environments