### PR TITLE
refactor(*): isolate all electron specific code in platform specific files

### DIFF
--- a/app/actions/export.ts
+++ b/app/actions/export.ts
@@ -1,0 +1,1 @@
+export { exportDatasetVersion } from './platformSpecific/export.TARGET_PLATFORM'

--- a/app/actions/platformSpecific/export.electron.ts
+++ b/app/actions/platformSpecific/export.electron.ts
@@ -5,7 +5,7 @@ import moment from 'moment'
 import { refStringFromQriRef } from '../../models/qriRef'
 import { VersionInfo, qriRefFromVersionInfo } from '../../models/store'
 
-export default function exportDatasetVersion (vi: VersionInfo, config: 'zip' | 'csv') {
+export function exportDatasetVersion (vi: VersionInfo, config: 'zip' | 'csv') {
   const window = remote.getCurrentWindow()
   const defaultPath = `${vi.username}-${vi.name}-${moment(vi.commitTime).format('YYYY-MM-DDThh-mm-ss-a')}.${config}`
   const selectedPath: string | undefined = remote.dialog.showSaveDialogSync(window, { defaultPath })

--- a/app/actions/platformSpecific/export.web.ts
+++ b/app/actions/platformSpecific/export.web.ts
@@ -1,5 +1,5 @@
 import { VersionInfo } from '../../models/store'
 
-export default function exportDatasetVersion (_: VersionInfo) {
-  alert('can\'t export from the web!')
+export function exportDatasetVersion (_: VersionInfo) {
+  console.log("exportDatasetVersion is not implemented in the webapp version of Qri Desktop")
 }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 import { CSSTransition } from 'react-transition-group'
 import { ConnectedRouter, push } from 'connected-react-router'
@@ -111,7 +111,7 @@ class AppComponent extends React.Component<AppProps, AppState> {
   }
 
   private handleReload () {
-    reloadWindow && reloadWindow()
+    reloadWindow()
   }
 
   private handleSetDebugLogPath (_e: any, path: string) {
@@ -119,24 +119,19 @@ class AppComponent extends React.Component<AppProps, AppState> {
   }
 
   private handleExportDebugLog () {
-    if (saveDialogSync) {
-      const exportFilename: string | undefined = saveDialogSync({
-        defaultPath: 'qri-debug.log'
-      })
-      if (!exportFilename) {
-        // Dialog cancelled, do nothing
-        return
-      }
-      if (!this.state.debugLogPath) {
-        // Don't have a log file, log and do nothing
-        console.log('debugLogsPath not set, cannot export!')
-        return
-      }
-      fs.copyFileSync(this.state.debugLogPath, exportFilename)
+    const exportFilename: string | undefined = saveDialogSync({
+      defaultPath: 'qri-debug.log'
+    })
+    if (!exportFilename) {
+      // Dialog cancelled, do nothing
       return
     }
-
-    console.log('Export debug log not set up in webapp version of Qri Desktop')
+    if (!this.state.debugLogPath) {
+      // Don't have a log file, log and do nothing
+      console.log('debugLogsPath not set, cannot export!')
+      return
+    }
+    fs.copyFileSync(this.state.debugLogPath, exportFilename)
   }
 
   private handleIncompatibleBackend (_: any, ver: string) {
@@ -152,23 +147,21 @@ class AppComponent extends React.Component<AppProps, AppState> {
   }
 
   componentDidMount () {
-    if (addRendererListener) {
-      // handle ipc events from electron menus
-      addRendererListener('create-dataset', this.handleNewDataset)
-      addRendererListener('pull-dataset', this.handlePullDataset)
-      addRendererListener('history-push', this.handlePush)
-      addRendererListener('set-debug-log-path', this.handleSetDebugLogPath)
-      addRendererListener('export-debug-log', this.handleExportDebugLog)
-      addRendererListener('reload', this.handleReload)
-      addRendererListener('incompatible-backend', this.handleIncompatibleBackend)
+    // handle ipc events from electron menus
+    addRendererListener('create-dataset', this.handleNewDataset)
+    addRendererListener('pull-dataset', this.handlePullDataset)
+    addRendererListener('history-push', this.handlePush)
+    addRendererListener('set-debug-log-path', this.handleSetDebugLogPath)
+    addRendererListener('export-debug-log', this.handleExportDebugLog)
+    addRendererListener('reload', this.handleReload)
+    addRendererListener('incompatible-backend', this.handleIncompatibleBackend)
 
-      // listen for communication from the main process
-      addRendererListener('migrating-backend', this.handleMigratingBackend)
-      addRendererListener('migration-failed', this.handleMigrationFailure)
-      addRendererListener('starting-backend', this.handleStartingBackend)
-    }
+    // listen for communication from the main process
+    addRendererListener('migrating-backend', this.handleMigratingBackend)
+    addRendererListener('migration-failed', this.handleMigrationFailure)
+    addRendererListener('starting-backend', this.handleStartingBackend)
 
-    sendElectronEventToMain && sendElectronEventToMain('app-fully-loaded')
+    sendElectronEventToMain('app-fully-loaded')
 
     setInterval(() => {
       if (this.props.apiConnection !== 1) {
@@ -182,17 +175,15 @@ class AppComponent extends React.Component<AppProps, AppState> {
   }
 
   componentWillUnmount () {
-    if (removeRendererListener) {
-      removeRendererListener('create-dataset', this.handleNewDataset)
-      removeRendererListener('pull-dataset', this.handlePullDataset)
-      removeRendererListener('history-push', this.handlePush)
-      removeRendererListener('set-debug-log-path', this.handleSetDebugLogPath)
-      removeRendererListener('reload', this.handleReload)
-      removeRendererListener('incompatible-backend', this.handleIncompatibleBackend)
-      removeRendererListener('migrating-backend', this.handleMigratingBackend)
-      removeRendererListener('migration-failed', this.handleMigrationFailure)
-      removeRendererListener('starting-backend', this.handleStartingBackend)
-    }
+    removeRendererListener('create-dataset', this.handleNewDataset)
+    removeRendererListener('pull-dataset', this.handlePullDataset)
+    removeRendererListener('history-push', this.handlePush)
+    removeRendererListener('set-debug-log-path', this.handleSetDebugLogPath)
+    removeRendererListener('reload', this.handleReload)
+    removeRendererListener('incompatible-backend', this.handleIncompatibleBackend)
+    removeRendererListener('migrating-backend', this.handleMigratingBackend)
+    removeRendererListener('migration-failed', this.handleMigrationFailure)
+    removeRendererListener('starting-backend', this.handleStartingBackend)
   }
 
   componentDidUpdate (prevProps: AppProps) {

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -12,7 +12,7 @@ import {
   sendElectronEventToMain,
   saveDialogSync,
   reloadWindow
-} from './platformSpecific/app.TARGET_PLATFORM'
+} from './platformSpecific/App.TARGET_PLATFORM'
 
 // import constants
 import { DEFAULT_POLL_INTERVAL } from '../constants'

--- a/app/components/AppError.tsx
+++ b/app/components/AppError.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import WelcomeTemplate from './onboard/WelcomeTemplate'
 import ExternalLink from './ExternalLink'
 import { DISCORD_URL, QRI_IO_URL } from '../constants'

--- a/app/components/AppLoading.tsx
+++ b/app/components/AppLoading.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import WelcomeTemplate from './onboard/WelcomeTemplate'
 const version: string = require('../../version').desktopVersion
 

--- a/app/components/BodyJson.tsx
+++ b/app/components/BodyJson.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import ReactJson from 'react-json-view'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'

--- a/app/components/BodyTable.tsx
+++ b/app/components/BodyTable.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import * as _ from 'underscore'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSync } from '@fortawesome/free-solid-svg-icons'

--- a/app/components/Code.tsx
+++ b/app/components/Code.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 interface CodeProps {
   data: string

--- a/app/components/CommitDetails.tsx
+++ b/app/components/CommitDetails.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import numeral from 'numeral'
 
 import { VersionInfo } from '../models/store'

--- a/app/components/ContextMenuArea.tsx
+++ b/app/components/ContextMenuArea.tsx
@@ -1,0 +1,7 @@
+/**
+ * Context menus only make sense in context of the electron app right now
+ * as all the actions that one can take are dependent on the dataset being
+ * either in your namespace and/or should be actions that happen only if
+ * you are working locally
+ */
+export { ContextMenuArea, MenuItems } from './platformSpecific/ContextMenuArea.TARGET_PLATFORM'

--- a/app/components/DatasetReference.tsx
+++ b/app/components/DatasetReference.tsx
@@ -1,6 +1,6 @@
 // a component that displays the dataset reference including edit-in-place UI
 // for dataset rename
-import * as React from 'react'
+import React from 'react'
 import { AnyAction } from 'redux'
 import classNames from 'classnames'
 

--- a/app/components/DetailsBar.tsx
+++ b/app/components/DetailsBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 

--- a/app/components/ExternalLink.tsx
+++ b/app/components/ExternalLink.tsx
@@ -1,15 +1,3 @@
-import * as React from 'react'
-import { onClick } from './platformSpecific/ExternalLink.TARGET_PLATFORM'
-
-export interface ExternalLinkProps {
-  id?: string
-  href: string
-  children: React.ReactNode
-  className?: string
-  tooltip?: string
-}
-
-const ExternalLink: React.FunctionComponent<ExternalLinkProps> = ({ id, href, children, className, tooltip }) =>
-  <a id={id} href={href} onClick={(e) => onClick(e, href)} target='_blank' rel="noopener noreferrer" className={className} data-tip={tooltip}>{children}</a>
+import { ExternalLink } from './platformSpecific/ExternalLink.TARGET_PLATFORM'
 
 export default ExternalLink

--- a/app/components/FormatConfigHistory.tsx
+++ b/app/components/FormatConfigHistory.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Structure as IStructure } from '../models/dataset'
 import { formatConfigOptions } from './Structure'
 

--- a/app/components/KeyValueTable.tsx
+++ b/app/components/KeyValueTable.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 interface KeyValueTableProps {
   data: any

--- a/app/components/PseudoLink.tsx
+++ b/app/components/PseudoLink.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 const PseudoLink: React.FunctionComponent = ({ children }) =>
   <span className='pseudo-link'>{children}</span>

--- a/app/components/Resizable.tsx
+++ b/app/components/Resizable.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 /**
  * Component abstracting a resizable panel.

--- a/app/components/Signin.tsx
+++ b/app/components/Signin.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 import { Link } from 'react-router-dom'
 

--- a/app/components/StatsChart.tsx
+++ b/app/components/StatsChart.tsx
@@ -1,6 +1,6 @@
 import { ResponsiveBar } from '@nivo/bar'
 import { ResponsivePie } from '@nivo/pie'
-import * as React from 'react'
+import React from 'react'
 import numeral from 'numeral'
 
 import LabeledStats from './item/LabeledStats'

--- a/app/components/Structure.tsx
+++ b/app/components/Structure.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 

--- a/app/components/TwoDSchemaLayout.tsx
+++ b/app/components/TwoDSchemaLayout.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faToggleOn } from '@fortawesome/free-solid-svg-icons'
 

--- a/app/components/chrome/Button.tsx
+++ b/app/components/chrome/Button.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import classNames from 'classnames'
 import { Link } from 'react-router-dom'
 

--- a/app/components/chrome/Close.tsx
+++ b/app/components/chrome/Close.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 interface CloseProps {
   right?: boolean

--- a/app/components/chrome/NavbarItem.tsx
+++ b/app/components/chrome/NavbarItem.tsx
@@ -11,12 +11,13 @@ export interface NavbarItemProps {
   disabled?: boolean
   onClick?: (event: React.MouseEvent) => void
   link?: string
+  externalLink?: boolean
   items?: React.ReactElement[]
   active?: boolean
 }
 
 const NavbarItem: React.FunctionComponent<NavbarItemProps> = (props) => {
-  const { id = '', icon, tooltip, disabled, onClick, link, active } = props
+  const { id = '', icon, tooltip, disabled, onClick, link, externalLink, active } = props
 
   const item = (
     <div
@@ -36,7 +37,7 @@ const NavbarItem: React.FunctionComponent<NavbarItemProps> = (props) => {
   )
 
   return link ? (
-    <Link to={link}>
+    <Link to={link} target={externalLink && '_blank'}>
       {item}
     </Link>
   ) : item

--- a/app/components/chrome/NavbarItem.tsx
+++ b/app/components/chrome/NavbarItem.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import classNames from 'classnames'
 import { Link } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/app/components/chrome/SearchBox.tsx
+++ b/app/components/chrome/SearchBox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 interface SearchBoxProps {
   id?: string

--- a/app/components/chrome/Spinner.tsx
+++ b/app/components/chrome/Spinner.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import classNames from 'classnames'
 
 export interface SpinnerProps {

--- a/app/components/chrome/SpinnerWithIcon.tsx
+++ b/app/components/chrome/SpinnerWithIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Spinner from './Spinner'
 import { logo } from '../onboard/WelcomeTemplate'
 import { CSSTransition } from 'react-transition-group'

--- a/app/components/collection/Collection.tsx
+++ b/app/components/collection/Collection.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { Switch, Route, useLocation, useRouteMatch, Redirect } from 'react-router-dom'

--- a/app/components/collection/Collection.tsx
+++ b/app/components/collection/Collection.tsx
@@ -4,6 +4,8 @@ import { ipcRenderer, shell } from 'electron'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { Switch, Route, useLocation, useRouteMatch, Redirect } from 'react-router-dom'
 
+import { showDatasetMenu } from './platformSpecific/Collection.TARGET_PLATFORM'
+
 import { RouteProps, VersionInfo } from '../../models/store'
 import { Modal, ModalType } from '../../models/modals'
 import { QriRef, qriRefFromRoute } from '../../models/qriRef'
@@ -166,17 +168,17 @@ const CollectionRouter: React.FunctionComponent<CollectionRouterProps> = (props)
       >
         <Switch location={location}>
           <Route exact path={path} render={() => {
-            ipcRenderer.send('show-dataset-menu', false)
+            showDatasetMenu(false)
             return <CollectionHome />
           }} />
           <Route path={`${path}/edit/:username/:name`} render={() => {
-            ipcRenderer.send('show-dataset-menu', true)
+            showDatasetMenu(true)
             return noDatasetsRedirect(
               <EditDataset />
             )
           }}/>
           <Route path={`${path}/:username/:name/at/ipfs/:path`} render={(props) => {
-            ipcRenderer.send('show-dataset-menu', true)
+            showDatasetMenu(true)
             return noDatasetsRedirect(
               <Dataset {...props} />
             )

--- a/app/components/collection/Collection.tsx
+++ b/app/components/collection/Collection.tsx
@@ -1,20 +1,18 @@
 import * as React from 'react'
 import { Action } from 'redux'
-import { ipcRenderer, shell } from 'electron'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { Switch, Route, useLocation, useRouteMatch, Redirect } from 'react-router-dom'
 
-import { showDatasetMenu } from './platformSpecific/Collection.TARGET_PLATFORM'
+import {
+  showDatasetMenu
+} from './platformSpecific/Collection.TARGET_PLATFORM'
 
 import { RouteProps, VersionInfo } from '../../models/store'
-import { Modal, ModalType } from '../../models/modals'
 import { QriRef, qriRefFromRoute } from '../../models/qriRef'
 
-import { setModal, setSidebarWidth } from '../../actions/ui'
+import { setSidebarWidth } from '../../actions/ui'
 
 import {
-  selectFsiPath,
-  selectWorkingDatasetIsPublished,
   selectSessionUsername,
   selectShowDetailsBar,
   selectSidebarWidth,
@@ -39,8 +37,6 @@ require('../../assets/qri-blob-logo-tiny.png')
 export interface CollectionProps extends RouteProps {
   // display details
   qriRef: QriRef
-  isPublished: boolean
-  fsiPath: string
   hasDatasets: boolean
   showDetailsBar: boolean
   sidebarWidth: number
@@ -48,51 +44,10 @@ export interface CollectionProps extends RouteProps {
   sessionUsername: string
 
   // setting actions
-  setModal: (modal: Modal) => void
   setSidebarWidth: (type: string, sidebarWidth: number) => Action
 }
 
 export class CollectionComponent extends React.Component<CollectionProps> {
-  constructor (props: CollectionProps) {
-    super(props);
-
-    [
-      'openWorkingDirectory',
-      'publishUnpublishDataset'
-    ].forEach((m) => { this[m] = this[m].bind(this) })
-  }
-
-  componentDidMount () {
-    // electron menu events
-    ipcRenderer.on('open-working-directory', this.openWorkingDirectory)
-    ipcRenderer.on('publish-unpublish-dataset', this.publishUnpublishDataset)
-  }
-
-  componentWillUnmount () {
-    ipcRenderer.removeListener('open-working-directory', this.openWorkingDirectory)
-    ipcRenderer.removeListener('publish-unpublish-dataset', this.publishUnpublishDataset)
-  }
-
-  openWorkingDirectory () {
-    shell.openItem(this.props.fsiPath)
-  }
-
-  publishUnpublishDataset () {
-    const { isPublished, setModal } = this.props
-
-    isPublished
-      ? setModal({
-        type: ModalType.UnpublishDataset,
-        username: this.props.qriRef.username,
-        name: this.props.qriRef.name
-      })
-      : setModal({
-        type: ModalType.PublishDataset,
-        username: this.props.qriRef.username,
-        name: this.props.qriRef.name
-      })
-  }
-
   render () {
     const {
       qriRef,
@@ -217,8 +172,6 @@ export default connectComponentToProps(
        * we should pull the published status of the specific version being shown
        * rather then the status of the dataset at head.
        */
-      isPublished: selectWorkingDatasetIsPublished(state),
-      fsiPath: selectFsiPath(state),
       hasDatasets: selectHasDatasets(state),
       showDetailsBar: selectShowDetailsBar(state),
       sidebarWidth: selectSidebarWidth(state, 'workbench'),
@@ -228,7 +181,6 @@ export default connectComponentToProps(
     }
   },
   {
-    setModal,
     setSidebarWidth
   }
 )

--- a/app/components/collection/ComponentList.tsx
+++ b/app/components/collection/ComponentList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import { Status, SelectedComponent, ComponentStatus, RouteProps } from '../../models/store'
 import { pathToDataset } from '../../paths'

--- a/app/components/collection/ComponentRouter.tsx
+++ b/app/components/collection/ComponentRouter.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 import { useSelector } from 'react-redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'

--- a/app/components/collection/Dataset.tsx
+++ b/app/components/collection/Dataset.tsx
@@ -63,17 +63,19 @@ export const DatasetComponent: React.FunctionComponent<DatasetProps> = (props) =
   }
 
   React.useEffect(() => {
-    if (addRendererListener) {
-      addRendererListener('open-working-directory', openWorkingDirectory)
-      addRendererListener('publish-unpublish-dataset', publishUnpublishDataset)
-    }
+    addRendererListener('open-working-directory', openWorkingDirectory)
+
     return () => {
-      if (removeRendererListener) {
-        removeRendererListener('open-working-directory', openWorkingDirectory)
-        removeRendererListener('publish-unpublish-dataset', publishUnpublishDataset)
-      }
+      removeRendererListener('open-working-directory', openWorkingDirectory)
     }
-  }, [])
+  }, [fsiPath])
+
+  React.useEffect(() => {
+    addRendererListener('publish-unpublish-dataset', publishUnpublishDataset)
+    return () => {
+      removeRendererListener('publish-unpublish-dataset', publishUnpublishDataset)
+    }
+  }, [qriRef.username, qriRef.name])
 
   React.useEffect(() => {
     fetchWorkbench(qriRef)

--- a/app/components/collection/Dataset.tsx
+++ b/app/components/collection/Dataset.tsx
@@ -1,12 +1,19 @@
 import React from 'react'
 
+import {
+  addRendererListener,
+  removeRendererListener,
+  openDirectory
+} from './platformSpecific/Dataset.TARGET_PLATFORM'
+
+import { Modal, ModalType } from '../../models/modals'
 import Store, { RouteProps } from '../../models/Store'
 import Dataset from '../../models/dataset'
 import { QriRef, qriRefFromRoute } from '../../models/qriRef'
 import { LaunchedFetchesAction } from '../../store/api'
 import { connectComponentToPropsWithRouter } from '../../utils/connectComponentToProps'
 import { fetchWorkbench } from '../../actions/workbench'
-import { selectDataset } from '../../selections'
+import { selectDataset, selectFsiPath, selectInNamespace, selectWorkingDatasetIsPublished } from '../../selections'
 import { setModal } from '../../actions/ui'
 
 import ComponentList from './ComponentList'
@@ -19,15 +26,54 @@ import LogList from './LogList'
 export interface DatasetProps extends RouteProps {
   qriRef: QriRef
   dataset: Dataset
+  isPublished: boolean
+  inNamespace: boolean
+  fsiPath: string
   fetchWorkbench: (qriRef: QriRef) => LaunchedFetchesAction
+  setModal: (modal: Modal) => void
 }
 
 export const DatasetComponent: React.FunctionComponent<DatasetProps> = (props) => {
   const {
     qriRef,
     dataset,
-    fetchWorkbench
+    isPublished,
+    fsiPath,
+    inNamespace,
+    fetchWorkbench,
+    setModal
   } = props
+
+  const publishUnpublishDataset = () => {
+    inNamespace && isPublished
+      ? setModal({
+        type: ModalType.UnpublishDataset,
+        username: qriRef.username,
+        name: qriRef.name
+      })
+      : setModal({
+        type: ModalType.PublishDataset,
+        username: qriRef.username,
+        name: qriRef.name
+      })
+  }
+
+  const openWorkingDirectory = () => {
+    openDirectory(fsiPath)
+  }
+
+  React.useEffect(() => {
+    if (addRendererListener) {
+      addRendererListener('open-working-directory', openWorkingDirectory)
+      addRendererListener('publish-unpublish-dataset', publishUnpublishDataset)
+    }
+    return () => {
+      if (removeRendererListener) {
+        removeRendererListener('open-working-directory', openWorkingDirectory)
+        removeRendererListener('publish-unpublish-dataset', publishUnpublishDataset)
+      }
+    }
+  }, [])
 
   React.useEffect(() => {
     fetchWorkbench(qriRef)
@@ -61,10 +107,14 @@ export const DatasetComponent: React.FunctionComponent<DatasetProps> = (props) =
 export default connectComponentToPropsWithRouter(
   DatasetComponent,
   (state: Store, ownProps: DatasetProps) => {
+    const qriRef = qriRefFromRoute(ownProps)
     return {
       ...ownProps,
-      qriRef: qriRefFromRoute(ownProps),
-      dataset: selectDataset(state)
+      qriRef,
+      dataset: selectDataset(state),
+      isPublished: selectWorkingDatasetIsPublished(state),
+      fsiPath: selectFsiPath(state),
+      inNamespace: selectInNamespace(state, qriRef)
     }
   },
   {

--- a/app/components/collection/DisabledComponentList.tsx
+++ b/app/components/collection/DisabledComponentList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import ComponentItem from '../item/ComponentItem'
 import { components } from './WorkingComponentList'

--- a/app/components/collection/EditDataset.tsx
+++ b/app/components/collection/EditDataset.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import Store, { RouteProps } from '../../models/Store'
 import { LaunchedFetchesAction } from '../../store/api'

--- a/app/components/collection/LogList.tsx
+++ b/app/components/collection/LogList.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
-import { MenuItemConstructorOptions } from 'electron'
-import ContextMenuArea from 'react-electron-contextmenu'
+
+/**
+ * Context menus only make sense in context of the electron app right now
+ * as all the actions that one can take are dependent on the dataset being
+ * either in your namespace and/or should be actions that happen only if
+ * you are working locally
+ */
+import ContextMenuArea, { MenuItems } from '../platformSpecific/ContextMenuArea.TARGET_PLATFORM'
 
 import { ApiActionThunk } from '../../store/api'
 import { QriRef, qriRefFromRoute, qriRefIsEmpty } from '../../models/qriRef'
@@ -83,7 +89,7 @@ export const LogListComponent: React.FunctionComponent<LogListProps> = (props) =
               }}
             />
           }
-          const menuItems: MenuItemConstructorOptions[] = [
+          const menuItems: MenuItems[] = [
             {
               label: 'Export this version',
               click: () => {
@@ -92,7 +98,11 @@ export const LogListComponent: React.FunctionComponent<LogListProps> = (props) =
             }
           ]
           return (
-            <ContextMenuArea menuItems={menuItems} key={item.path}>
+            <ContextMenuArea
+              data={menuItems}
+              menuItemsFactory={(data) => data}
+              key={item.path}
+            >
               <LogListItem
                 data={item}
                 key={item.path}

--- a/app/components/collection/LogList.tsx
+++ b/app/components/collection/LogList.tsx
@@ -6,7 +6,7 @@ import React from 'react'
  * either in your namespace and/or should be actions that happen only if
  * you are working locally
  */
-import ContextMenuArea, { MenuItems } from '../platformSpecific/ContextMenuArea.TARGET_PLATFORM'
+import { ContextMenuArea, MenuItems } from '../ContextMenuArea'
 
 import { ApiActionThunk } from '../../store/api'
 import { QriRef, qriRefFromRoute, qriRefIsEmpty } from '../../models/qriRef'

--- a/app/components/collection/ParseError.tsx
+++ b/app/components/collection/ParseError.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import path from 'path'
 
 import { SelectedComponent } from '../../models/store'
@@ -7,7 +7,7 @@ import { connectComponentToProps } from '../../utils/connectComponentToProps'
 
 import { selectWorkingStatusInfo } from '../../selections'
 
-import { ShowInFilesystem } from './platformSpecific/ShowInFilesystem.TARGET_PLATFORM'
+import { ShowInFilesystem } from './ShowInFilesystem'
 
 interface ParseErrorProps {
   // from parent component
@@ -23,7 +23,7 @@ const ParseErrorComponent: React.FunctionComponent<ParseErrorProps> = ({ compone
         <div>
           <h4>There are parsing errors in your {component}</h4>
           <p>Fix the errors in your <strong>{filename}</strong> file to be able to view it in Qri Desktop.</p>
-          {ShowInFilesystem && <ShowInFilesystem path={filename && path.dirname(filename)} />}
+          <ShowInFilesystem path={filename && path.dirname(filename)} />
         </div>
       </div>
     </div>

--- a/app/components/collection/ParseError.tsx
+++ b/app/components/collection/ParseError.tsx
@@ -1,33 +1,34 @@
 import * as React from 'react'
-import { shell } from 'electron'
+import path from 'path'
 
 import { SelectedComponent } from '../../models/store'
 
 import { connectComponentToProps } from '../../utils/connectComponentToProps'
 
-import { selectWorkingStatusInfo, selectFsiPath } from '../../selections'
+import { selectWorkingStatusInfo } from '../../selections'
 
-import Button from '../chrome/Button'
+import { ShowInFilesystem } from './platformSpecific/ShowInFilesystem.TARGET_PLATFORM'
 
 interface ParseErrorProps {
   // from parent component
   component: string
   // from connect
   filename?: string
-  fsiPath?: string
 }
 
-const ParseErrorComponent: React.FunctionComponent<ParseErrorProps> = ({ component, filename, fsiPath = '' }) => (
-  <div className='unlinked-dataset'>
-    <div className='message-container'>
-      <div>
-        <h4>There are parsing errors in your {component}</h4>
-        <p>Fix the errors in your <strong>{filename}</strong> file to be able to view it in Qri Desktop.</p>
-        <Button id='show_errors_in_finder' text="Show in Finder" color="primary" onClick={() => { shell.openItem(fsiPath) }} />
+const ParseErrorComponent: React.FunctionComponent<ParseErrorProps> = ({ component, filename }) => {
+  return (
+    <div className='unlinked-dataset margin'>
+      <div className='message-container'>
+        <div>
+          <h4>There are parsing errors in your {component}</h4>
+          <p>Fix the errors in your <strong>{filename}</strong> file to be able to view it in Qri Desktop.</p>
+          {ShowInFilesystem && <ShowInFilesystem path={filename && path.dirname(filename)} />}
+        </div>
       </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default connectComponentToProps(
   ParseErrorComponent,
@@ -35,8 +36,7 @@ export default connectComponentToProps(
     const statusInfo = selectWorkingStatusInfo(state, ownProps.component as SelectedComponent)
     return {
       ...ownProps,
-      filename: statusInfo.filepath,
-      fsiPath: selectFsiPath(state)
+      filename: statusInfo.filepath
     }
   }
 )

--- a/app/components/collection/ShowInFilesystem.tsx
+++ b/app/components/collection/ShowInFilesystem.tsx
@@ -1,0 +1,1 @@
+export { ShowInFilesystem } from './platformSpecific/ShowInFilesystem.TARGET_PLATFORM'

--- a/app/components/collection/WorkingComponentList.tsx
+++ b/app/components/collection/WorkingComponentList.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import path from 'path'
 import classNames from 'classnames'
-import { clipboard, shell, MenuItemConstructorOptions } from 'electron'
+
+import { showItemInFolder, copyToClipboard } from './platformSpecific/WorkingComponentList.TARGET_PLATFORM'
 
 import { checkClearToCommit } from '../../utils/formValidation'
 import { QriRef, qriRefFromRoute } from '../../models/qriRef'
@@ -13,7 +14,14 @@ import { discardMutationsChanges } from '../../actions/mutations'
 import { selectStatusFromMutations, selectFsiPath, selectHasHistory } from '../../selections'
 import { pathToEdit } from '../../paths'
 
-import ContextMenuArea from '../ContextMenuArea'
+/**
+ * Context menus only make sense in context of the electron app right now
+ * as all the actions that one can take are dependent on the dataset being
+ * either in your namespace and/or should be actions that happen only if
+ * you are working locally
+ */
+import ContextMenuArea, { MenuItems } from '../platformSpecific/ContextMenuArea.TARGET_PLATFORM'
+
 import ComponentItem from '../item/ComponentItem'
 import { connectComponentToPropsWithRouter } from '../../utils/connectComponentToProps'
 import { Action } from 'redux'
@@ -116,7 +124,7 @@ export const WorkingComponentListComponent: React.FunctionComponent<WorkingCompo
             }
           }
 
-          let menuItems: MenuItemConstructorOptions[] = []
+          let menuItems: MenuItems[] = []
           if (status[name]) {
             const { filepath, status: fileStatus } = status[name]
             let filename = ''
@@ -127,11 +135,11 @@ export const WorkingComponentListComponent: React.FunctionComponent<WorkingCompo
               menuItems = [
                 {
                   label: 'Open in Finder',
-                  click: () => { shell.showItemInFolder(`${fsiPath}/${filename}`) }
+                  click: () => { showItemInFolder(`${fsiPath}/${filename}`) }
                 },
                 {
                   label: 'Copy File Path',
-                  click: () => { clipboard.writeText(`${fsiPath}/${filename}`) }
+                  click: () => { copyToClipboard(`${fsiPath}/${filename}`) }
                 }
               ]
 
@@ -160,7 +168,11 @@ export const WorkingComponentListComponent: React.FunctionComponent<WorkingCompo
           }
 
           return (
-            <ContextMenuArea data={menuItems} menuItemsFactory={(data) => data} key={name}>
+            <ContextMenuArea
+              data={menuItems}
+              menuItemsFactory={(data) => data}
+              key={name}
+            >
               <ComponentItem
                 key={name}
                 displayName={displayName}

--- a/app/components/collection/WorkingComponentList.tsx
+++ b/app/components/collection/WorkingComponentList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import path from 'path'
 import classNames from 'classnames'
 
@@ -14,13 +14,7 @@ import { discardMutationsChanges } from '../../actions/mutations'
 import { selectStatusFromMutations, selectFsiPath, selectHasHistory } from '../../selections'
 import { pathToEdit } from '../../paths'
 
-/**
- * Context menus only make sense in context of the electron app right now
- * as all the actions that one can take are dependent on the dataset being
- * either in your namespace and/or should be actions that happen only if
- * you are working locally
- */
-import ContextMenuArea, { MenuItems } from '../platformSpecific/ContextMenuArea.TARGET_PLATFORM'
+import { ContextMenuArea, MenuItems } from '../ContextMenuArea'
 
 import ComponentItem from '../item/ComponentItem'
 import { connectComponentToPropsWithRouter } from '../../utils/connectComponentToProps'

--- a/app/components/collection/collectionHome/CollectionHome.tsx
+++ b/app/components/collection/collectionHome/CollectionHome.tsx
@@ -17,7 +17,7 @@ interface CollectionHomeProps {
 
 export const CollectionHome: React.FC<CollectionHomeProps> = ({ setModal }) => {
   React.useEffect(() => {
-    showDatasetMenu && showDatasetMenu(false)
+    showDatasetMenu(false)
   }, [])
 
   return (

--- a/app/components/collection/collectionHome/CollectionHome.tsx
+++ b/app/components/collection/collectionHome/CollectionHome.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { ipcRenderer } from 'electron'
 import { faDownload, faPlus } from '@fortawesome/free-solid-svg-icons'
+
+import { showDatasetMenu } from './platformSpecific/CollectionHome.TARGET_PLATFORM'
 
 import { setModal } from '../../../actions/ui'
 import { connectComponentToProps } from '../../../utils/connectComponentToProps'
@@ -16,7 +17,7 @@ interface CollectionHomeProps {
 
 export const CollectionHome: React.FC<CollectionHomeProps> = ({ setModal }) => {
   React.useEffect(() => {
-    ipcRenderer.send('show-dataset-menu', false)
+    showDatasetMenu && showDatasetMenu(false)
   }, [])
 
   return (

--- a/app/components/collection/collectionHome/DatasetList.tsx
+++ b/app/components/collection/collectionHome/DatasetList.tsx
@@ -4,11 +4,12 @@ import classNames from "classnames"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 
+import { onClickOpenInFinder } from './platformSpecific/DatasetList.TARGET_PLATFORM'
+
 import { pathToDataset } from '../../../paths'
 import { QriRef } from '../../../models/qriRef'
 import { Modal, ModalType } from '../../../models/modals'
 import { Store, MyDatasets, WorkingDataset, VersionInfo, RouteProps, ToastType } from '../../../models/store'
-import { onClickOpenInFinder } from '../../platformSpecific/DatasetStatus.TARGET_PLATFORM'
 import { connectComponentToPropsWithRouter } from '../../../utils/connectComponentToProps'
 import { setFilter } from '../../../actions/myDatasets'
 import { pullDatasets, fetchMyDatasets, removeDatasetsAndFetch } from '../../../actions/api'

--- a/app/components/collection/collectionHome/platformSpecific/CollectionHome.electron.ts
+++ b/app/components/collection/collectionHome/platformSpecific/CollectionHome.electron.ts
@@ -1,0 +1,5 @@
+import { ipcRenderer } from 'electron'
+
+export function showDatasetMenu (show: boolean) {
+  ipcRenderer.send('show-dataset-menu', show)
+}

--- a/app/components/collection/collectionHome/platformSpecific/CollectionHome.web.ts
+++ b/app/components/collection/collectionHome/platformSpecific/CollectionHome.web.ts
@@ -1,0 +1,1 @@
+export function showDatasetMenu (show: boolean) {}

--- a/app/components/collection/collectionHome/platformSpecific/DatasetList.electron.ts
+++ b/app/components/collection/collectionHome/platformSpecific/DatasetList.electron.ts
@@ -1,0 +1,3 @@
+import { shell } from 'electron'
+
+export const onClickOpenInFinder = (fsiPath: string) => shell.openItem(fsiPath)

--- a/app/components/collection/collectionHome/platformSpecific/DatasetList.web.ts
+++ b/app/components/collection/collectionHome/platformSpecific/DatasetList.web.ts
@@ -1,4 +1,4 @@
-// This file is needed for webpack to build DatasetStatus for in-browser rendering without loading
+// This file is needed for webpack to build DatasetList for in-browser rendering without loading
 // the electron dependency, but in practice we do not expect the "open in finder" icon to ever be
 // used on Web so this function should never be called.
 export const onClickOpenInFinder = () => {}

--- a/app/components/collection/datasetComponents/Body.tsx
+++ b/app/components/collection/datasetComponents/Body.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 
 import { ApiActionThunk } from '../../../store/api'

--- a/app/components/collection/datasetComponents/Commit.tsx
+++ b/app/components/collection/datasetComponents/Commit.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import moment from 'moment'
 
 import { QriRef, qriRefFromRoute } from '../../../models/qriRef'

--- a/app/components/collection/datasetComponents/CommitEditor.tsx
+++ b/app/components/collection/datasetComponents/CommitEditor.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 import classNames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/app/components/collection/datasetComponents/Metadata.tsx
+++ b/app/components/collection/datasetComponents/Metadata.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import Store, { RouteProps } from '../../../models/store'
 import { Meta, Citation, License, User } from '../../../models/dataset'

--- a/app/components/collection/datasetComponents/MetadataEditor.tsx
+++ b/app/components/collection/datasetComponents/MetadataEditor.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import cloneDeep from 'clone-deep'

--- a/app/components/collection/datasetComponents/Readme.tsx
+++ b/app/components/collection/datasetComponents/Readme.tsx
@@ -2,16 +2,12 @@ import * as React from 'react'
 
 import Store, { RouteProps } from '../../../models/store'
 import { refStringFromQriRef, QriRef, qriRefFromRoute } from '../../../models/qriRef'
-import { onClick as openExternal } from '../../platformSpecific/ExternalLink.TARGET_PLATFORM'
+import { openExternal } from './platformSpecific/Readme.TARGET_PLATFORM'
 
 import { connectComponentToProps } from '../../../utils/connectComponentToProps'
 
 export interface ReadmeProps extends RouteProps {
   qriRef: QriRef
-}
-
-const handleClick = (e: React.MouseEvent) => {
-  openExternal(e, e.target.href)
 }
 
 export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => {
@@ -45,7 +41,9 @@ export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => 
       // use "editor-preview" class to piggie-back off the simplemde styling
       className="editor-preview"
       ref={ref}
-      onClick={handleClick}
+      onClick={(e) => {
+        openExternal(e, e.target.href)
+      }}
     >loading...
     </div>
   )

--- a/app/components/collection/datasetComponents/ReadmeEditor.tsx
+++ b/app/components/collection/datasetComponents/ReadmeEditor.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import SimpleMDE from 'react-simplemde-editor'
 import { useDebounce } from 'use-debounce'
 
@@ -8,7 +8,7 @@ import hasParseError from '../../../utils/hasParseError'
 import Dataset from '../../../models/dataset'
 import { refStringFromQriRef, QriRef, qriRefFromRoute } from '../../../models/qriRef'
 import Store, { StatusInfo, RouteProps } from '../../../models/store'
-import { onClick as openExternal } from '../../platformSpecific/ExternalLink.TARGET_PLATFORM'
+import { openExternal } from './platformSpecific/Readme.TARGET_PLATFORM'
 
 import { writeDataset } from '../../../actions/workbench'
 

--- a/app/components/collection/datasetComponents/StructureEditor.tsx
+++ b/app/components/collection/datasetComponents/StructureEditor.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 

--- a/app/components/collection/datasetComponents/Transform.tsx
+++ b/app/components/collection/datasetComponents/Transform.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { ApiActionThunk } from '../../../store/api'
 
 import Dataset from '../../../models/dataset'

--- a/app/components/collection/datasetComponents/platformSpecific/Readme.electron.ts
+++ b/app/components/collection/datasetComponents/platformSpecific/Readme.electron.ts
@@ -1,0 +1,8 @@
+import React from 'react'
+import { shell } from 'electron'
+
+export function openExternal (e: React.MouseEvent, href: string) {
+  e.preventDefault()
+  e.stopPropagation()
+  shell.openExternal(href)
+}

--- a/app/components/collection/datasetComponents/platformSpecific/Readme.web.ts
+++ b/app/components/collection/datasetComponents/platformSpecific/Readme.web.ts
@@ -1,0 +1,2 @@
+import React from 'react'
+export function openExternal (e: React.MouseEvent, href: string) {}

--- a/app/components/collection/headerButtons/CheckoutButton.tsx
+++ b/app/components/collection/headerButtons/CheckoutButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { faFile, faLink } from '@fortawesome/free-solid-svg-icons'
 
 import { RouteProps } from '../../../models/store'

--- a/app/components/collection/headerButtons/CopyCloudLinkButton.tsx
+++ b/app/components/collection/headerButtons/CopyCloudLinkButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { faFile } from '@fortawesome/free-regular-svg-icons'
 import { faLink } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -53,7 +53,7 @@ export const CopyCloudLinkButtonComponent: React.FunctionComponent<CopyCloudLink
       </span>
     )}
     onClick={() => {
-      addToClipboard && addToClipboard(`${QRI_CLOUD_URL}/${username}/${name}`)
+      addToClipboard(`${QRI_CLOUD_URL}/${username}/${name}`)
     }}
   />)
 }

--- a/app/components/collection/headerButtons/ExportButton.tsx
+++ b/app/components/collection/headerButtons/ExportButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { RouteProps } from 'react-router-dom'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 

--- a/app/components/collection/headerButtons/PublishButton.tsx
+++ b/app/components/collection/headerButtons/PublishButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { faCloudUploadAlt } from '@fortawesome/free-solid-svg-icons'
 
 import { RouteProps } from '../../../models/store'

--- a/app/components/collection/headerButtons/RemoveButton.tsx
+++ b/app/components/collection/headerButtons/RemoveButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { faTrash } from '@fortawesome/free-solid-svg-icons'
 import { RouteProps } from 'react-router-dom'
 

--- a/app/components/collection/headerButtons/RenameButton.tsx
+++ b/app/components/collection/headerButtons/RenameButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { faPen } from '@fortawesome/free-solid-svg-icons'
 
 import { RouteProps } from '../../../models/store'

--- a/app/components/collection/headerButtons/ShowFilesButton.tsx
+++ b/app/components/collection/headerButtons/ShowFilesButton.tsx
@@ -1,5 +1,5 @@
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons'
-import * as React from 'react'
+import React from 'react'
 import { RouteProps } from 'react-router-dom'
 
 import { isDatasetSelected, QriRef, qriRefFromRoute } from '../../../models/qriRef'
@@ -42,7 +42,7 @@ export const ShowFilesButtonComponent: React.FunctionComponent<ShowFilesButtonPr
     icon={showIcon && faFolderOpen}
     size={size}
     onClick={() => {
-      openItem && openItem(fsiPath)
+      openItem(fsiPath)
     }}
   />)
 }

--- a/app/components/collection/headerButtons/UnpublishButton.tsx
+++ b/app/components/collection/headerButtons/UnpublishButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { faCloud, faTimes } from '@fortawesome/free-solid-svg-icons'
 
 import { RouteProps } from '../../../models/store'

--- a/app/components/collection/headerButtons/ViewInCloudButton.tsx
+++ b/app/components/collection/headerButtons/ViewInCloudButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { faCloud } from '@fortawesome/free-solid-svg-icons'
 
 import { RouteProps } from '../../../models/store'
@@ -49,7 +49,7 @@ export const ViewInCloudButtonComponent: React.FunctionComponent<ViewInCloudButt
     icon={showIcon && faCloud}
     size={size}
     onClick={() => {
-      openInExternalWindow && openInExternalWindow(`${QRI_CLOUD_URL}/${username}/${name}`)
+      openInExternalWindow(`${QRI_CLOUD_URL}/${username}/${name}`)
     }}
   />)
 }

--- a/app/components/collection/headerButtons/platformSpecific/ButtonActions.web.ts
+++ b/app/components/collection/headerButtons/platformSpecific/ButtonActions.web.ts
@@ -1,8 +1,5 @@
-/**
- * need to have web specific versions of the functions inside
- * `ButtonActions.electron.ts`
- *
- * openItem
- * atToClipboard
- *
- */
+export const openItem = (path: string) => {}
+
+export const addToClipboard = (text: string) => {}
+
+export const openInExternalWindow = async (url: string) => {}

--- a/app/components/collection/layouts/DatasetSidebar.tsx
+++ b/app/components/collection/layouts/DatasetSidebar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import { QriRef, qriRefFromRoute } from '../../../models/qriRef'
 import { VersionInfo, RouteProps } from '../../../models/store'

--- a/app/components/collection/platformSpecific/Collection.electron.ts
+++ b/app/components/collection/platformSpecific/Collection.electron.ts
@@ -1,0 +1,5 @@
+import { ipcRenderer } from 'electron'
+
+export function showDatasetMenu (show: boolean) {
+  ipcRenderer.send('show-dataset-menu', show)
+}

--- a/app/components/collection/platformSpecific/Collection.web.ts
+++ b/app/components/collection/platformSpecific/Collection.web.ts
@@ -1,0 +1,1 @@
+export function showDatasetMenu (show: boolean) {}

--- a/app/components/collection/platformSpecific/Dataset.electron.ts
+++ b/app/components/collection/platformSpecific/Dataset.electron.ts
@@ -1,0 +1,12 @@
+import { ipcRenderer, shell } from 'electron'
+export function addRendererListener (eventType: string, func: (e?: any, s?: string) => void) {
+  ipcRenderer.on(eventType, func)
+}
+
+export function removeRendererListener (eventType: string, func: (e?: any, s?: string) => void) {
+  ipcRenderer.removeListener(eventType, func)
+}
+
+export function openDirectory (path: string) {
+  shell.openItem(path)
+}

--- a/app/components/collection/platformSpecific/Dataset.web.ts
+++ b/app/components/collection/platformSpecific/Dataset.web.ts
@@ -1,0 +1,5 @@
+export function addRendererListener (eventType: string, func: (e?: any, s?: string) => void) {}
+
+export function removeRendererListener (eventType: string, func: (e?: any, s?: string) => void) {}
+
+export function openDirectory (path: string) {}

--- a/app/components/collection/platformSpecific/ShowInFilesystem.electron.tsx
+++ b/app/components/collection/platformSpecific/ShowInFilesystem.electron.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { shell } from 'electron'
+
+import Button from '../../chrome/Button'
+
+interface ShowInFilesystemProps {
+  path: string
+}
+
+export const ShowInFilesystem: React.FunctionComponent<ShowInFilesystemProps> = ({ path }) =>
+  <Button
+    id='show-in-filesystem'
+    text={`Show in ${process.platform === 'darwin' ? 'Finder' : 'Explorer'}`}
+    color='primary'
+    onClick={() => {
+      shell.openItem(path)
+    }}
+  />

--- a/app/components/collection/platformSpecific/ShowInFilesystem.electron.tsx
+++ b/app/components/collection/platformSpecific/ShowInFilesystem.electron.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { shell } from 'electron'
 
 import Button from '../../chrome/Button'
@@ -7,7 +7,7 @@ interface ShowInFilesystemProps {
   path: string
 }
 
-export const ShowInFilesystem: React.FunctionComponent<ShowInFilesystemProps> = ({ path }) =>
+const ShowInFilesystem: React.FunctionComponent<ShowInFilesystemProps> = ({ path }) =>
   <Button
     id='show-in-filesystem'
     text={`Show in ${process.platform === 'darwin' ? 'Finder' : 'Explorer'}`}
@@ -16,3 +16,5 @@ export const ShowInFilesystem: React.FunctionComponent<ShowInFilesystemProps> = 
       shell.openItem(path)
     }}
   />
+
+export default ShowInFilesystem

--- a/app/components/collection/platformSpecific/ShowInFilesystem.web.tsx
+++ b/app/components/collection/platformSpecific/ShowInFilesystem.web.tsx
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const ShowInFilesystem: React.FunctionComponent = () => { return null }

--- a/app/components/collection/platformSpecific/WorkingComponentList.electron.ts
+++ b/app/components/collection/platformSpecific/WorkingComponentList.electron.ts
@@ -1,0 +1,9 @@
+import { clipboard, shell } from 'electron'
+
+export function showItemInFolder (path: string) {
+  shell.showItemInFolder(path)
+}
+
+export function copyToClipboard (text: string) {
+  clipboard.writeText(text)
+}

--- a/app/components/collection/platformSpecific/WorkingComponentList.web.ts
+++ b/app/components/collection/platformSpecific/WorkingComponentList.web.ts
@@ -1,7 +1,3 @@
-export function showItemInFolder (path: string) {
-  console.log('showItemInFolder not implemented in webapp version of the Qri Desktop')
-}
+export function showItemInFolder (path: string) {}
 
-export function copyToClipboard (text: string) {
-  console.log('copyToClipboard not implemented in webapp version of the Qri Desktop')
-}
+export function copyToClipboard (text: string) {}

--- a/app/components/collection/platformSpecific/WorkingComponentList.web.ts
+++ b/app/components/collection/platformSpecific/WorkingComponentList.web.ts
@@ -1,0 +1,7 @@
+export function showItemInFolder (path: string) {
+  console.log('showItemInFolder not implemented in webapp version of the Qri Desktop')
+}
+
+export function copyToClipboard (text: string) {
+  console.log('copyToClipboard not implemented in webapp version of the Qri Desktop')
+}

--- a/app/components/compare/Compare.tsx
+++ b/app/components/compare/Compare.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 
 import { BACKEND_URL } from '../../constants'

--- a/app/components/compare/CompareSidebar.tsx
+++ b/app/components/compare/CompareSidebar.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
-import { remote } from 'electron'
 import fs from 'fs'
 import { Action } from 'redux'
 import classNames from 'classnames'
+
+import { showOpenDialogSync } from './platformSpecific/CompareSidebar.TARGET_PLATFORM'
 
 import Store, { ToastType } from '../../models/store'
 
@@ -28,8 +29,7 @@ export interface CompareSidebarProps {
 
 export const CompareSidebarComponent: React.FunctionComponent<CompareSidebarProps> = ({ data, onChange, openToast }) => {
   const pathPicker = (side: string) => {
-    const window = remote.getCurrentWindow()
-    const filePaths: string[] | undefined = remote.dialog.showOpenDialogSync(window, {
+    const filePaths: string[] | undefined = showOpenDialogSync({
       title: 'Choose a CSV file',
       buttonLabel: 'Load',
       filters: [

--- a/app/components/compare/CompareSidebar.tsx
+++ b/app/components/compare/CompareSidebar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import fs from 'fs'
 import { Action } from 'redux'
 import classNames from 'classnames'

--- a/app/components/compare/LineDiff.tsx
+++ b/app/components/compare/LineDiff.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import DiffStat from './DiffStat'
 

--- a/app/components/compare/platformSpecific/CompareSidebar.electron.ts
+++ b/app/components/compare/platformSpecific/CompareSidebar.electron.ts
@@ -1,0 +1,5 @@
+import { remote, OpenDialogSyncOptions } from 'electron'
+
+export function showOpenDialogSync (opts: OpenDialogSyncOptions): string[] | undefined {
+  return remote.dialog.showOpenDialogSync(remote.getCurrentWindow(), opts)
+}

--- a/app/components/compare/platformSpecific/CompareSidebar.web.ts
+++ b/app/components/compare/platformSpecific/CompareSidebar.web.ts
@@ -1,0 +1,4 @@
+export function showOpenDialogSync (): undefined {
+  console.log("showOpenDialogSync is not implemented for the webapp version of the Qri Desktop")
+  return undefined
+}

--- a/app/components/form/DebouncedTextInput.tsx
+++ b/app/components/form/DebouncedTextInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { useDebounce } from 'use-debounce'
 import TextInput, { TextInputProps } from './TextInput'
 

--- a/app/components/form/DropdownInput.tsx
+++ b/app/components/form/DropdownInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Select from 'react-select'
 
 import InputLabel from './InputLabel'

--- a/app/components/form/DynamicEditField.tsx
+++ b/app/components/form/DynamicEditField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import classNames from 'classnames'
 import stripHtml from 'string-strip-html'
 

--- a/app/components/form/InputLabel.tsx
+++ b/app/components/form/InputLabel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import classNames from 'classnames'

--- a/app/components/form/MetadataMultiInput.tsx
+++ b/app/components/form/MetadataMultiInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import cloneDeep from 'clone-deep'

--- a/app/components/form/MultiTextInput.tsx
+++ b/app/components/form/MultiTextInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 

--- a/app/components/form/Row.tsx
+++ b/app/components/form/Row.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 const Row: React.FunctionComponent<any> = ({ children }) =>
   <div className='flex-space-between'>{children}</div>

--- a/app/components/form/SelectInput.tsx
+++ b/app/components/form/SelectInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import classNames from 'classnames'
 import { ISelectOption } from '../../models/forms'
 

--- a/app/components/form/TextAreaInput.tsx
+++ b/app/components/form/TextAreaInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import InputLabel from './InputLabel'
 

--- a/app/components/form/TextInput.tsx
+++ b/app/components/form/TextInput.tsx
@@ -66,7 +66,7 @@ const TextInput: React.FunctionComponent<TextInputProps> = (props) => {
         type={type}
         maxLength={maxLength}
         className='input'
-        defaultValue={stateValue || ''}
+        value={stateValue || ''}
         placeholder={placeHolder}
         onChange={handleOnChange}
         onBlur={onBlur}

--- a/app/components/item/DataType.tsx
+++ b/app/components/item/DataType.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Icon from '../chrome/Icon'
 
 export type DataTypes = 'string' | 'integer' | 'number' | 'boolean' | 'null' | 'any' | 'array' | 'object'

--- a/app/components/item/DatasetItem.tsx
+++ b/app/components/item/DatasetItem.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import { VersionInfo } from '../../models/store'
 import DatasetDetailsSubtext from '../dataset/DatasetDetailsSubtext'

--- a/app/components/item/MetadataMultiInputItem.tsx
+++ b/app/components/item/MetadataMultiInputItem.tsx
@@ -1,7 +1,7 @@
 // TODO (chriswhong): restore drag and drop sorting functionality,
 // check out https://github.com/qri-io/desktop/commit/f0c1ac08850540be4b43db1fbb6b6a8d5d577594
 
-import * as React from 'react'
+import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 

--- a/app/components/item/SchemaItem.tsx
+++ b/app/components/item/SchemaItem.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Icon from '../chrome/Icon'
 import DynamicEditField from '../form/DynamicEditField'
 import { DataTypes } from './DataType'

--- a/app/components/item/SearchResult.tsx
+++ b/app/components/item/SearchResult.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import moment from 'moment'
 import numeral from 'numeral'
 import { SearchResult } from '../../models/search'

--- a/app/components/modals/Buttons.tsx
+++ b/app/components/modals/Buttons.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Button from '../chrome/Button'
 
 interface ButtonsProps {

--- a/app/components/modals/Error.tsx
+++ b/app/components/modals/Error.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import classNames from 'classnames'
 
 interface ErrorProps {

--- a/app/components/modals/ExportDataset.tsx
+++ b/app/components/modals/ExportDataset.tsx
@@ -5,7 +5,7 @@ import { dismissModal } from '../../actions/ui'
 import { ExportDatasetModal } from '../../../app/models/modals'
 import { selectModal } from '../../selections'
 import { connectComponentToProps } from '../../utils/connectComponentToProps'
-import exportDatasetVersion from '../../actions/platformSpecific/export.TARGET_PLATFORM'
+import { exportDatasetVersion } from '../../actions/export'
 
 import Modal from './Modal'
 import Error from './Error'

--- a/app/components/modals/LinkDataset.tsx
+++ b/app/components/modals/LinkDataset.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { remote } from 'electron'
 import { Action } from 'redux'
 
+import { showOpenDialogSync } from './platformSpecific/LinkDataset.TARGET_PLATFORM'
 import { LinkDatasetModal } from '../../models/modals'
 import { ApiAction } from '../../store/api'
 
@@ -63,8 +63,7 @@ export const LinkDatasetComponent: React.FunctionComponent<LinkDatasetProps> = (
   const isQriDataset = (path: string) => !path
 
   const showDirectoryPicker = () => {
-    const window = remote.getCurrentWindow()
-    const directory: string[] | undefined = remote.dialog.showOpenDialogSync(window, {
+    const directory: string[] | undefined = showOpenDialogSync({
       properties: ['createDirectory', 'openDirectory']
     })
 

--- a/app/components/modals/LinkDataset.tsx
+++ b/app/components/modals/LinkDataset.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 
 import { showOpenDialogSync } from './platformSpecific/LinkDataset.TARGET_PLATFORM'

--- a/app/components/modals/PublishDataset.tsx
+++ b/app/components/modals/PublishDataset.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import { ApiAction } from '../../store/api'
 import { PublishDatasetModal } from '../../models/modals'

--- a/app/components/modals/PullDataset.tsx
+++ b/app/components/modals/PullDataset.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { CSSTransition } from 'react-transition-group'
 
 import { ApiAction } from '../../store/api'

--- a/app/components/modals/SearchModal.tsx
+++ b/app/components/modals/SearchModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import _ from 'underscore'
 
 import { BACKEND_URL } from '../../constants'

--- a/app/components/modals/Tabs.tsx
+++ b/app/components/modals/Tabs.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import classNames from 'classnames'
 
 interface TabProps {

--- a/app/components/modals/UnpublishDataset.tsx
+++ b/app/components/modals/UnpublishDataset.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import { ApiAction } from '../../store/api'
 import { UnpublishDatasetModal } from '../../models/modals'

--- a/app/components/modals/platformSpecific/LinkDataset.electron.ts
+++ b/app/components/modals/platformSpecific/LinkDataset.electron.ts
@@ -1,0 +1,5 @@
+import { remote, OpenDialogSyncOptions } from 'electron'
+
+export function showOpenDialogSync (opts: OpenDialogSyncOptions): string[] | undefined {
+  return remote.dialog.showOpenDialogSync(remote.getCurrentWindow(), opts)
+}

--- a/app/components/modals/platformSpecific/LinkDataset.web.ts
+++ b/app/components/modals/platformSpecific/LinkDataset.web.ts
@@ -1,0 +1,4 @@
+export function showOpenDialogSync (): undefined {
+  console.log("showOpenDialogSync is not implemented for the webapp version of the Qri Desktop")
+  return undefined
+}

--- a/app/components/nav/NavSidebar.tsx
+++ b/app/components/nav/NavSidebar.tsx
@@ -1,5 +1,5 @@
 // globals __BUILD__
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 import {
   faExternalLinkAlt,
@@ -10,8 +10,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { IconDefinition } from '@fortawesome/free-regular-svg-icons'
-
-import { openInExternalWindow } from './platformSpecific/NavSidebar.TARGET_PLATFORM'
 
 import { connectComponentToPropsWithRouter } from '../../utils/connectComponentToProps'
 import { DISCORD_URL, QRI_CLOUD_URL } from '../../constants'
@@ -157,15 +155,12 @@ export const NavbarComponent: React.FunctionComponent<NavbarProps> = (props: Nav
           }
         </div>
         <div className='navbar-bottom'>
-          <NavbarItem
-            icon={faComment}
-            tooltip={'Need help? Ask questions<br/> in our Discord channel'}
-            // when we have a function for `openInExternalWindow` we don't need
-            // a link to get us there, and vise-versa
-            onClick={() => { openInExternalWindow && openInExternalWindow(DISCORD_URL) }}
-            link={!openInExternalWindow && DISCORD_URL}
-            externalLink
-          />
+          <ExternalLink id='open-discord' href={DISCORD_URL}>
+            <NavbarItem
+              icon={faComment}
+              tooltip={'Need help? Ask questions<br/> in our Discord channel'}
+            />
+          </ExternalLink>
           <NavbarItem
             id='nav-options'
             icon={

--- a/app/components/nav/NavSidebar.tsx
+++ b/app/components/nav/NavSidebar.tsx
@@ -1,7 +1,6 @@
 // globals __BUILD__
 import * as React from 'react'
 import { Action } from 'redux'
-import { shell } from 'electron'
 import {
   faExternalLinkAlt,
   faDatabase,
@@ -11,6 +10,8 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { IconDefinition } from '@fortawesome/free-regular-svg-icons'
+
+import { openInExternalWindow } from './platformSpecific/NavSidebar.TARGET_PLATFORM'
 
 import { connectComponentToPropsWithRouter } from '../../utils/connectComponentToProps'
 import { DISCORD_URL, QRI_CLOUD_URL } from '../../constants'
@@ -159,7 +160,11 @@ export const NavbarComponent: React.FunctionComponent<NavbarProps> = (props: Nav
           <NavbarItem
             icon={faComment}
             tooltip={'Need help? Ask questions<br/> in our Discord channel'}
-            onClick={() => { shell.openExternal(DISCORD_URL) }}
+            // when we have a function for `openInExternalWindow` we don't need
+            // a link to get us there, and vise-versa
+            onClick={() => { openInExternalWindow && openInExternalWindow(DISCORD_URL) }}
+            link={!openInExternalWindow && DISCORD_URL}
+            externalLink
           />
           <NavbarItem
             id='nav-options'

--- a/app/components/nav/TabPicker.tsx
+++ b/app/components/nav/TabPicker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import classNames from 'classnames'
 

--- a/app/components/nav/platformSpecific/NavSidebar.electron.ts
+++ b/app/components/nav/platformSpecific/NavSidebar.electron.ts
@@ -1,0 +1,5 @@
+import { shell } from 'electron'
+
+export function openInExternalWindow (uri: string) {
+  shell.openExternal(uri)
+}

--- a/app/components/nav/platformSpecific/NavSidebar.electron.ts
+++ b/app/components/nav/platformSpecific/NavSidebar.electron.ts
@@ -1,5 +1,0 @@
-import { shell } from 'electron'
-
-export function openInExternalWindow (uri: string) {
-  shell.openExternal(uri)
-}

--- a/app/components/network/Network.tsx
+++ b/app/components/network/Network.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 
 import { QriRef, qriRefFromRoute } from '../../models/qriRef'

--- a/app/components/onboard/Signup.tsx
+++ b/app/components/onboard/Signup.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 import { Link } from 'react-router-dom'
 

--- a/app/components/onboard/Welcome.tsx
+++ b/app/components/onboard/Welcome.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Action } from 'redux'
 import ExternalLink from '../ExternalLink'
 import WelcomeTemplate from './WelcomeTemplate'

--- a/app/components/onboard/WelcomeTemplate.tsx
+++ b/app/components/onboard/WelcomeTemplate.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react' // eslint-disable-line
+import React from 'react' // eslint-disable-line
 import Spinner from '../chrome/Spinner'
 import classNames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/app/components/overlay/HamburgerOverlay.tsx
+++ b/app/components/overlay/HamburgerOverlay.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import { DatasetAction } from '../../models/dataset'
 

--- a/app/components/overlay/Overlay.tsx
+++ b/app/components/overlay/Overlay.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
-import * as React from 'react'
+import React from 'react'
 import Icon from '../chrome/Icon'
 import classNames from 'classnames'
 

--- a/app/components/overlay/TypePickerOverlay.tsx
+++ b/app/components/overlay/TypePickerOverlay.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Overlay from './Overlay'
 import { typesAndDescriptions } from '../structure/TypePicker'
 import DataType from '../item/DataType'

--- a/app/components/platformSpecific/App.electron.ts
+++ b/app/components/platformSpecific/App.electron.ts
@@ -1,0 +1,21 @@
+import { ipcRenderer, remote } from 'electron'
+
+export function addRendererListener (eventType: string, func: (e?: any, s?: string) => void) {
+  ipcRenderer.on(eventType, func)
+}
+
+export function removeRendererListener (eventType: string, func: (e?: any, s?: string) => void) {
+  ipcRenderer.removeListener(eventType, func)
+}
+
+export function sendElectronEventToMain (eventType: string) {
+  ipcRenderer.send(eventType)
+}
+
+export function saveDialogSync (opts: Electron.SaveDialogSyncOptions): string | undefined {
+  return remote.dialog.showSaveDialogSync(remote.getCurrentWindow(), opts)
+}
+
+export function reloadWindow () {
+  remote.getCurrentWindow().reload()
+}

--- a/app/components/platformSpecific/App.web.ts
+++ b/app/components/platformSpecific/App.web.ts
@@ -1,0 +1,9 @@
+export function addRendererListener (eventType: string, func: (e?: any, s?: string) => void) {}
+
+export function removeRendererListener (eventType: string, func: (e?: any, s?: string) => void) {}
+
+export function sendElectronEventToMain (eventType: string) {}
+
+export function saveDialogSync (opts: Electron.SaveDialogSyncOptions): string | undefined { return undefined }
+
+export function reloadWindow () {}

--- a/app/components/platformSpecific/ContextMenuArea.electron.tsx
+++ b/app/components/platformSpecific/ContextMenuArea.electron.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react'
-import { remote } from 'electron'
+import { remote, MenuItemConstructorOptions } from 'electron'
 
 const { Menu } = remote
 
+export type MenuItems = MenuItemConstructorOptions
+
 export interface Props<T> {
-  menuItemsFactory: (data: T) => Electron.MenuItemConstructorOptions[]
+  menuItemsFactory: (data: T) => MenuItems[]
   data: T
   style?: any
 }

--- a/app/components/platformSpecific/ContextMenuArea.electron.tsx
+++ b/app/components/platformSpecific/ContextMenuArea.electron.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { remote, MenuItemConstructorOptions } from 'electron'
 
 const { Menu } = remote

--- a/app/components/platformSpecific/ContextMenuArea.web.tsx
+++ b/app/components/platformSpecific/ContextMenuArea.web.tsx
@@ -1,0 +1,17 @@
+/**
+ * Context menus only make sense in context of the electron app right now
+ * as all the actions that one can take are dependent on the dataset being
+ * either in your namespace and/or should be actions that happen only if
+ * you are working locally
+ */
+import * as React from 'react'
+
+export type MenuItems = any
+
+export const ContextMenuArea: React.FC<any> = (props) => {
+  return (
+    <div style ={{ ...props.style }} >
+      { props.children }
+    </div>
+  )
+}

--- a/app/components/platformSpecific/ContextMenuArea.web.tsx
+++ b/app/components/platformSpecific/ContextMenuArea.web.tsx
@@ -4,7 +4,7 @@
  * either in your namespace and/or should be actions that happen only if
  * you are working locally
  */
-import * as React from 'react'
+import React from 'react'
 
 export type MenuItems = any
 
@@ -15,3 +15,5 @@ export const ContextMenuArea: React.FC<any> = (props) => {
     </div>
   )
 }
+
+export default ContextMenuArea

--- a/app/components/platformSpecific/ExternalLink.electron.tsx
+++ b/app/components/platformSpecific/ExternalLink.electron.tsx
@@ -1,6 +1,27 @@
+import React from 'react'
 import { shell } from 'electron'
 
-export const onClick = (e: React.MouseEvent, href: string) => {
+export interface ExternalLinkProps {
+  id?: string
+  href: string
+  children: React.ReactNode
+  className?: string
+  tooltip?: string
+}
+
+export function openExternal (e: React.MouseEvent, href: string) {
   e.preventDefault()
   shell.openExternal(href)
 }
+
+export const ExternalLink: React.FunctionComponent<ExternalLinkProps> = ({ id, href, children, className, tooltip }) =>
+  <a id={id}
+    href={href}
+    onClick={(e) => openExternal(e, href)}
+    target='_blank'
+    rel="noopener noreferrer"
+    className={className}
+    data-tip={tooltip}
+  >{children}</a>
+
+export default ExternalLink

--- a/app/components/platformSpecific/ExternalLink.web.tsx
+++ b/app/components/platformSpecific/ExternalLink.web.tsx
@@ -1,4 +1,16 @@
-// This file is needed for webpack to build ExternalLink for in-browser rendering without loading
-// the electron dependency. When ExternalLink is rendered on Web, this function is a noop
-// and the href is preferred.
-export const onClick = () => undefined
+import React from 'react'
+
+export interface ExternalLinkProps {
+  id?: string
+  href: string
+  children: React.ReactNode
+  className?: string
+  tooltip?: string
+}
+
+export function openExternal (e: React.MouseEvent, href: string) {}
+
+export const ExternalLink: React.FunctionComponent<ExternalLinkProps> = ({ id, href, children, className, tooltip }) =>
+  <a id={id} href={href} target='_blank' rel="noopener noreferrer" className={className} data-tip={tooltip}>{children}</a>
+
+export default ExternalLink

--- a/app/components/structure/ColumnType.tsx
+++ b/app/components/structure/ColumnType.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import classNames from 'classnames'
 import { DataTypes } from '../item/DataType'
 

--- a/app/components/structure/FormatConfigEditor.tsx
+++ b/app/components/structure/FormatConfigEditor.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 

--- a/app/components/structure/Schema.tsx
+++ b/app/components/structure/Schema.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import cloneDeep from 'clone-deep'
 
 import { Schema as ISchema } from '../../models/dataset'

--- a/app/components/structure/TypePicker.tsx
+++ b/app/components/structure/TypePicker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import ColumnType from './ColumnType'
 import TypePickerOverlay from '../overlay/TypePickerOverlay'

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
-import * as ReactDOM from 'react-dom'
+import React from 'react'
+import ReactDOM from 'react-dom'
 import 'regenerator-runtime/runtime'
 import { Provider } from 'react-redux'
 import ErrorHandler from './components/ErrorHandler'

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -298,17 +298,9 @@ app.on('ready', () =>
           {
             id: 'show-collection',
             label: 'Collection',
-            accelerator: 'CmdOrCtrl+2',
+            accelerator: 'CmdOrCtrl+1',
             click () {
               mainWindow.webContents.send('history-push', '/collection')
-            }
-          },
-          {
-            id: 'show-workbench',
-            label: 'Workbench',
-            accelerator: 'CmdOrCtrl+2',
-            click () {
-              mainWindow.webContents.send('history-push', '/workbench')
             }
           },
           {
@@ -360,25 +352,6 @@ app.on('ready', () =>
         id: 'dataset-menu',
         label: 'Dataset',
         submenu: [
-          {
-            id: 'show-status',
-            label: 'Show Status',
-            accelerator: 'CmdOrCtrl+[',
-            click () {
-              mainWindow.webContents.send('show-status')
-            }
-          },
-          {
-            id: 'show-history',
-            label: 'Show History',
-            accelerator: 'CmdOrCtrl+]',
-            click () {
-              mainWindow.webContents.send('show-history')
-            }
-          },
-          {
-            type: 'separator'
-          },
           {
             id: 'publish-unpublish-dataset',
             label: 'Publish/Unpublish Dataset',

--- a/app/platformSpecific/routes.electron.ts
+++ b/app/platformSpecific/routes.electron.ts
@@ -1,0 +1,5 @@
+import { ipcRenderer } from 'electron'
+
+export function showDatasetMenu (show: boolean) {
+  ipcRenderer.send('show-dataset-menu', show)
+}

--- a/app/platformSpecific/routes.web.ts
+++ b/app/platformSpecific/routes.web.ts
@@ -1,0 +1,1 @@
+export function showDatasetMenu (show: boolean) {}

--- a/app/reducers/platformSpecific/ui.web.ts
+++ b/app/reducers/platformSpecific/ui.web.ts
@@ -1,0 +1,5 @@
+import { Modal } from "../../models/modals"
+
+export const blockMenusOnFirstLoad = () => {}
+
+export const blockMenusIfModalIsOpen = (modal: Modal) => {}

--- a/app/reducers/platformSpecific/workingDataset.web.ts
+++ b/app/reducers/platformSpecific/workingDataset.web.ts
@@ -1,0 +1,1 @@
+export const unblockDatasetMenus = (fsiPath: string, published: boolean) => {}

--- a/app/reducers/ui.ts
+++ b/app/reducers/ui.ts
@@ -68,7 +68,7 @@ const initialState = {
 }
 
 // send an event to electron to block menus on first load
-if (blockMenusOnFirstLoad) blockMenusOnFirstLoad()
+blockMenusOnFirstLoad()
 
 const [, ADD_SUCC] = apiActionTypes('add')
 const [, INIT_SUCC] = apiActionTypes('init')
@@ -130,7 +130,7 @@ export default (state = initialState, action: AnyAction) => {
       const modal = action.payload
 
       // if modal is open, block electron menus
-      if (blockMenusIfModalIsOpen) blockMenusIfModalIsOpen(modal)
+      blockMenusIfModalIsOpen(modal)
 
       return {
         ...state,

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -75,7 +75,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
     case DATASET_SUCC: // when adding a new dataset, set it as the new workingDataset
       const { name, path, peername, published, dataset, fsiPath } = action.payload.data
 
-      if (unblockDatasetMenus) unblockDatasetMenus(fsiPath, published)
+      unblockDatasetMenus(fsiPath, published)
 
       return {
         ...state,

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -50,7 +50,7 @@ export const RoutesComponent: React.FunctionComponent<RoutesProps> = (props) => 
   }
 
   const sectionElement = (section: string, dest: React.ReactElement): React.ReactElement => {
-    showDatasetMenu && showDatasetMenu(false)
+    showDatasetMenu(false)
     return requireSignin(dest)
   }
 

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -1,7 +1,8 @@
 // globals __BUILD__
 import React from 'react'
 import { Switch, Route, Redirect } from 'react-router-dom'
-import { ipcRenderer } from 'electron'
+
+import { showDatasetMenu } from './platformSpecific/routes.TARGET_PLATFORM'
 
 import Store from '../models/store'
 import {
@@ -49,7 +50,7 @@ export const RoutesComponent: React.FunctionComponent<RoutesProps> = (props) => 
   }
 
   const sectionElement = (section: string, dest: React.ReactElement): React.ReactElement => {
-    ipcRenderer.send('show-dataset-menu', false)
+    showDatasetMenu && showDatasetMenu(false)
     return requireSignin(dest)
   }
 
@@ -94,7 +95,7 @@ export const RoutesComponent: React.FunctionComponent<RoutesProps> = (props) => 
         }
 
         <Route path='/' render={() => {
-          ipcRenderer.send('show-dataset-menu', false)
+          showDatasetMenu(false)
           return requireSignin(<Redirect to='/collection' />)
         }} />
       </Switch>

--- a/app/utils/connectComponentToProps.ts
+++ b/app/utils/connectComponentToProps.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Dispatch, bindActionCreators, ActionCreatorsMapObject } from 'redux'
 import { connect, Matching } from 'react-redux'
 import { withRouter } from 'react-router-dom'

--- a/test/e2e/e2e.spec.ts
+++ b/test/e2e/e2e.spec.ts
@@ -539,7 +539,7 @@ describe('Qri End to End tests', function spec () {
 
     await click('#export-button')
     await click('#submit')
-    await delay(400) // wait to ensure file has time to write
+    await delay(500) // wait to ensure file has time to write
     expect(fs.existsSync(savePath)).toEqual(true)
   })
 


### PR DESCRIPTION
This will allow us to use the contents of the `app` to build a webapp without needing electron.

relates to #663 