### PR TITLE
fix(`Changes`): first round styling adjustments based on feedback

### DIFF
--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -1,20 +1,25 @@
 // a layout component for the resizable sidebar with main content area
 import React from 'react'
 import { Resizable } from './Resizable'
-import NavTopbar from '../components/nav/NavTopbar'
+import NavTopbar, { NavbarButtonProps } from '../components/nav/NavTopbar'
 
 interface LayoutProps {
   id: string
-  sidebarWidth: number
+  sidebarWidth?: number
   sidebarContent?: React.ReactElement
   mainContent: React.ReactElement
   headerContent?: React.ReactElement
-  topbarButtons: NavbarButtonProps[]
+  topbarButtons?: NavbarButtonProps[]
   onSidebarResize?: (width: number) => void
   maximumSidebarWidth?: number
   subTitle?: string
   title?: string | React.ReactElement
 
+  /**
+   * backButtonUrl - when it exists, will override the "back" button push location
+   * in the NavTopBar
+   */
+  backButtonUrl?: string
   /**
    * Some views may not want to display the navbar, setting `showNav` = false
    * will hide it
@@ -26,6 +31,7 @@ interface LayoutProps {
 const Layout: React.FunctionComponent<LayoutProps> = (props: LayoutProps) => {
   const {
     id,
+    backButtonUrl,
     sidebarContent,
     sidebarWidth,
     onSidebarResize,
@@ -40,7 +46,12 @@ const Layout: React.FunctionComponent<LayoutProps> = (props: LayoutProps) => {
 
   return (
     <div id={id} className='sidebar-layout'>
-      {showNav && <NavTopbar subTitle={subTitle} title={title} buttons={topbarButtons} />}
+      {showNav && <NavTopbar
+        subTitle={subTitle}
+        title={title}
+        buttons={topbarButtons}
+        backButtonUrl={backButtonUrl}
+      />}
       {headerContent}
       <div className='columns'>
         {sidebarContent && <Resizable

--- a/app/components/changes/DatasetSummaryDiff.tsx
+++ b/app/components/changes/DatasetSummaryDiff.tsx
@@ -5,7 +5,21 @@ import { VersionInfo } from '../../models/store'
 import Commitish from '../chrome/Commitish'
 import CommitDetails from '../CommitDetails'
 
-const CommitItem: React.FC<VersionInfo> = (props) => {
+interface DatasetSummaryItemProps {
+  data: VersionInfo
+  /**
+   * displayName - defaults to true, when false, doesn not show the dataset
+   * username/name combination
+   */
+  shouldDisplayName?: boolean
+}
+
+const DatasetSummaryItem: React.FC<DatasetSummaryItemProps> = (props) => {
+  const {
+    data,
+    shouldDisplayName = true
+  } = props
+
   const {
     path,
     commitTitle,
@@ -14,17 +28,17 @@ const CommitItem: React.FC<VersionInfo> = (props) => {
     bodyRows,
     username,
     name
-  } = props
+  } = data
 
   return (
     <div style={{ margin: 20 } }>
-      <div
+      {shouldDisplayName && <div
         style={ {
           fontFamily: 'monospace',
           fontSize: 18,
           color: 'black',
           textOverflow: 'ellipsis'
-        }}>{username}/{name}</div>
+        }}>{username}/{name}</div>}
       {path && <Commitish text={path}/>}
       <div><CommitDetails
         commitTitle={commitTitle || ''}
@@ -42,6 +56,8 @@ const DatasetSummaryDiff: React.FC<IVersionInfoDiff> = (props) => {
     left,
     right
   } = props
+
+  const shouldDisplayName = !(left.name === right.name && left.username === right.username)
   return (
     <table style={{ width: '100%', marginTop: 40 }}>
       <thead>
@@ -67,10 +83,10 @@ const DatasetSummaryDiff: React.FC<IVersionInfoDiff> = (props) => {
       <tbody>
         <tr>
           <td >
-            <CommitItem {...left} />
+            <DatasetSummaryItem data={left} shouldDisplayName={shouldDisplayName} />
           </td>
           <td>
-            <CommitItem {...right} />
+            <DatasetSummaryItem data={right} shouldDisplayName={shouldDisplayName} />
           </td>
         </tr>
       </tbody>

--- a/app/components/changes/DatasetSummaryDiff.tsx
+++ b/app/components/changes/DatasetSummaryDiff.tsx
@@ -48,17 +48,17 @@ const DatasetSummaryDiff: React.FC<IVersionInfoDiff> = (props) => {
         <tr>
           <th style={{
             fontSize: 16,
-            fontWeight: 300,
+            fontWeight: 400,
             textTransform: 'uppercase',
-            color: '#737373'
+            color: 'red'
           }}>
             BASE
           </th>
           <th style={{
             fontSize: 16,
-            fontWeight: 300,
+            fontWeight: 400,
             textTransform: 'uppercase',
-            color: '#737373'
+            color: 'green'
           }}>
             COMPARE
           </th>

--- a/app/components/changes/StatDiff.tsx
+++ b/app/components/changes/StatDiff.tsx
@@ -13,8 +13,9 @@ const SummaryItem: React.FC<ISummaryStats> = (props) => {
   for (const [key, val] of Object.entries(props)) {
     if (key !== 'delta') {
       statsList.push({
-        label: key,
+        label: key === 'totalSize' ? 'File Size' : key,
         value: val,
+        inBytes: key === 'totalSize',
         delta: props.delta && props.delta[key]
       })
     }

--- a/app/components/changes/StringDiff.tsx
+++ b/app/components/changes/StringDiff.tsx
@@ -26,12 +26,15 @@ const StringDiff: React.FC<IStringDiff | IStructureDiff | IMetaDiff> = (props) =
     collapsable
     componentStatus={status}
     animationOn={false}
+    showNoChanges
+    startOpen={!(status === 'unmodified' || name === 'structure')}
     content={<ReactDiffViewer
       styles={styles}
       oldValue={typeof left === 'string' ? left : JSON.stringify(left, null, 2)}
       newValue={typeof right === 'string' ? right : JSON.stringify(right, null, 2)}
       splitView={true}
       compareMethod={DiffMethod.WORDS}
+      showDiffOnly={status !== 'unmodified'}
     />}
   />
 }

--- a/app/components/chrome/Segment.tsx
+++ b/app/components/chrome/Segment.tsx
@@ -15,6 +15,13 @@ interface SegmentProps {
   contentHeight?: number
   componentStatus?: ComponentStatus
   animationOn?: boolean
+  startOpen?: boolean
+
+  /**
+   * showNoChanges - when true, we expect an indication that there have been
+   * "no changes". The default is `false`
+  */
+  showNoChanges?: boolean
 }
 
 const Segment: React.FunctionComponent<SegmentProps> = (props) => {
@@ -27,12 +34,14 @@ const Segment: React.FunctionComponent<SegmentProps> = (props) => {
     collapsable = false,
     expandable = false,
     contentHeight = 400,
-    componentStatus = ''
+    componentStatus = '',
+    startOpen = true,
+    showNoChanges = false
   } = props
 
   if (content === null) return null
 
-  const [isOpen, setIsOpen] = React.useState(true)
+  const [isOpen, setIsOpen] = React.useState(startOpen)
   const [isExpanded, setIsExpanded] = React.useState(false)
 
   let heightStyle = {}
@@ -69,7 +78,7 @@ const Segment: React.FunctionComponent<SegmentProps> = (props) => {
           </div>
         </div>
         <div className='right-side'>
-          { componentStatus && <StatusDot status={componentStatus}/>}
+          { componentStatus && <StatusDot status={componentStatus} showNoChanges={showNoChanges} />}
           {/* ensure the container div you want to expand to has the css */}
           {/* property 'position: relative' */}
           {expandable &&

--- a/app/components/chrome/StatusDot.tsx
+++ b/app/components/chrome/StatusDot.tsx
@@ -6,11 +6,16 @@ import { ComponentStatus } from '../../models/store'
 
 export interface StatusDotProps {
   status: ComponentStatus
+  showNoChanges?: boolean
 }
 
 export const StatusDot: React.FunctionComponent<StatusDotProps> = (props) => {
+  const {
+    status,
+    showNoChanges = false
+  } = props
   let statusTooltip
-  switch (props.status) {
+  switch (status) {
     case 'modified':
       statusTooltip = 'modified'
       break
@@ -29,6 +34,9 @@ export const StatusDot: React.FunctionComponent<StatusDotProps> = (props) => {
         data-tip='Parsing Error'
         size='sm' />)
     default:
+      if (showNoChanges) {
+        return <div>No Changes</div>
+      }
       statusTooltip = 'unmodified'
   }
 

--- a/app/components/collection/DatasetChanges.tsx
+++ b/app/components/collection/DatasetChanges.tsx
@@ -6,11 +6,10 @@ import { LaunchedFetchesAction } from '../../store/api'
 import { connectComponentToPropsWithRouter } from '../../utils/connectComponentToProps'
 import { fetchWorkbench } from '../../actions/workbench'
 
-import DatasetLayout from './layouts/DatasetLayout'
-import LogList from './LogList'
-// import Changes from '../changes/Changes'
 import { selectLogPageInfo, selectChangeReportLeft } from '../../selections'
 import Changes, { LoadingDatasetChanges } from '../changes/Changes'
+import Layout from '../Layout'
+import { pathToDataset } from '../../paths'
 
 export interface DatasetChangesProps extends RouteProps {
   qriRef: QriRef
@@ -33,8 +32,11 @@ export const DatasetChangesComponent: React.FunctionComponent<DatasetChangesProp
   }, [qriRef.location])
 
   return (
-    <DatasetLayout
+    <Layout
       id='dataset-changes'
+      backButtonUrl={pathToDataset(qriRef.username, qriRef.name, qriRef.path || '')}
+      subTitle={`${qriRef.username}/`}
+      title={qriRef.name}
       mainContent={
         <div className='dataset-content transition-group'>
           {
@@ -45,7 +47,6 @@ export const DatasetChangesComponent: React.FunctionComponent<DatasetChangesProp
                 right={qriRef}
               />}
         </div>}
-      sidebarContent={<LogList qriRef={qriRef}/>}
     />
   )
 }

--- a/app/components/collection/datasetComponents/Body.tsx
+++ b/app/components/collection/datasetComponents/Body.tsx
@@ -30,7 +30,7 @@ export interface BodyProps extends RouteProps {
 }
 
 function shouldDisplayJsonViewer (format: string) {
-  return (format !== undefined && format !== 'csv' && format !== 'xlsx')
+  return !format || (format !== 'csv' && format !== 'xlsx')
 }
 
 export interface Header {

--- a/app/components/item/LabeledStats.tsx
+++ b/app/components/item/LabeledStats.tsx
@@ -47,7 +47,11 @@ const LabeledStats: React.FunctionComponent<LabeledStatsProps> = (props) => {
         if (typeof displayVal === 'number') {
           if (stat.inBytes) {
             displayVal = fileSize(displayVal)
-            displayDelta = stat.delta && fileSize(displayDelta)
+            // fileSize will return 0 if the input is negative
+            displayDelta = stat.delta && fileSize(Math.abs(stat.delta))
+            if (typeof stat.delta === 'number' && stat.delta < 0) {
+              displayDelta = `-${displayDelta}`
+            }
           } else {
             displayVal = abbreviateNumber(stat.value)
             displayDelta = stat.delta && abbreviateNumber(displayDelta)

--- a/app/components/item/StatDiffRow.tsx
+++ b/app/components/item/StatDiffRow.tsx
@@ -88,7 +88,7 @@ export const StatDiffItem: React.FC<StatDiffItemProps> = (props) => {
     <div className='margin-bottom'>
       {chartName && <div className='label small uppercase margin-bottom'>{chartName}</div>}
       {chartName
-        ? <StatsChart data={data} delta={delta} />
+        ? <StatsChart data={data} delta={delta} title={chartName} />
         : <div style={{
           display: 'flex',
           justifyContent: 'center',

--- a/app/components/modals/platformSpecific/ExportSubmitButton.electron.tsx
+++ b/app/components/modals/platformSpecific/ExportSubmitButton.electron.tsx
@@ -5,17 +5,18 @@ interface ExportSubmitButtonProps {
   text: string
   disabled: boolean
   loading: boolean
-  onSubmit: () => void
+  onClick: () => void
   download?: string
   downloadName?: string
 }
 
-export const ExportSubmitButton: React.FunctionComponent<ExportSubmitButtonProps> = ({ text, disabled, loading, onSubmit }) =>
-  <Button
+export const ExportSubmitButton: React.FunctionComponent<ExportSubmitButtonProps> = ({ text, disabled, loading, onClick }) => {
+  return <Button
     id='submit'
     color='dark'
     text={text}
-    onClick={onSubmit}
+    onClick={onClick}
     loading={loading}
     disabled={disabled}
   />
+}

--- a/app/components/modals/platformSpecific/ExportSubmitButton.web.tsx
+++ b/app/components/modals/platformSpecific/ExportSubmitButton.web.tsx
@@ -5,17 +5,17 @@ interface ExportSubmitButtonProps {
   text: string
   disabled: boolean
   loading: boolean
-  onSubmit: () => void
+  onClick: () => void
   download: string
   downloadName: string
 }
 
-export const ExportSubmitButton: React.FunctionComponent<ExportSubmitButtonProps> = ({ text, disabled, loading, onSubmit, download, downloadName }) =>
+export const ExportSubmitButton: React.FunctionComponent<ExportSubmitButtonProps> = ({ text, disabled, loading, onClick, download, downloadName }) =>
   <Button
     id='submit'
     color='dark'
     text='Download...'
-    onClick={onSubmit}
+    onClick={onClick}
     loading={loading}
     disabled={disabled}
     download={download}

--- a/app/components/nav/NavTopbar.tsx
+++ b/app/components/nav/NavTopbar.tsx
@@ -13,6 +13,12 @@ import Hamburger from '../chrome/Hamburger'
 interface NavTopbarProps extends RouteProps {
   title: string
   subTitle?: string
+
+  /**
+   * backButtonUrl - when it exists, will override default back button behavior
+   * to instead `history.push` to the backButtonUrl location
+   */
+  backButtonUrl?: string
   buttons: NavbarButtonProps[]
 }
 
@@ -32,11 +38,22 @@ export interface NavbarButtonProps {
 
 // Navbar is persistent chrome from app-wide navigation
 export const NavTopbarComponent: React.FunctionComponent<NavTopbarProps> = (props) => {
-  const { title, subTitle, buttons = [], location, match, history } = props
+  const {
+    title,
+    subTitle,
+    buttons = [],
+    location,
+    match,
+    history,
+    backButtonUrl
+  } = props
   // determines if route is at base route (e.g. /collection or /network)
   const isBaseRoute = Object.keys(match.params).length === 0
 
   const onBackClick = () => {
+    if (backButtonUrl) {
+      return history.push(backButtonUrl)
+    }
     // if not on base route, clicking back takes you to base route
     // (e.g. /collection/edit/username/dataset/body => /collection)
     const baseRoute = location.pathname.split("/")[1]

--- a/app/components/nav/NavTopbar.tsx
+++ b/app/components/nav/NavTopbar.tsx
@@ -64,7 +64,7 @@ export const NavTopbarComponent: React.FunctionComponent<NavTopbarProps> = (prop
     <div className='page-navbar'>
       <div className='row'>
         <div className='nav-buttons'>
-          {!isBaseRoute && <a className='back' onClick={onBackClick}><BackArrow /></a>}
+          {!isBaseRoute && <a id='back' className='back' onClick={onBackClick}><BackArrow /></a>}
         </div>
         {!__BUILD__.REMOTE && <div className='transfers'>
           <Transfers />

--- a/app/reducers/dataset.ts
+++ b/app/reducers/dataset.ts
@@ -6,6 +6,7 @@ import bodyValue from '../utils/bodyValue'
 import {
   DATASET_REQ
 } from './workingDataset'
+import { REMOVE_SUCC } from './selections'
 
 const initialState: DatasetStore = {
   path: '',
@@ -169,6 +170,12 @@ const DatasetReducer: Reducer = (state = initialState, action: AnyAction): Datas
         peername: action.username,
         name: action.name
       }
+
+    case REMOVE_SUCC:
+      if (state.peername === action.payload.request.segments.username && state.name === action.payload.request.segments.name) {
+        return initialState
+      }
+      return state
 
     default:
       return state

--- a/app/reducers/log.ts
+++ b/app/reducers/log.ts
@@ -3,6 +3,9 @@ import { Reducer, AnyAction } from 'redux'
 import { Log } from '../models/store'
 import { apiActionTypes } from '../utils/actionType'
 import { reducerWithPagination } from '../utils/pagination'
+import {
+  REMOVE_SUCC
+} from './selections'
 
 const initialState: Log = {
   pageInfo: {
@@ -38,6 +41,12 @@ const logReducer: Reducer = (state = initialState, action: AnyAction): Log | nul
         ...state,
         pageInfo: reducerWithPagination(action, state.pageInfo)
       }
+
+    case REMOVE_SUCC:
+      if (state.peername === action.payload.request.segments.username && state.name === action.payload.request.segments.name) {
+        return initialState
+      }
+      return state
     default:
       return state
   }

--- a/app/reducers/selections.ts
+++ b/app/reducers/selections.ts
@@ -43,7 +43,7 @@ export default (state = initialState, action: AnyAction) => {
       // if the given peername and name don't match the selected peername and name return early
       // otherwise, fall through to clearing the selection
       if (action.type === REMOVE_SUCC) {
-        if (!(action.payload.request.segments.peername === state.peername && action.payload.request.segments.name === state.name)) {
+        if (!(action.payload.request.segments.username === state.peername && action.payload.request.segments.name === state.name)) {
           return state
         }
       }

--- a/app/reducers/workingDataset.ts
+++ b/app/reducers/workingDataset.ts
@@ -225,7 +225,7 @@ const workingDatasetsReducer: Reducer = (state = initialState, action: AnyAction
       }
 
     case REMOVE_SUCC:
-      if (state.peername === action.payload.request.segments.peername && state.name === action.payload.request.segments.name) {
+      if (state.peername === action.payload.request.segments.username && state.name === action.payload.request.segments.name) {
         return initialState
       }
       return state

--- a/app/utils/fileSize.ts
+++ b/app/utils/fileSize.ts
@@ -37,6 +37,9 @@ export default function fileSize (l: number): string {
 var SI_SYMBOL = ['', 'k', 'M', 'G', 'T', 'P', 'E']
 
 export function abbreviateNumber (number: number) {
+  if (number === undefined) {
+    return undefined
+  }
   // what tier? (determines SI symbol)
   var tier = Math.log10(number) / 3 | 0
 

--- a/stories/12-ChangeReport.stories.tsx
+++ b/stories/12-ChangeReport.stories.tsx
@@ -60,25 +60,25 @@ export const stringDiff = () => {
       <StringDiff
         left={res.meta.left}
         right={res.meta.right}
-        componentStatus={res.meta.meta.status}
+        componentStatus={res.meta.about.status}
         name='meta'
       />
       <StringDiff
         left={res.structure.left}
         right={res.structure.right}
-        componentStatus={res.structure.meta.status}
+        componentStatus={res.structure.about.status}
         name='structure'
       />
       <StringDiff
         left={res.readme.left}
         right={res.readme.right}
-        componentStatus={res.readme.meta.status}
+        componentStatus={res.readme.about.status}
         name='readme'
       />
       <StringDiff
         left={res.transform.left}
         right={res.transform.right}
-        componentStatus={res.transform.meta.status}
+        componentStatus={res.transform.about.status}
         name='transform'
       />
     </>

--- a/stories/data/change_report_sample_api_response.json
+++ b/stories/data/change_report_sample_api_response.json
@@ -67,10 +67,10 @@
     }
   },
   "readme": {
-    "left": "#JHU CSSE COVID-19 Daily Reports (aggregated)\n\nTken from the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data), this dataset is an aggregation of all the CSV files in the daily updates folder.",
+    "left": "#JHU CSSE COVID-19 Daily Reports (aggregated)\n\nTaken from the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data), this dataset is an aggregation of all the CSV files in the daily updates folder.\n\nDataset pulled monthly",
     "right": "#JHU CSSE COVID-19 Daily Reports (aggregated)\n\nTaken from the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data), this dataset is an aggregation of all the CSV files in the daily updates folder.\n\nDataset pulled monthly",
     "about": {
-      "status": "modified"
+      "status": "unmodified"
     }
   },
   "structure": {
@@ -253,7 +253,7 @@
         "entries": 19378,
         "columns": 1,
         "nullValues": -10,
-        "totalSize": 3074177
+        "totalSize": 945917966
       }
     },
     "columns": [

--- a/test/app/reducers/selections.test.ts
+++ b/test/app/reducers/selections.test.ts
@@ -71,7 +71,7 @@ describe('Body Reducer', () => {
       payload: {
         request: {
           segments: {
-            peername: 'baz',
+            username: 'baz',
             name: 'qux'
           }
         }
@@ -89,7 +89,7 @@ describe('Body Reducer', () => {
       payload: {
         request: {
           segments: {
-            peername: 'foo',
+            username: 'foo',
             name: 'bar'
           }
         }

--- a/test/e2e/e2e.spec.ts
+++ b/test/e2e/e2e.spec.ts
@@ -11,8 +11,8 @@ import { schemaColumns } from '../../app/utils/schemaColumns'
 
 const { Application } = require('spectron')
 
-const takeScreenshots = false
-const printConsoleLogs = false
+const takeScreenshots = true
+const printConsoleLogs = true
 
 function artifactPathFromDir (dir: string, s: string): string {
   return path.join(dir, s)
@@ -488,7 +488,7 @@ describe('Qri End to End tests', function spec () {
   // structure write and commit
   it('fsi editing - edit the structure & commit', async () => {
     await utils.atDataset(username, datasetName)
-    await editCSVStructureAndCommit('fsi-setructure-edit', username, datasetName, { structure: csvStructure, commit: structureCommit }, 'modified', utils, imagesDir)
+    await editCSVStructureAndCommit('fsi-structure-edit', username, datasetName, { structure: csvStructure, commit: structureCommit }, 'modified', utils, imagesDir)
   })
 
   // rename
@@ -1001,7 +1001,7 @@ async function writeCommitAndSubmit (uniqueName: string, username: string, datas
 
   if (!firstCommit) {
     await waitForExist('#change-report')
-    await click('#HEAD-0')
+    await click('#back')
   }
   await atDatasetVersion(0, artifactPathFromDir(imagesDir, `${name}-commit-on-history-tab.png`))
   // check component status
@@ -1261,6 +1261,9 @@ async function editCSVStructureAndCommit (uniqueName: string, username: string, 
 
   // on status tab
   await click('#working-version', artifactPathFromDir(imagesDir, `${name}-click-status-tab.png`))
+  if (takeScreenshots) {
+    await takeScreenshot(artifactPathFromDir(imagesDir, `${name}-at-working-version.png`))
+  }
   // commit should be disabled
   await doesNotExist('.clear-to-commit #commit-status', artifactPathFromDir(imagesDir, `${name}-commit-does-not-exist-clear-to-commit.png`))
   // click #structure-status

--- a/test/e2e/e2e.spec.ts
+++ b/test/e2e/e2e.spec.ts
@@ -979,7 +979,8 @@ async function writeCommitAndSubmit (uniqueName: string, username: string, datas
     takeScreenshot,
     checkStatus,
     atDatasetVersion,
-    expectTextToContain
+    expectTextToContain,
+    atChanges
   } = utils
 
   // commit should be enabled
@@ -1000,7 +1001,7 @@ async function writeCommitAndSubmit (uniqueName: string, username: string, datas
   await click('#submit', artifactPathFromDir(imagesDir, `${name}-commit-click-submit.png`))
 
   if (!firstCommit) {
-    await waitForExist('#change-report')
+    await atChanges(username, datasetName, `${name}-at-change-report`)
     await click('#back')
   }
   await atDatasetVersion(0, artifactPathFromDir(imagesDir, `${name}-commit-on-history-tab.png`))


### PR DESCRIPTION
- StatusDot - when 'unmodified' we now have an option to show text that indicates that there are "No Changes"
- Segment - optional `startOpen` param that defaults to `true`. When `false`, the `Segment` starts closed
- StringDiff - when a component is "unmodified", default to having all text displayed
- ChangeReport - “Base” is red “Compare” is green
- StringDiff - Structure should by default start "rolled up" aka `startOpen` === false
- Labeled stats - Now we expect `Stat` to have another field `inBytes`. When a `Stat` has a `number` value & `inBytes` is true, we display the stat in Gb, Mb, b, etc.
- SummaryItem - when we iterate through the given Stats, if one of the stats is "totalSize", send over "File Size" as the label, and ensure `inBytes` is `true`.
- DatasetChanges - adjust layout so changes feels more like a modal that you need to click back from
- DatasetSummaryItem - add optional `shouldDisplayName` param, when false does not show the `username/dataset` name combo